### PR TITLE
Крылов Михаил. Вариант 12. Технология STL. Вычисление многомерных интегралов методом Монте-Карло.

### DIFF
--- a/tasks/stl/krylov_m_monte_carlo/func_tests/main.cpp
+++ b/tasks/stl/krylov_m_monte_carlo/func_tests/main.cpp
@@ -1,0 +1,201 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstddef>
+#include <numbers>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+#include "../include/mci_common.hpp"
+#include "../include/mci_seq.hpp"
+#include "../include/mci_stl.hpp"
+
+using namespace krylov_m_monte_carlo;
+
+using DeterminedTestCase = std::pair<IntegrationParams, double>;
+
+class krylov_m_monte_carlo_test_stl  // NOLINT(readability-identifier-naming)
+    : public ::testing::TestWithParam<DeterminedTestCase> {
+ protected:
+  // to preserve control flow
+#define EXEC_TASK(Task, params, out)         \
+  {                                          \
+    Task task((params).CreateTaskData(out)); \
+    ASSERT_TRUE(task.Validation());          \
+    task.PreProcessing();                    \
+    task.Run();                              \
+    task.PostProcessing();                   \
+  }
+
+  static void RunTest(IntegrationParams&& params, double ref) {
+    double out{};
+    EXEC_TASK(TaskSTL, params, out);
+
+    const double eps = std::abs(ref - out) / out;
+    if (ref == 0 || std::isnan(eps)) {
+      EXPECT_NEAR(out, ref, 0.3);
+    } else {
+      EXPECT_LE(eps, 0.1) << "actual: " << out << ", ref: " << ref;
+    }
+  }
+  static void RunUndeterminedTest(IntegrationParams&& params) {
+    double out{};
+    EXEC_TASK(TaskSequential, params, out);
+
+    RunTest(std::move(params), out);
+  }
+#undef EXEC_TASK
+
+  static IntegrationParams GenerateSampleParams(std::size_t dimensions, MathFunction func, std::size_t iterations) {
+    return {.func = func, .bounds = std::vector<Bound>(dimensions, {0., 1.}), .iterations = iterations};
+  }
+};
+
+TEST_F(krylov_m_monte_carlo_test_stl, sample_1d) {
+  RunUndeterminedTest(
+      GenerateSampleParams(1, [](const Point& x) { return std::pow(x[0], 2) + std::sin(x[0]); }, 50'000));
+}
+TEST_F(krylov_m_monte_carlo_test_stl, sample_2d) {
+  RunUndeterminedTest(GenerateSampleParams(
+      2, [](const Point& x) { return (std::pow(x[0], 3) * std::sin(x[0])) + std::exp(x[1]); }, 50'000));
+}
+TEST_F(krylov_m_monte_carlo_test_stl, sample_3d) {
+  RunUndeterminedTest(GenerateSampleParams(
+      3, [](const Point& x) { return (std::pow(x[0], 4) * std::sin(x[0])) + (std::exp(x[1]) * std::log(x[2])); },
+      50'000));
+}
+TEST_F(krylov_m_monte_carlo_test_stl, sample_4d) {
+  RunUndeterminedTest(GenerateSampleParams(
+      4,
+      [](const Point& x) {
+        return (std::pow(x[0], 5) * std::sin(x[0])) + std::exp(x[1]) + (std::log(x[2]) * std::tan(x[3]));
+      },
+      50'000));
+}
+TEST_F(krylov_m_monte_carlo_test_stl, sample_5d) {
+  RunUndeterminedTest(GenerateSampleParams(
+      5, [](const Point& x) { return std::pow(std::numbers::e, -std::reduce(x.begin(), x.end(), 0.)); }, 50'000));
+}
+
+TEST_F(krylov_m_monte_carlo_test_stl, validation_failure) {
+  IntegrationParams params{.func = [](const Point&) { return 0.; }, .bounds = {{1, 0}}, .iterations = 100'000};
+  double stub{};
+
+  TaskSTL task(params.CreateTaskData(stub));
+  EXPECT_FALSE(task.Validation());
+}
+
+TEST_P(krylov_m_monte_carlo_test_stl, determined) {
+  auto [params, ref] = GetParam();
+  RunTest(std::move(params), ref);
+}
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_stl, krylov_m_monte_carlo_test_stl, ::testing::Values( // NOLINT(misc-use-anonymous-namespace)
+    DeterminedTestCase{
+        {
+            .func = [](const Point& x) {
+                return 0.;
+            },
+            .bounds = {
+                {-5, 5}
+            },
+            .iterations = 75'000
+        },
+        0.
+    },
+    DeterminedTestCase{
+        {
+            .func = [](const Point& x) {
+                return 5.;
+            },
+            .bounds = {
+                {-5, 5}
+            },
+            .iterations = 75'000
+        },
+        50.
+    },
+    DeterminedTestCase{
+        {
+            .func = [](const Point& x) {
+                return std::sin(x[0]);
+            },
+            .bounds = {
+                {42, 42}
+            },
+            .iterations = 75'000
+        },
+        0.
+    },
+    DeterminedTestCase{
+        {
+            .func = [](const Point& x) {
+                return ((std::cos(x[0]) + 1) * (-std::sin(x[0]))) - std::cos(2 * x[0]);
+            },
+            .bounds = {
+                {-std::numbers::pi, std::numbers::pi}
+            },
+            .iterations = 75'000
+        },
+        0.
+    },
+    DeterminedTestCase{
+        {
+            .func = [](const Point& x) {
+                return ((std::cos(x[0]) + 1) * (-std::sin(x[0]))) - std::cos(2 * x[0]);
+            },
+            .bounds = {
+                {-std::numbers::pi, std::numbers::pi}
+            },
+            .iterations = 75'000
+        },
+        0.
+    },
+    DeterminedTestCase{
+        {
+            .func = [](const Point& x) {
+                return ((std::sin(2 * x[0])) * (-4 * std::sin(2 * x[0]))) - (0.5 * std::cos(x[0])) - (1.5 * std::cos(3 * x[0]));
+            },
+            .bounds = {
+                {-std::numbers::pi, std::numbers::pi}
+            },
+            .iterations = 75'000
+        },
+        -4 * std::numbers::pi
+    },
+    DeterminedTestCase{
+        {
+            .func = [](const Point& x) {
+                return std::pow(x[0], 2) + (4 * x[1]);
+            },
+            .bounds = {
+                {11, 14},
+                {7, 10}
+            },
+            .iterations = 75'000
+        },
+        []{
+            constexpr auto kAntiderivative = [](const double x) { return std::pow(x, 3) + (102 * x); };
+            return kAntiderivative(14) - kAntiderivative(11);
+        }()
+    },
+    DeterminedTestCase{
+        {
+            .func = [](const Point& x) {
+                return 9 * std::pow(x[0], 3) * std::pow(x[1], 2);
+            },
+            .bounds = {
+                {1, 3},
+                {2, 4}
+            },
+            .iterations = 75'000
+        },
+        []{
+            constexpr auto kAntiderivative = [](const double x) { return 42 * std::pow(x, 4); };
+            return kAntiderivative(3) - kAntiderivative(1);
+        }()
+    }
+));
+// clang-format on

--- a/tasks/stl/krylov_m_monte_carlo/include/mci_common.hpp
+++ b/tasks/stl/krylov_m_monte_carlo/include/mci_common.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <random>
+#include <span>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace krylov_m_monte_carlo {
+
+using Point = std::span<double>;
+using MathFunction = double (*)(const Point&);  // <-- avoid extra indirection [std::function<double(const Point&)>]
+using Bound = std::pair<double, double>;
+
+struct IntegrationParams {
+  MathFunction func;
+  std::vector<Bound> bounds;
+  std::size_t iterations;
+
+  [[nodiscard]] std::size_t Dimensions() const noexcept { return bounds.size(); }
+
+  //
+
+  std::shared_ptr<ppc::core::TaskData> CreateTaskData(double& result) {
+    constexpr auto kUglyUnsafeTaskDataAddr = []<typename T>(T& o) {
+      return reinterpret_cast<decltype(std::declval<ppc::core::TaskData>().inputs)::value_type>(&o);
+    };
+
+    auto task_data = std::make_shared<ppc::core::TaskData>();
+
+    task_data->inputs = {kUglyUnsafeTaskDataAddr(*this)};
+    task_data->inputs_count = {1, 1, 2, 2};
+    //
+    task_data->outputs = {kUglyUnsafeTaskDataAddr(result)};
+    task_data->outputs_count = {1};
+
+    return task_data;
+  }
+
+  static IntegrationParams& FromTaskData(ppc::core::TaskData& task_data) noexcept {
+    return *reinterpret_cast<IntegrationParams*>(task_data.inputs[0]);
+  }
+  static double& OutputOf(ppc::core::TaskData& task_data) noexcept {
+    return *reinterpret_cast<double*>(task_data.outputs[0]);
+  }
+};
+
+class TaskCommon : public ppc::core::Task {
+ public:
+  explicit TaskCommon(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+
+  bool ValidationImpl() override;
+  bool PreProcessingImpl() override;
+  bool RunImpl() override = 0;
+  bool PostProcessingImpl() override;
+
+ protected:
+  IntegrationParams* params;
+  double res;
+
+  double vol;
+  std::vector<std::uniform_real_distribution<double>> dists;
+};
+
+}  // namespace krylov_m_monte_carlo

--- a/tasks/stl/krylov_m_monte_carlo/include/mci_seq.hpp
+++ b/tasks/stl/krylov_m_monte_carlo/include/mci_seq.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <utility>
+
+#include "./mci_common.hpp"
+#include "core/task/include/task.hpp"
+
+namespace krylov_m_monte_carlo {
+
+class TaskSequential : public TaskCommon {
+ public:
+  explicit TaskSequential(ppc::core::TaskDataPtr task_data) : TaskCommon(std::move(task_data)) {}
+
+  bool RunImpl() override;
+};
+
+}  // namespace krylov_m_monte_carlo

--- a/tasks/stl/krylov_m_monte_carlo/include/mci_stl.hpp
+++ b/tasks/stl/krylov_m_monte_carlo/include/mci_stl.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <utility>
+
+#include "./mci_common.hpp"
+#include "core/task/include/task.hpp"
+
+namespace krylov_m_monte_carlo {
+
+class TaskSTL : public TaskCommon {
+ public:
+  explicit TaskSTL(ppc::core::TaskDataPtr task_data) : TaskCommon(std::move(task_data)) {}
+
+  bool RunImpl() override;
+};
+
+}  // namespace krylov_m_monte_carlo

--- a/tasks/stl/krylov_m_monte_carlo/perf_tests/main.cpp
+++ b/tasks/stl/krylov_m_monte_carlo/perf_tests/main.cpp
@@ -23,7 +23,7 @@ class krylov_m_monte_carlo_test_stl : public ::testing::Test {  // NOLINT(readab
                                           std::exp(x[4]);
                                  },
                              .bounds = std::vector<Bound>(5, {0., 1.}),
-                             .iterations = 12'000'000};
+                             .iterations = 4'000'000};
 
     auto task = std::make_shared<TaskSTL>(params.CreateTaskData(out));
 

--- a/tasks/stl/krylov_m_monte_carlo/perf_tests/main.cpp
+++ b/tasks/stl/krylov_m_monte_carlo/perf_tests/main.cpp
@@ -23,7 +23,7 @@ class krylov_m_monte_carlo_test_stl : public ::testing::Test {  // NOLINT(readab
                                           std::exp(x[4]);
                                  },
                              .bounds = std::vector<Bound>(5, {0., 1.}),
-                             .iterations = 1'800'000};
+                             .iterations = 12'000'000};
 
     auto task = std::make_shared<TaskSTL>(params.CreateTaskData(out));
 

--- a/tasks/stl/krylov_m_monte_carlo/perf_tests/main.cpp
+++ b/tasks/stl/krylov_m_monte_carlo/perf_tests/main.cpp
@@ -1,0 +1,58 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cmath>
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "../include/mci_common.hpp"
+#include "../include/mci_stl.hpp"
+#include "core/perf/include/perf.hpp"
+
+using namespace krylov_m_monte_carlo;
+
+class krylov_m_monte_carlo_test_stl : public ::testing::Test {  // NOLINT(readability-identifier-naming)
+ protected:
+  static void RunPerfTest(const std::function<void(ppc::core::Perf &, const std::shared_ptr<ppc::core::PerfAttr> &,
+                                                   const std::shared_ptr<ppc::core::PerfResults> &)> &runner) {
+    double out{};
+    IntegrationParams params{.func =
+                                 [](const Point &x) {
+                                   return std::log(x[0]) + std::sin(x[1]) + std::cos(x[2]) + std::tan(x[3]) +
+                                          std::exp(x[4]);
+                                 },
+                             .bounds = std::vector<Bound>(5, {0., 1.}),
+                             .iterations = 1'800'000};
+
+    auto task = std::make_shared<TaskSTL>(params.CreateTaskData(out));
+
+    //
+    auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+    perf_attr->num_running = 10;
+    const auto t0 = std::chrono::high_resolution_clock::now();
+    perf_attr->current_timer = [&] {
+      auto current_time_point = std::chrono::high_resolution_clock::now();
+      auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+      return static_cast<double>(duration) * 1e-9;
+    };
+
+    //
+    auto perf_results = std::make_shared<ppc::core::PerfResults>();
+    ppc::core::Perf perf_analyzer(task);
+    runner(perf_analyzer, perf_attr, perf_results);
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
+  }
+};
+
+TEST_F(krylov_m_monte_carlo_test_stl, test_pipeline_run) {
+  RunPerfTest([](auto &perf_analyzer, const auto &perf_attr, const auto &perf_results) {
+    perf_analyzer.PipelineRun(perf_attr, perf_results);
+  });
+}
+
+TEST_F(krylov_m_monte_carlo_test_stl, test_task_run) {
+  RunPerfTest([](auto &perf_analyzer, const auto &perf_attr, const auto &perf_results) {
+    perf_analyzer.TaskRun(perf_attr, perf_results);
+  });
+}

--- a/tasks/stl/krylov_m_monte_carlo/src/mci_common.cpp
+++ b/tasks/stl/krylov_m_monte_carlo/src/mci_common.cpp
@@ -1,0 +1,34 @@
+#include "../include/mci_common.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <random>
+
+bool krylov_m_monte_carlo::TaskCommon::ValidationImpl() {
+  return std::ranges::all_of(IntegrationParams::FromTaskData(*task_data).bounds,
+                             [](const Bound& bound) { return bound.second >= bound.first; });
+}
+
+bool krylov_m_monte_carlo::TaskCommon::PreProcessingImpl() {
+  params = &IntegrationParams::FromTaskData(*task_data);
+  res = {};
+  vol = 1.;
+  //
+  const std::size_t dimensions = params->Dimensions();
+  dists.resize(dimensions);
+  //
+
+  auto dist_it = dists.begin();
+  for (const auto& bound : params->bounds) {
+    *(dist_it++) = std::uniform_real_distribution<double>{bound.first, bound.second};
+    vol *= bound.second - bound.first;
+  }
+
+  return true;
+}
+
+bool krylov_m_monte_carlo::TaskCommon::PostProcessingImpl() {
+  IntegrationParams::OutputOf(*task_data) = res;
+  return true;
+}

--- a/tasks/stl/krylov_m_monte_carlo/src/mci_seq.cpp
+++ b/tasks/stl/krylov_m_monte_carlo/src/mci_seq.cpp
@@ -1,0 +1,28 @@
+#include "../include/mci_seq.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <random>
+#include <vector>
+
+bool krylov_m_monte_carlo::TaskSequential::RunImpl() {
+  const auto dimensions = params->Dimensions();
+  const auto iterations = params->iterations;
+  const auto func = params->func;
+
+  std::random_device dev;
+  std::mt19937 gen(dev());
+
+  std::vector<double> x(dimensions);
+  double sum = 0.;
+  for (std::size_t _ = 0; _ < iterations; ++_) {
+    for (std::size_t p = 0; p < dimensions; ++p) {
+      x[p] = dists[p](gen);
+    }
+    sum += func(x);
+  }
+
+  res = (vol * sum) / static_cast<double>(iterations);
+
+  return true;
+}

--- a/tasks/stl/krylov_m_monte_carlo/src/mci_stl.cpp
+++ b/tasks/stl/krylov_m_monte_carlo/src/mci_stl.cpp
@@ -1,0 +1,60 @@
+#include "../include/mci_stl.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <functional>
+#include <future>
+#include <numeric>
+#include <random>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "core/util/include/util.hpp"
+
+bool krylov_m_monte_carlo::TaskSTL::RunImpl() {
+  const auto dimensions = params->Dimensions();
+  const auto iterations = params->iterations;
+  const auto func = params->func;
+
+  std::random_device dev;
+  std::mt19937 gen(dev());
+
+  const auto calculation_thread = [&](std::size_t local_iterations, std::promise<double> &&promise) {
+    auto local_gen = gen;
+    std::vector<double> x(dimensions);
+    double partial_sum = 0.;
+    for (std::size_t _ = 0; _ < local_iterations; ++_) {
+      for (std::size_t p = 0; p < dimensions; ++p) {
+        x[p] = dists[p](local_gen);
+      }
+      partial_sum += func(x);
+    }
+
+    promise.set_value(partial_sum);
+  };
+
+  const std::size_t workers = ppc::util::GetPPCNumThreads();
+  std::vector<std::future<double>> futures(workers);
+  {
+    const std::size_t amount = iterations / workers;
+    const std::size_t threshold = iterations % workers;
+
+    std::vector<std::thread> threads(workers);
+    for (std::size_t i = 0; i < workers; i++) {
+      const std::size_t assigned = amount + ((i < threshold) ? 1 : 0);
+      std::promise<double> promise;
+      futures[i] = promise.get_future();
+      threads[i] = std::thread(calculation_thread, assigned, std::move(promise));
+    }
+    std::ranges::for_each(threads, [](auto &thread) { thread.join(); });
+  }
+
+  const double sum = std::transform_reduce(futures.begin(), futures.end(), 0., std::plus{},
+                                           [](std::future<double> &future) { return future.get(); });
+
+  res = (vol * sum) / static_cast<double>(iterations);
+
+  return true;
+}


### PR DESCRIPTION
На вход подается функция для интегрирования, принимающая координату точки в виде вектора значений, вектор пределов интегрирования, определяющий размерность функции, и точность, определяемую числом итераций.

На каждой итерации производится выбор случайной точки в заданной области, значения функции в точках суммируются. После выполнения всех итераций, итоговая оценка интеграла вычисляется как среднее значение функции, умноженное на объем области интегрирования - произведение длин ее сторон в каждой плоскости.

Распараллеливание происходит на уровне цикла по числу итераций.

Буфер координат точки инициализируется отдельно для каждого потока, поскольку не может быть разделяемым по определению. Генератор случайных чисел `mt19937` разделяем, но из-за реализованной им синхронизации разделенный доступ к нему приводит к возникновению узкого места, поэтому для каждого потока инициализируется выделенный генератор случайных чисел с тем же сидом.

Для равномерного распределения итераций по потокам используется тривиальный алгоритм.\
Для редукции парциальных сумм используются механизм, предоставляемый `std::future`.
