### PR TITLE
Шульпин Илья. Вариант 23. Технология SEQ. Построение выпуклой оболочки – проход Джарвиса.

### DIFF
--- a/scripts/create_perf_table.py
+++ b/scripts/create_perf_table.py
@@ -38,8 +38,8 @@ for line in logs_lines:
         task_name = result[0][1]
         perf_type = result[0][2]
         perf_time = float(result[0][3])
-        if perf_time < 1.0:
-            msg = f"Performance time = {perf_time} < 1 second : for {task_type} - {task_name} - {perf_type} \n"
+        if perf_time < 0.1:
+            msg = f"Performance time = {perf_time} < 0.1 second : for {task_type} - {task_name} - {perf_type} \n"
             raise Exception(msg)
         result_tables[perf_type][task_name][task_type] = perf_time
 

--- a/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -11,11 +12,11 @@
 
 namespace shulpin_i_jarvis_seq {
 static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(const shulpin_i_jarvis_seq::Point& center,
-                                                                       double radius, size_t num_points) {
+                                                                       size_t num_points, double radius) {
   std::vector<shulpin_i_jarvis_seq::Point> points;
 
   for (size_t i = 0; i < num_points; ++i) {
-    double angle = 2.0 * std::numbers::pi * i / num_points;
+    double angle = 2.0 * std::numbers::pi * static_cast<double>(i) / static_cast<double> (num_points);
     double x = center.x + (radius * std::cos(angle));
     double y = center.y + (radius * std::sin(angle));
     points.emplace_back(x, y);
@@ -24,7 +25,7 @@ static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(const shu
   return points;
 }
 
-static void TestBody(std::vector<shulpin_i_jarvis_seq::Point>& input,
+void TestBody(std::vector<shulpin_i_jarvis_seq::Point>& input,
                      std::vector<shulpin_i_jarvis_seq::Point>& expected) {
   std::vector<shulpin_i_jarvis_seq::Point> result(expected.size());
 
@@ -65,7 +66,7 @@ static void TestBodyFalse(std::vector<shulpin_i_jarvis_seq::Point>& input,
 }
 
 static void TestBodyRandomCircle(std::vector<shulpin_i_jarvis_seq::Point>& input,
-                                 std::vector<shulpin_i_jarvis_seq::Point>& expected, size_t& numPoints) {
+                                 std::vector<shulpin_i_jarvis_seq::Point>& expected, size_t& num_points) {
   std::vector<shulpin_i_jarvis_seq::Point> result(expected.size());
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
@@ -82,7 +83,7 @@ static void TestBodyRandomCircle(std::vector<shulpin_i_jarvis_seq::Point>& input
   seq_task.Run();
   seq_task.PostProcessing();
 
-  size_t tmp = numPoints >> 1;
+  size_t tmp = num_points >> 1;
 
   for (size_t i = 0; i < result.size(); ++i) {
     size_t idx = (i < tmp) ? (i + tmp) : (i - tmp);
@@ -153,7 +154,7 @@ TEST(shulpin_i_jarvis_seq, circle_r10_p100) {
   double radius = 10.0;
   size_t num_points = 100;
   std::vector<shulpin_i_jarvis_seq::Point> input =
-      shulpin_i_jarvis_seq::GeneratePointsInCircle(center, radius, num_points);
+      shulpin_i_jarvis_seq::GeneratePointsInCircle(center, num_points, radius);
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;
 
   shulpin_i_jarvis_seq::TestBodyRandomCircle(input, expected, num_points);
@@ -164,7 +165,7 @@ TEST(shulpin_i_jarvis_seq, circle_r10_p1000) {
   double radius = 10.0;
   size_t num_points = 1000;
   std::vector<shulpin_i_jarvis_seq::Point> input =
-      shulpin_i_jarvis_seq::GeneratePointsInCircle(center, radius, num_points);
+      shulpin_i_jarvis_seq::GeneratePointsInCircle(center, num_points, radius);
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;
 
   shulpin_i_jarvis_seq::TestBodyRandomCircle(input, expected, num_points);
@@ -175,7 +176,7 @@ TEST(shulpin_i_jarvis_seq, circle_r10_p10000) {
   double radius = 10.0;
   size_t num_points = 10000;
   std::vector<shulpin_i_jarvis_seq::Point> input =
-      shulpin_i_jarvis_seq::GeneratePointsInCircle(center, radius, num_points);
+      shulpin_i_jarvis_seq::GeneratePointsInCircle(center, num_points, radius);
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;
 
   shulpin_i_jarvis_seq::TestBodyRandomCircle(input, expected, num_points);

--- a/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
@@ -10,7 +10,7 @@
 #include "core/task/include/task.hpp"
 #include "seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp"
 
-namespace shulpin_i_jarvis_seq {
+namespace {
 static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(size_t num_points,
                                                                        const shulpin_i_jarvis_seq::Point& center,
                                                                        double radius) {
@@ -23,7 +23,7 @@ static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(size_t nu
   }
   return points;
 }
-}  // namespace shulpin_i_jarvis_seq
+}  // namespace
 
 namespace {
 void MainTestBody(std::vector<shulpin_i_jarvis_seq::Point>& input, std::vector<shulpin_i_jarvis_seq::Point>& expected) {
@@ -155,8 +155,7 @@ TEST(shulpin_i_jarvis_seq, circle_r10_p100) {
   double radius = 10.0;
   size_t num_points = 100;
 
-  std::vector<shulpin_i_jarvis_seq::Point> input =
-      shulpin_i_jarvis_seq::GeneratePointsInCircle(num_points, center, radius);
+  std::vector<shulpin_i_jarvis_seq::Point> input = GeneratePointsInCircle(num_points, center, radius);
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;
 
   TestBodyRandomCircle(input, expected, num_points);
@@ -168,8 +167,7 @@ TEST(shulpin_i_jarvis_seq, circle_r10_p1000) {
   double radius = 10.0;
   size_t num_points = 1000;
 
-  std::vector<shulpin_i_jarvis_seq::Point> input =
-      shulpin_i_jarvis_seq::GeneratePointsInCircle(num_points, center, radius);
+  std::vector<shulpin_i_jarvis_seq::Point> input = GeneratePointsInCircle(num_points, center, radius);
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;
 
   TestBodyRandomCircle(input, expected, num_points);

--- a/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
@@ -90,7 +90,7 @@ void TestBodyRandomCircle(std::vector<shulpin_i_jarvis_seq::Point>& input,
     EXPECT_EQ(expected[i].y, result[idx].y);
   }
 }
-}
+}  // namespace
 
 TEST(shulpin_i_jarvis_seq, square_with_point) {
   std::vector<shulpin_i_jarvis_seq::Point> input = {{0, 0}, {2, 0}, {2, 2}, {0, 2}, {1, 1}};

--- a/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
@@ -1,50 +1,45 @@
 #include <gtest/gtest.h>
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <string>
 #include <vector>
+#include <numbers>
 
 #include "core/task/include/task.hpp"
-#include "core/util/include/util.hpp"
 #include "seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp"
 
-namespace shulpin_i_Jarvis_seq {
-std::vector<shulpin_i_Jarvis_seq::Point> generatePointsInCircle(const shulpin_i_Jarvis_seq::Point& center,
-                                                                double radius, uint32_t numPoints) {
-  std::vector<shulpin_i_Jarvis_seq::Point> points;
+namespace shulpin_i_jarvis_seq {
+static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(const shulpin_i_jarvis_seq::Point& center,
+                                                                       double radius, size_t num_points) {
+  std::vector<shulpin_i_jarvis_seq::Point> points;
 
-  for (uint32_t i = 0; i < numPoints; ++i) {
-    double angle = 2.0 * M_PI * i / numPoints;
-    double x = center.x + radius * cos(angle);
-    double y = center.y + radius * sin(angle);
-    points.push_back({x, y});
+  for (size_t i = 0; i < num_points; ++i) {
+    double angle = 2.0 * std::numbers::pi * i / num_points;
+    double x = center.x + (radius * std::cos(angle));
+    double y = center.y + (radius * std::sin(angle));
+    points.emplace_back(x, y);
   }
 
   return points;
 }
 
-void TestBody(std::vector<shulpin_i_Jarvis_seq::Point>& input, std::vector<shulpin_i_Jarvis_seq::Point>& expected) {
-  std::vector<shulpin_i_Jarvis_seq::Point> result(expected.size());
+static void TestBody(std::vector<shulpin_i_jarvis_seq::Point>& input, std::vector<shulpin_i_jarvis_seq::Point>& expected) {
+  std::vector<shulpin_i_jarvis_seq::Point> result(expected.size());
 
-  auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
 
-  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
-  taskDataSeq->inputs_count.emplace_back(static_cast<uint32_t>(input.size()));
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data_seq->inputs_count.emplace_back(static_cast<uint32_t>(input.size()));
 
-  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(result.data()));
-  taskDataSeq->outputs_count.emplace_back(static_cast<uint32_t>(result.size()));
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(result.data()));
+  task_data_seq->outputs_count.emplace_back(static_cast<uint32_t>(result.size()));
 
-  shulpin_i_Jarvis_seq::JarvisSequential SeqTask(taskDataSeq);
-  ASSERT_EQ(SeqTask.Validation(), true);
-  SeqTask.PreProcessing();
-  SeqTask.Run();
-  SeqTask.PostProcessing();
+  shulpin_i_jarvis_seq::JarvisSequential seq_task(task_data_seq);
+  ASSERT_EQ(seq_task.Validation(), true);
+  seq_task.PreProcessing();
+  seq_task.Run();
+  seq_task.PostProcessing();
 
   for (size_t i = 0; i < result.size(); ++i) {
     ASSERT_EQ(expected[i].x, result[i].x);
@@ -52,39 +47,39 @@ void TestBody(std::vector<shulpin_i_Jarvis_seq::Point>& input, std::vector<shulp
   }
 }
 
-void TestBody_False(std::vector<shulpin_i_Jarvis_seq::Point>& input,
-                    std::vector<shulpin_i_Jarvis_seq::Point>& expected) {
-  std::vector<shulpin_i_Jarvis_seq::Point> result(expected.size());
+static void TestBodyFalse(std::vector<shulpin_i_jarvis_seq::Point>& input,
+                    std::vector<shulpin_i_jarvis_seq::Point>& expected) {
+  std::vector<shulpin_i_jarvis_seq::Point> result(expected.size());
 
-  auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
 
-  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
-  taskDataSeq->inputs_count.emplace_back(static_cast<uint32_t>(input.size()));
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data_seq->inputs_count.emplace_back(static_cast<uint32_t>(input.size()));
 
-  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(result.data()));
-  taskDataSeq->outputs_count.emplace_back(static_cast<uint32_t>(result.size()));
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(result.data()));
+  task_data_seq->outputs_count.emplace_back(static_cast<uint32_t>(result.size()));
 
-  shulpin_i_Jarvis_seq::JarvisSequential SeqTask(taskDataSeq);
-  ASSERT_EQ(SeqTask.Validation(), false);
+  shulpin_i_jarvis_seq::JarvisSequential seq_task(task_data_seq);
+  ASSERT_EQ(seq_task.Validation(), false);
 }
 
-void TestBody_Random_Circle(std::vector<shulpin_i_Jarvis_seq::Point>& input,
-                            std::vector<shulpin_i_Jarvis_seq::Point>& expected, size_t& numPoints) {
-  std::vector<shulpin_i_Jarvis_seq::Point> result(expected.size());
+static void TestBodyRandomCircle(std::vector<shulpin_i_jarvis_seq::Point>& input,
+                            std::vector<shulpin_i_jarvis_seq::Point>& expected, size_t& numPoints) {
+  std::vector<shulpin_i_jarvis_seq::Point> result(expected.size());
 
-  auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
 
-  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
-  taskDataSeq->inputs_count.emplace_back(static_cast<uint32_t>(input.size()));
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data_seq->inputs_count.emplace_back(static_cast<uint32_t>(input.size()));
 
-  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(result.data()));
-  taskDataSeq->outputs_count.emplace_back(static_cast<uint32_t>(result.size()));
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(result.data()));
+  task_data_seq->outputs_count.emplace_back(static_cast<uint32_t>(result.size()));
 
-  shulpin_i_Jarvis_seq::JarvisSequential SeqTask(taskDataSeq);
-  ASSERT_EQ(SeqTask.Validation(), true);
-  SeqTask.PreProcessing();
-  SeqTask.Run();
-  SeqTask.PostProcessing();
+  shulpin_i_jarvis_seq::JarvisSequential seq_task(task_data_seq);
+  ASSERT_EQ(seq_task.Validation(), true);
+  seq_task.PreProcessing();
+  seq_task.Run();
+  seq_task.PostProcessing();
 
   size_t tmp = numPoints >> 1;
 
@@ -96,91 +91,91 @@ void TestBody_Random_Circle(std::vector<shulpin_i_Jarvis_seq::Point>& input,
 }
 }  // namespace shulpin_i_Jarvis_seq
 
-TEST(shulpin_i_Jarvis_seqq, square_with_point) {
-  std::vector<shulpin_i_Jarvis_seq::Point> input = {{0, 0}, {2, 0}, {2, 2}, {0, 2}, {1, 1}};
-  std::vector<shulpin_i_Jarvis_seq::Point> expected = {{0, 0}, {2, 0}, {2, 2}, {0, 2}};
+TEST(shulpin_i_jarvis_seq, square_with_point) {
+  std::vector<shulpin_i_jarvis_seq::Point> input = {{0, 0}, {2, 0}, {2, 2}, {0, 2}, {1, 1}};
+  std::vector<shulpin_i_jarvis_seq::Point> expected = {{0, 0}, {2, 0}, {2, 2}, {0, 2}};
 
-  shulpin_i_Jarvis_seq::TestBody(input, expected);
+  shulpin_i_jarvis_seq::TestBody(input, expected);
 }
 
-TEST(shulpin_i_Jarvis_seqq, triangle) {
-  std::vector<shulpin_i_Jarvis_seq::Point> input = {{0, 0}, {3, 0}, {1, 2}};
-  std::vector<shulpin_i_Jarvis_seq::Point> expected = {{0, 0}, {3, 0}, {1, 2}};
+TEST(shulpin_i_jarvis_seq, triangle) {
+  std::vector<shulpin_i_jarvis_seq::Point> input = {{0, 0}, {3, 0}, {1, 2}};
+  std::vector<shulpin_i_jarvis_seq::Point> expected = {{0, 0}, {3, 0}, {1, 2}};
 
-  shulpin_i_Jarvis_seq::TestBody(input, expected);
+  shulpin_i_jarvis_seq::TestBody(input, expected);
 }
 
-TEST(shulpin_i_Jarvis_seqq, octagone) {
-  std::vector<shulpin_i_Jarvis_seq::Point> input = {{1, 0}, {2, 0}, {3, 1}, {3, 2}, {2, 3}, {1, 3}, {0, 2}, {0, 1}};
-  std::vector<shulpin_i_Jarvis_seq::Point> expected = {{0, 1}, {1, 0}, {2, 0}, {3, 1}, {3, 2}, {2, 3}, {1, 3}, {0, 2}};
+TEST(shulpin_i_jarvis_seq, octagone) {
+  std::vector<shulpin_i_jarvis_seq::Point> input = {{1, 0}, {2, 0}, {3, 1}, {3, 2}, {2, 3}, {1, 3}, {0, 2}, {0, 1}};
+  std::vector<shulpin_i_jarvis_seq::Point> expected = {{0, 1}, {1, 0}, {2, 0}, {3, 1}, {3, 2}, {2, 3}, {1, 3}, {0, 2}};
 
-  shulpin_i_Jarvis_seq::TestBody(input, expected);
+  shulpin_i_jarvis_seq::TestBody(input, expected);
 }
 
-TEST(shulpin_i_Jarvis_seqq, repeated_points) {
-  std::vector<shulpin_i_Jarvis_seq::Point> input = {{0, 0}, {2, 0}, {2, 2}, {0, 2}, {2, 0}, {0, 0}};
-  std::vector<shulpin_i_Jarvis_seq::Point> expected = {{0, 0}, {2, 0}, {2, 2}, {0, 2}};
+TEST(shulpin_i_jarvis_seq, repeated_points) {
+  std::vector<shulpin_i_jarvis_seq::Point> input = {{0, 0}, {2, 0}, {2, 2}, {0, 2}, {2, 0}, {0, 0}};
+  std::vector<shulpin_i_jarvis_seq::Point> expected = {{0, 0}, {2, 0}, {2, 2}, {0, 2}};
 
-  shulpin_i_Jarvis_seq::TestBody(input, expected);
+  shulpin_i_jarvis_seq::TestBody(input, expected);
 }
 
-TEST(shulpin_i_Jarvis_seqq, real_case) {
-  std::vector<shulpin_i_Jarvis_seq::Point> input = {{1, 1}, {3, 2}, {5, 1}, {4, 3}, {2, 4}, {1, 3}, {3, 3}};
-  std::vector<shulpin_i_Jarvis_seq::Point> expected = {{1, 1}, {5, 1}, {4, 3}, {2, 4}, {1, 3}};
+TEST(shulpin_i_jarvis_seq, real_case) {
+  std::vector<shulpin_i_jarvis_seq::Point> input = {{1, 1}, {3, 2}, {5, 1}, {4, 3}, {2, 4}, {1, 3}, {3, 3}};
+  std::vector<shulpin_i_jarvis_seq::Point> expected = {{1, 1}, {5, 1}, {4, 3}, {2, 4}, {1, 3}};
 
-  shulpin_i_Jarvis_seq::TestBody(input, expected);
+  shulpin_i_jarvis_seq::TestBody(input, expected);
 }
 
-TEST(shulpin_i_Jarvis_seqq, one_point_validation_false) {
-  std::vector<shulpin_i_Jarvis_seq::Point> input = {{0, 0}};
-  std::vector<shulpin_i_Jarvis_seq::Point> expected = {{0, 0}};
+TEST(shulpin_i_jarvis_seq, one_point_validation_false) {
+  std::vector<shulpin_i_jarvis_seq::Point> input = {{0, 0}};
+  std::vector<shulpin_i_jarvis_seq::Point> expected = {{0, 0}};
 
-  shulpin_i_Jarvis_seq::TestBody_False(input, expected);
+  shulpin_i_jarvis_seq::TestBodyFalse(input, expected);
 }
 
-TEST(shulpin_i_Jarvis_seqq, three_points_validation_false) {
-  std::vector<shulpin_i_Jarvis_seq::Point> input = {{1, 1}, {2, 2}};
-  std::vector<shulpin_i_Jarvis_seq::Point> expected = {{1, 1}, {2, 2}};
+TEST(shulpin_i_jarvis_seq, three_points_validation_false) {
+  std::vector<shulpin_i_jarvis_seq::Point> input = {{1, 1}, {2, 2}};
+  std::vector<shulpin_i_jarvis_seq::Point> expected = {{1, 1}, {2, 2}};
 
-  shulpin_i_Jarvis_seq::TestBody_False(input, expected);
+  shulpin_i_jarvis_seq::TestBodyFalse(input, expected);
 }
 
-TEST(shulpin_i_Jarvis_seqq, zero_points_validation_false) {
-  std::vector<shulpin_i_Jarvis_seq::Point> input = {};
-  std::vector<shulpin_i_Jarvis_seq::Point> expected = {};
+TEST(shulpin_i_jarvis_seq, zero_points_validation_false) {
+  std::vector<shulpin_i_jarvis_seq::Point> input = {};
+  std::vector<shulpin_i_jarvis_seq::Point> expected = {};
 
-  shulpin_i_Jarvis_seq::TestBody_False(input, expected);
+  shulpin_i_jarvis_seq::TestBodyFalse(input, expected);
 }
 
-TEST(shulpin_i_Jarvis_seqq, circle_r10_p100) {
-  shulpin_i_Jarvis_seq::Point center{0, 0};
+TEST(shulpin_i_jarvis_seq, circle_r10_p100) {
+  shulpin_i_jarvis_seq::Point center{0, 0};
   double radius = 10.0;
-  size_t numPoints = 100;
-  std::vector<shulpin_i_Jarvis_seq::Point> input =
-      shulpin_i_Jarvis_seq::generatePointsInCircle(center, radius, numPoints);
-  std::vector<shulpin_i_Jarvis_seq::Point> expected = input;
+  size_t num_points = 100;
+  std::vector<shulpin_i_jarvis_seq::Point> input =
+      shulpin_i_jarvis_seq::GeneratePointsInCircle(center, radius, num_points);
+  std::vector<shulpin_i_jarvis_seq::Point> expected = input;
 
-  shulpin_i_Jarvis_seq::TestBody_Random_Circle(input, expected, numPoints);
+  shulpin_i_jarvis_seq::TestBodyRandomCircle(input, expected, num_points);
 }
 
-TEST(shulpin_i_Jarvis_seqq, circle_r10_p1000) {
-  shulpin_i_Jarvis_seq::Point center{0, 0};
+TEST(shulpin_i_jarvis_seq, circle_r10_p1000) {
+  shulpin_i_jarvis_seq::Point center{0, 0};
   double radius = 10.0;
-  size_t numPoints = 1000;
-  std::vector<shulpin_i_Jarvis_seq::Point> input =
-      shulpin_i_Jarvis_seq::generatePointsInCircle(center, radius, numPoints);
-  std::vector<shulpin_i_Jarvis_seq::Point> expected = input;
+  size_t num_points = 1000;
+  std::vector<shulpin_i_jarvis_seq::Point> input =
+      shulpin_i_jarvis_seq::GeneratePointsInCircle(center, radius, num_points);
+  std::vector<shulpin_i_jarvis_seq::Point> expected = input;
 
-  shulpin_i_Jarvis_seq::TestBody_Random_Circle(input, expected, numPoints);
+  shulpin_i_jarvis_seq::TestBodyRandomCircle(input, expected, num_points);
 }
 
-TEST(shulpin_i_Jarvis_seqq, circle_r10_p10000) {
-  shulpin_i_Jarvis_seq::Point center{0, 0};
+TEST(shulpin_i_jarvis_seq, circle_r10_p10000) {
+  shulpin_i_jarvis_seq::Point center{0, 0};
   double radius = 10.0;
-  size_t numPoints = 10000;
-  std::vector<shulpin_i_Jarvis_seq::Point> input =
-      shulpin_i_Jarvis_seq::generatePointsInCircle(center, radius, numPoints);
-  std::vector<shulpin_i_Jarvis_seq::Point> expected = input;
+  size_t num_points = 10000;
+  std::vector<shulpin_i_jarvis_seq::Point> input =
+      shulpin_i_jarvis_seq::GeneratePointsInCircle(center, radius, num_points);
+  std::vector<shulpin_i_jarvis_seq::Point> expected = input;
 
-  shulpin_i_Jarvis_seq::TestBody_Random_Circle(input, expected, numPoints);
+  shulpin_i_jarvis_seq::TestBodyRandomCircle(input, expected, num_points);
 }

--- a/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
@@ -22,8 +22,10 @@ static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(const shu
   }
   return points;
 }
+}  // namespace shulpin_i_jarvis_seq
 
-void TestBody(std::vector<shulpin_i_jarvis_seq::Point>& input, std::vector<shulpin_i_jarvis_seq::Point>& expected) {
+namespace {
+void MainTestBody(std::vector<shulpin_i_jarvis_seq::Point>& input, std::vector<shulpin_i_jarvis_seq::Point>& expected) {
   std::vector<shulpin_i_jarvis_seq::Point> result(expected.size());
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
@@ -46,8 +48,8 @@ void TestBody(std::vector<shulpin_i_jarvis_seq::Point>& input, std::vector<shulp
   }
 }
 
-static void TestBodyFalse(std::vector<shulpin_i_jarvis_seq::Point>& input,
-                          std::vector<shulpin_i_jarvis_seq::Point>& expected) {
+void TestBodyFalse(std::vector<shulpin_i_jarvis_seq::Point>& input,
+                   std::vector<shulpin_i_jarvis_seq::Point>& expected) {
   std::vector<shulpin_i_jarvis_seq::Point> result(expected.size());
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
@@ -62,8 +64,8 @@ static void TestBodyFalse(std::vector<shulpin_i_jarvis_seq::Point>& input,
   ASSERT_EQ(seq_task.Validation(), false);
 }
 
-static void TestBodyRandomCircle(std::vector<shulpin_i_jarvis_seq::Point>& input,
-                                 std::vector<shulpin_i_jarvis_seq::Point>& expected, size_t& num_points) {
+void TestBodyRandomCircle(std::vector<shulpin_i_jarvis_seq::Point>& input,
+                          std::vector<shulpin_i_jarvis_seq::Point>& expected, size_t& num_points) {
   std::vector<shulpin_i_jarvis_seq::Point> result(expected.size());
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
@@ -88,62 +90,62 @@ static void TestBodyRandomCircle(std::vector<shulpin_i_jarvis_seq::Point>& input
     EXPECT_EQ(expected[i].y, result[idx].y);
   }
 }
-}  // namespace shulpin_i_jarvis_seq
+}
 
 TEST(shulpin_i_jarvis_seq, square_with_point) {
   std::vector<shulpin_i_jarvis_seq::Point> input = {{0, 0}, {2, 0}, {2, 2}, {0, 2}, {1, 1}};
   std::vector<shulpin_i_jarvis_seq::Point> expected = {{0, 0}, {2, 0}, {2, 2}, {0, 2}};
 
-  shulpin_i_jarvis_seq::TestBody(input, expected);
+  MainTestBody(input, expected);
 }
 
 TEST(shulpin_i_jarvis_seq, triangle) {
   std::vector<shulpin_i_jarvis_seq::Point> input = {{0, 0}, {3, 0}, {1, 2}};
   std::vector<shulpin_i_jarvis_seq::Point> expected = {{0, 0}, {3, 0}, {1, 2}};
 
-  shulpin_i_jarvis_seq::TestBody(input, expected);
+  MainTestBody(input, expected);
 }
 
 TEST(shulpin_i_jarvis_seq, octagone) {
   std::vector<shulpin_i_jarvis_seq::Point> input = {{1, 0}, {2, 0}, {3, 1}, {3, 2}, {2, 3}, {1, 3}, {0, 2}, {0, 1}};
   std::vector<shulpin_i_jarvis_seq::Point> expected = {{0, 1}, {1, 0}, {2, 0}, {3, 1}, {3, 2}, {2, 3}, {1, 3}, {0, 2}};
 
-  shulpin_i_jarvis_seq::TestBody(input, expected);
+  MainTestBody(input, expected);
 }
 
 TEST(shulpin_i_jarvis_seq, repeated_points) {
   std::vector<shulpin_i_jarvis_seq::Point> input = {{0, 0}, {2, 0}, {2, 2}, {0, 2}, {2, 0}, {0, 0}};
   std::vector<shulpin_i_jarvis_seq::Point> expected = {{0, 0}, {2, 0}, {2, 2}, {0, 2}};
 
-  shulpin_i_jarvis_seq::TestBody(input, expected);
+  MainTestBody(input, expected);
 }
 
 TEST(shulpin_i_jarvis_seq, real_case) {
   std::vector<shulpin_i_jarvis_seq::Point> input = {{1, 1}, {3, 2}, {5, 1}, {4, 3}, {2, 4}, {1, 3}, {3, 3}};
   std::vector<shulpin_i_jarvis_seq::Point> expected = {{1, 1}, {5, 1}, {4, 3}, {2, 4}, {1, 3}};
 
-  shulpin_i_jarvis_seq::TestBody(input, expected);
+  MainTestBody(input, expected);
 }
 
 TEST(shulpin_i_jarvis_seq, one_point_validation_false) {
   std::vector<shulpin_i_jarvis_seq::Point> input = {{0, 0}};
   std::vector<shulpin_i_jarvis_seq::Point> expected = {{0, 0}};
 
-  shulpin_i_jarvis_seq::TestBodyFalse(input, expected);
+  TestBodyFalse(input, expected);
 }
 
 TEST(shulpin_i_jarvis_seq, three_points_validation_false) {
   std::vector<shulpin_i_jarvis_seq::Point> input = {{1, 1}, {2, 2}};
   std::vector<shulpin_i_jarvis_seq::Point> expected = {{1, 1}, {2, 2}};
 
-  shulpin_i_jarvis_seq::TestBodyFalse(input, expected);
+  TestBodyFalse(input, expected);
 }
 
 TEST(shulpin_i_jarvis_seq, zero_points_validation_false) {
   std::vector<shulpin_i_jarvis_seq::Point> input = {};
   std::vector<shulpin_i_jarvis_seq::Point> expected = {};
 
-  shulpin_i_jarvis_seq::TestBodyFalse(input, expected);
+  TestBodyFalse(input, expected);
 }
 
 TEST(shulpin_i_jarvis_seq, circle_r10_p100) {
@@ -153,7 +155,7 @@ TEST(shulpin_i_jarvis_seq, circle_r10_p100) {
   std::vector<shulpin_i_jarvis_seq::Point> input = shulpin_i_jarvis_seq::GeneratePointsInCircle(center, params);
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;
 
-  shulpin_i_jarvis_seq::TestBodyRandomCircle(input, expected, params.num_points);
+  TestBodyRandomCircle(input, expected, params.num_points);
 }
 
 TEST(shulpin_i_jarvis_seq, circle_r10_p1000) {
@@ -163,15 +165,5 @@ TEST(shulpin_i_jarvis_seq, circle_r10_p1000) {
   std::vector<shulpin_i_jarvis_seq::Point> input = shulpin_i_jarvis_seq::GeneratePointsInCircle(center, params);
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;
 
-  shulpin_i_jarvis_seq::TestBodyRandomCircle(input, expected, params.num_points);
-}
-
-TEST(shulpin_i_jarvis_seq, circle_r10_p5000) {
-  shulpin_i_jarvis_seq::Point center{0, 0};
-  shulpin_i_jarvis_seq::CircleParams params{10.0, 5000};
-
-  std::vector<shulpin_i_jarvis_seq::Point> input = shulpin_i_jarvis_seq::GeneratePointsInCircle(center, params);
-  std::vector<shulpin_i_jarvis_seq::Point> expected = input;
-
-  shulpin_i_jarvis_seq::TestBodyRandomCircle(input, expected, params.num_points);
+  TestBodyRandomCircle(input, expected, params.num_points);
 }

--- a/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
@@ -166,9 +166,9 @@ TEST(shulpin_i_jarvis_seq, circle_r10_p1000) {
   shulpin_i_jarvis_seq::TestBodyRandomCircle(input, expected, params.num_points);
 }
 
-TEST(shulpin_i_jarvis_seq, circle_r10_p10000) {
+TEST(shulpin_i_jarvis_seq, circle_r10_p5000) {
   shulpin_i_jarvis_seq::Point center{0, 0};
-  shulpin_i_jarvis_seq::CircleParams params{10.0, 10000};
+  shulpin_i_jarvis_seq::CircleParams params{10.0, 5000};
 
   std::vector<shulpin_i_jarvis_seq::Point> input = shulpin_i_jarvis_seq::GeneratePointsInCircle(center, params);
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;

--- a/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
@@ -12,16 +12,14 @@
 
 namespace shulpin_i_jarvis_seq {
 static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(const shulpin_i_jarvis_seq::Point& center,
-                                                                       size_t num_points, double radius) {
+                                                                       const CircleParams& params) {
   std::vector<shulpin_i_jarvis_seq::Point> points;
-
-  for (size_t i = 0; i < num_points; ++i) {
-    double angle = 2.0 * std::numbers::pi * static_cast<double>(i) / static_cast<double>(num_points);
-    double x = center.x + (radius * std::cos(angle));
-    double y = center.y + (radius * std::sin(angle));
+  for (size_t i = 0; i < params.num_points; ++i) {
+    double angle = 2.0 * std::numbers::pi * static_cast<double>(i) / static_cast<double>(params.num_points);
+    double x = center.x + (params.radius * std::cos(angle));
+    double y = center.y + (params.radius * std::sin(angle));
     points.emplace_back(x, y);
   }
-
   return points;
 }
 
@@ -150,33 +148,30 @@ TEST(shulpin_i_jarvis_seq, zero_points_validation_false) {
 
 TEST(shulpin_i_jarvis_seq, circle_r10_p100) {
   shulpin_i_jarvis_seq::Point center{0, 0};
-  double radius = 10.0;
-  size_t num_points = 100;
-  std::vector<shulpin_i_jarvis_seq::Point> input =
-      shulpin_i_jarvis_seq::GeneratePointsInCircle(center, num_points, radius);
+  shulpin_i_jarvis_seq::CircleParams params{10.0, 100};
+
+  std::vector<shulpin_i_jarvis_seq::Point> input = shulpin_i_jarvis_seq::GeneratePointsInCircle(center, params);
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;
 
-  shulpin_i_jarvis_seq::TestBodyRandomCircle(input, expected, num_points);
+  shulpin_i_jarvis_seq::TestBodyRandomCircle(input, expected, params.num_points);
 }
 
 TEST(shulpin_i_jarvis_seq, circle_r10_p1000) {
   shulpin_i_jarvis_seq::Point center{0, 0};
-  double radius = 10.0;
-  size_t num_points = 1000;
-  std::vector<shulpin_i_jarvis_seq::Point> input =
-      shulpin_i_jarvis_seq::GeneratePointsInCircle(center, num_points, radius);
+  shulpin_i_jarvis_seq::CircleParams params{10.0, 1000};
+
+  std::vector<shulpin_i_jarvis_seq::Point> input = shulpin_i_jarvis_seq::GeneratePointsInCircle(center, params);
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;
 
-  shulpin_i_jarvis_seq::TestBodyRandomCircle(input, expected, num_points);
+  shulpin_i_jarvis_seq::TestBodyRandomCircle(input, expected, params.num_points);
 }
 
 TEST(shulpin_i_jarvis_seq, circle_r10_p10000) {
   shulpin_i_jarvis_seq::Point center{0, 0};
-  double radius = 10.0;
-  size_t num_points = 10000;
-  std::vector<shulpin_i_jarvis_seq::Point> input =
-      shulpin_i_jarvis_seq::GeneratePointsInCircle(center, num_points, radius);
+  shulpin_i_jarvis_seq::CircleParams params{10.0, 10000};
+
+  std::vector<shulpin_i_jarvis_seq::Point> input = shulpin_i_jarvis_seq::GeneratePointsInCircle(center, params);
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;
 
-  shulpin_i_jarvis_seq::TestBodyRandomCircle(input, expected, num_points);
+  shulpin_i_jarvis_seq::TestBodyRandomCircle(input, expected, params.num_points);
 }

--- a/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
@@ -34,10 +34,10 @@ void TestBody(std::vector<shulpin_i_Jarvis_seq::Point>& input, std::vector<shulp
 
   auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
 
-  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
   taskDataSeq->inputs_count.emplace_back(static_cast<uint32_t>(input.size()));
 
-  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(result.data()));
   taskDataSeq->outputs_count.emplace_back(static_cast<uint32_t>(result.size()));
 
   shulpin_i_Jarvis_seq::JarvisSequential SeqTask(taskDataSeq);
@@ -94,7 +94,6 @@ void TestBody_Random_Circle(std::vector<shulpin_i_Jarvis_seq::Point>& input,
     EXPECT_EQ(expected[i].y, result[idx].y);
   }
 }
-    
 }  // namespace shulpin_i_Jarvis_seq
 
 TEST(shulpin_i_Jarvis_seqq, square_with_point) {

--- a/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
@@ -16,7 +16,7 @@ static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(const shu
   std::vector<shulpin_i_jarvis_seq::Point> points;
 
   for (size_t i = 0; i < num_points; ++i) {
-    double angle = 2.0 * std::numbers::pi * static_cast<double>(i) / static_cast<double> (num_points);
+    double angle = 2.0 * std::numbers::pi * static_cast<double>(i) / static_cast<double>(num_points);
     double x = center.x + (radius * std::cos(angle));
     double y = center.y + (radius * std::sin(angle));
     points.emplace_back(x, y);
@@ -26,7 +26,7 @@ static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(const shu
 }
 
 void TestBody(std::vector<shulpin_i_jarvis_seq::Point>& input,
-                     std::vector<shulpin_i_jarvis_seq::Point>& expected) {
+              std::vector<shulpin_i_jarvis_seq::Point>& expected) {
   std::vector<shulpin_i_jarvis_seq::Point> result(expected.size());
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();

--- a/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
@@ -3,8 +3,8 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <vector>
 #include <numbers>
+#include <vector>
 
 #include "core/task/include/task.hpp"
 #include "seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp"
@@ -24,7 +24,8 @@ static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(const shu
   return points;
 }
 
-static void TestBody(std::vector<shulpin_i_jarvis_seq::Point>& input, std::vector<shulpin_i_jarvis_seq::Point>& expected) {
+static void TestBody(std::vector<shulpin_i_jarvis_seq::Point>& input,
+                     std::vector<shulpin_i_jarvis_seq::Point>& expected) {
   std::vector<shulpin_i_jarvis_seq::Point> result(expected.size());
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
@@ -48,7 +49,7 @@ static void TestBody(std::vector<shulpin_i_jarvis_seq::Point>& input, std::vecto
 }
 
 static void TestBodyFalse(std::vector<shulpin_i_jarvis_seq::Point>& input,
-                    std::vector<shulpin_i_jarvis_seq::Point>& expected) {
+                          std::vector<shulpin_i_jarvis_seq::Point>& expected) {
   std::vector<shulpin_i_jarvis_seq::Point> result(expected.size());
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
@@ -64,7 +65,7 @@ static void TestBodyFalse(std::vector<shulpin_i_jarvis_seq::Point>& input,
 }
 
 static void TestBodyRandomCircle(std::vector<shulpin_i_jarvis_seq::Point>& input,
-                            std::vector<shulpin_i_jarvis_seq::Point>& expected, size_t& numPoints) {
+                                 std::vector<shulpin_i_jarvis_seq::Point>& expected, size_t& numPoints) {
   std::vector<shulpin_i_jarvis_seq::Point> result(expected.size());
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
@@ -89,7 +90,7 @@ static void TestBodyRandomCircle(std::vector<shulpin_i_jarvis_seq::Point>& input
     EXPECT_EQ(expected[i].y, result[idx].y);
   }
 }
-}  // namespace shulpin_i_Jarvis_seq
+}  // namespace shulpin_i_jarvis_seq
 
 TEST(shulpin_i_jarvis_seq, square_with_point) {
   std::vector<shulpin_i_jarvis_seq::Point> input = {{0, 0}, {2, 0}, {2, 2}, {0, 2}, {1, 1}};

--- a/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
@@ -52,7 +52,8 @@ void TestBody(std::vector<shulpin_i_Jarvis_seq::Point>& input, std::vector<shulp
   }
 }
 
-void TestBody_False(std::vector<shulpin_i_Jarvis_seq::Point>& input, std::vector<shulpin_i_Jarvis_seq::Point>& expected) {
+void TestBody_False(std::vector<shulpin_i_Jarvis_seq::Point>& input,
+                    std::vector<shulpin_i_Jarvis_seq::Point>& expected) {
   std::vector<shulpin_i_Jarvis_seq::Point> result(expected.size());
 
   auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
@@ -68,7 +69,7 @@ void TestBody_False(std::vector<shulpin_i_Jarvis_seq::Point>& input, std::vector
 }
 
 void TestBody_Random_Circle(std::vector<shulpin_i_Jarvis_seq::Point>& input,
-                    std::vector<shulpin_i_Jarvis_seq::Point>& expected, size_t& numPoints) {
+                            std::vector<shulpin_i_Jarvis_seq::Point>& expected, size_t& numPoints) {
   std::vector<shulpin_i_Jarvis_seq::Point> result(expected.size());
 
   auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
@@ -94,7 +95,7 @@ void TestBody_Random_Circle(std::vector<shulpin_i_Jarvis_seq::Point>& input,
   }
 }
     
-}// namespace shulpin_i_Jarvis_seq
+}  // namespace shulpin_i_Jarvis_seq
 
 TEST(shulpin_i_Jarvis_seqq, square_with_point) {
   std::vector<shulpin_i_Jarvis_seq::Point> input = {{0, 0}, {2, 0}, {2, 2}, {0, 2}, {1, 1}};
@@ -156,7 +157,7 @@ TEST(shulpin_i_Jarvis_seqq, circle_r10_p100) {
   shulpin_i_Jarvis_seq::Point center{0, 0};
   double radius = 10.0;
   size_t numPoints = 100;
-  std::vector<shulpin_i_Jarvis_seq::Point> input = 
+  std::vector<shulpin_i_Jarvis_seq::Point> input =
       shulpin_i_Jarvis_seq::generatePointsInCircle(center, radius, numPoints);
   std::vector<shulpin_i_Jarvis_seq::Point> expected = input;
 

--- a/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
@@ -1,0 +1,186 @@
+#include <gtest/gtest.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "core/util/include/util.hpp"
+#include "seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp"
+
+namespace shulpin_i_Jarvis_seq {
+std::vector<shulpin_i_Jarvis_seq::Point> generatePointsInCircle(const shulpin_i_Jarvis_seq::Point& center,
+                                                                double radius, uint32_t numPoints) {
+  std::vector<shulpin_i_Jarvis_seq::Point> points;
+
+  for (uint32_t i = 0; i < numPoints; ++i) {
+    double angle = 2.0 * M_PI * i / numPoints;
+    double x = center.x + radius * cos(angle);
+    double y = center.y + radius * sin(angle);
+    points.push_back({x, y});
+  }
+
+  return points;
+}
+
+void TestBody(std::vector<shulpin_i_Jarvis_seq::Point>& input, std::vector<shulpin_i_Jarvis_seq::Point>& expected) {
+  std::vector<shulpin_i_Jarvis_seq::Point> result(expected.size());
+
+  auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  taskDataSeq->inputs_count.emplace_back(static_cast<uint32_t>(input.size()));
+
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  taskDataSeq->outputs_count.emplace_back(static_cast<uint32_t>(result.size()));
+
+  shulpin_i_Jarvis_seq::JarvisSequential SeqTask(taskDataSeq);
+  ASSERT_EQ(SeqTask.Validation(), true);
+  SeqTask.PreProcessing();
+  SeqTask.Run();
+  SeqTask.PostProcessing();
+
+  for (size_t i = 0; i < result.size(); ++i) {
+    ASSERT_EQ(expected[i].x, result[i].x);
+    ASSERT_EQ(expected[i].y, result[i].y);
+  }
+}
+
+void TestBody_False(std::vector<shulpin_i_Jarvis_seq::Point>& input, std::vector<shulpin_i_Jarvis_seq::Point>& expected) {
+  std::vector<shulpin_i_Jarvis_seq::Point> result(expected.size());
+
+  auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  taskDataSeq->inputs_count.emplace_back(static_cast<uint32_t>(input.size()));
+
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(result.data()));
+  taskDataSeq->outputs_count.emplace_back(static_cast<uint32_t>(result.size()));
+
+  shulpin_i_Jarvis_seq::JarvisSequential SeqTask(taskDataSeq);
+  ASSERT_EQ(SeqTask.Validation(), false);
+}
+
+void TestBody_Random_Circle(std::vector<shulpin_i_Jarvis_seq::Point>& input,
+                    std::vector<shulpin_i_Jarvis_seq::Point>& expected, size_t& numPoints) {
+  std::vector<shulpin_i_Jarvis_seq::Point> result(expected.size());
+
+  auto taskDataSeq = std::make_shared<ppc::core::TaskData>();
+
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  taskDataSeq->inputs_count.emplace_back(static_cast<uint32_t>(input.size()));
+
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t*>(result.data()));
+  taskDataSeq->outputs_count.emplace_back(static_cast<uint32_t>(result.size()));
+
+  shulpin_i_Jarvis_seq::JarvisSequential SeqTask(taskDataSeq);
+  ASSERT_EQ(SeqTask.Validation(), true);
+  SeqTask.PreProcessing();
+  SeqTask.Run();
+  SeqTask.PostProcessing();
+
+  size_t tmp = numPoints >> 1;
+
+  for (size_t i = 0; i < result.size(); ++i) {
+    size_t idx = (i < tmp) ? (i + tmp) : (i - tmp);
+    EXPECT_EQ(expected[i].x, result[idx].x);
+    EXPECT_EQ(expected[i].y, result[idx].y);
+  }
+}
+    
+}// namespace shulpin_i_Jarvis_seq
+
+TEST(shulpin_i_Jarvis_seqq, square_with_point) {
+  std::vector<shulpin_i_Jarvis_seq::Point> input = {{0, 0}, {2, 0}, {2, 2}, {0, 2}, {1, 1}};
+  std::vector<shulpin_i_Jarvis_seq::Point> expected = {{0, 0}, {2, 0}, {2, 2}, {0, 2}};
+
+  shulpin_i_Jarvis_seq::TestBody(input, expected);
+}
+
+TEST(shulpin_i_Jarvis_seqq, triangle) {
+  std::vector<shulpin_i_Jarvis_seq::Point> input = {{0, 0}, {3, 0}, {1, 2}};
+  std::vector<shulpin_i_Jarvis_seq::Point> expected = {{0, 0}, {3, 0}, {1, 2}};
+
+  shulpin_i_Jarvis_seq::TestBody(input, expected);
+}
+
+TEST(shulpin_i_Jarvis_seqq, octagone) {
+  std::vector<shulpin_i_Jarvis_seq::Point> input = {{1, 0}, {2, 0}, {3, 1}, {3, 2}, {2, 3}, {1, 3}, {0, 2}, {0, 1}};
+  std::vector<shulpin_i_Jarvis_seq::Point> expected = {{0, 1}, {1, 0}, {2, 0}, {3, 1}, {3, 2}, {2, 3}, {1, 3}, {0, 2}};
+
+  shulpin_i_Jarvis_seq::TestBody(input, expected);
+}
+
+TEST(shulpin_i_Jarvis_seqq, repeated_points) {
+  std::vector<shulpin_i_Jarvis_seq::Point> input = {{0, 0}, {2, 0}, {2, 2}, {0, 2}, {2, 0}, {0, 0}};
+  std::vector<shulpin_i_Jarvis_seq::Point> expected = {{0, 0}, {2, 0}, {2, 2}, {0, 2}};
+
+  shulpin_i_Jarvis_seq::TestBody(input, expected);
+}
+
+TEST(shulpin_i_Jarvis_seqq, real_case) {
+  std::vector<shulpin_i_Jarvis_seq::Point> input = {{1, 1}, {3, 2}, {5, 1}, {4, 3}, {2, 4}, {1, 3}, {3, 3}};
+  std::vector<shulpin_i_Jarvis_seq::Point> expected = {{1, 1}, {5, 1}, {4, 3}, {2, 4}, {1, 3}};
+
+  shulpin_i_Jarvis_seq::TestBody(input, expected);
+}
+
+TEST(shulpin_i_Jarvis_seqq, one_point_validation_false) {
+  std::vector<shulpin_i_Jarvis_seq::Point> input = {{0, 0}};
+  std::vector<shulpin_i_Jarvis_seq::Point> expected = {{0, 0}};
+
+  shulpin_i_Jarvis_seq::TestBody_False(input, expected);
+}
+
+TEST(shulpin_i_Jarvis_seqq, three_points_validation_false) {
+  std::vector<shulpin_i_Jarvis_seq::Point> input = {{1, 1}, {2, 2}};
+  std::vector<shulpin_i_Jarvis_seq::Point> expected = {{1, 1}, {2, 2}};
+
+  shulpin_i_Jarvis_seq::TestBody_False(input, expected);
+}
+
+TEST(shulpin_i_Jarvis_seqq, zero_points_validation_false) {
+  std::vector<shulpin_i_Jarvis_seq::Point> input = {};
+  std::vector<shulpin_i_Jarvis_seq::Point> expected = {};
+
+  shulpin_i_Jarvis_seq::TestBody_False(input, expected);
+}
+
+TEST(shulpin_i_Jarvis_seqq, circle_r10_p100) {
+  shulpin_i_Jarvis_seq::Point center{0, 0};
+  double radius = 10.0;
+  size_t numPoints = 100;
+  std::vector<shulpin_i_Jarvis_seq::Point> input = 
+      shulpin_i_Jarvis_seq::generatePointsInCircle(center, radius, numPoints);
+  std::vector<shulpin_i_Jarvis_seq::Point> expected = input;
+
+  shulpin_i_Jarvis_seq::TestBody_Random_Circle(input, expected, numPoints);
+}
+
+TEST(shulpin_i_Jarvis_seqq, circle_r10_p1000) {
+  shulpin_i_Jarvis_seq::Point center{0, 0};
+  double radius = 10.0;
+  size_t numPoints = 1000;
+  std::vector<shulpin_i_Jarvis_seq::Point> input =
+      shulpin_i_Jarvis_seq::generatePointsInCircle(center, radius, numPoints);
+  std::vector<shulpin_i_Jarvis_seq::Point> expected = input;
+
+  shulpin_i_Jarvis_seq::TestBody_Random_Circle(input, expected, numPoints);
+}
+
+TEST(shulpin_i_Jarvis_seqq, circle_r10_p10000) {
+  shulpin_i_Jarvis_seq::Point center{0, 0};
+  double radius = 10.0;
+  size_t numPoints = 10000;
+  std::vector<shulpin_i_Jarvis_seq::Point> input =
+      shulpin_i_Jarvis_seq::generatePointsInCircle(center, radius, numPoints);
+  std::vector<shulpin_i_Jarvis_seq::Point> expected = input;
+
+  shulpin_i_Jarvis_seq::TestBody_Random_Circle(input, expected, numPoints);
+}

--- a/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
@@ -12,8 +12,8 @@
 
 namespace {
 std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(size_t num_points,
-                                                                       const shulpin_i_jarvis_seq::Point& center,
-                                                                       double radius) {
+                                                                const shulpin_i_jarvis_seq::Point& center,
+                                                                double radius) {
   std::vector<shulpin_i_jarvis_seq::Point> points;
   for (size_t i = 0; i < num_points; ++i) {
     double angle = 2.0 * std::numbers::pi * static_cast<double>(i) / static_cast<double>(num_points);

--- a/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
@@ -25,8 +25,7 @@ static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(const shu
   return points;
 }
 
-void TestBody(std::vector<shulpin_i_jarvis_seq::Point>& input,
-              std::vector<shulpin_i_jarvis_seq::Point>& expected) {
+void TestBody(std::vector<shulpin_i_jarvis_seq::Point>& input, std::vector<shulpin_i_jarvis_seq::Point>& expected) {
   std::vector<shulpin_i_jarvis_seq::Point> result(expected.size());
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();

--- a/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
@@ -23,9 +23,7 @@ std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(size_t num_point
   }
   return points;
 }
-}  // namespace
 
-namespace {
 void MainTestBody(std::vector<shulpin_i_jarvis_seq::Point>& input, std::vector<shulpin_i_jarvis_seq::Point>& expected) {
   std::vector<shulpin_i_jarvis_seq::Point> result(expected.size());
 
@@ -96,6 +94,13 @@ void TestBodyRandomCircle(std::vector<shulpin_i_jarvis_seq::Point>& input,
 TEST(shulpin_i_jarvis_seq, square_with_point) {
   std::vector<shulpin_i_jarvis_seq::Point> input = {{0, 0}, {2, 0}, {2, 2}, {0, 2}, {1, 1}};
   std::vector<shulpin_i_jarvis_seq::Point> expected = {{0, 0}, {2, 0}, {2, 2}, {0, 2}};
+
+  MainTestBody(input, expected);
+}
+
+TEST(shulpin_i_jarvis_seq, ox_line) {
+  std::vector<shulpin_i_jarvis_seq::Point> input = {{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}};
+  std::vector<shulpin_i_jarvis_seq::Point> expected = {{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}};
 
   MainTestBody(input, expected);
 }

--- a/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
@@ -11,13 +11,14 @@
 #include "seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp"
 
 namespace shulpin_i_jarvis_seq {
-static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(const shulpin_i_jarvis_seq::Point& center,
-                                                                       const CircleParams& params) {
+static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(size_t num_points,
+                                                                       const shulpin_i_jarvis_seq::Point& center,
+                                                                       double radius) {
   std::vector<shulpin_i_jarvis_seq::Point> points;
-  for (size_t i = 0; i < params.num_points; ++i) {
-    double angle = 2.0 * std::numbers::pi * static_cast<double>(i) / static_cast<double>(params.num_points);
-    double x = center.x + (params.radius * std::cos(angle));
-    double y = center.y + (params.radius * std::sin(angle));
+  for (size_t i = 0; i < num_points; ++i) {
+    double angle = 2.0 * std::numbers::pi * static_cast<double>(i) / static_cast<double>(num_points);
+    double x = center.x + (radius * std::cos(angle));
+    double y = center.y + (radius * std::sin(angle));
     points.emplace_back(x, y);
   }
   return points;
@@ -150,20 +151,26 @@ TEST(shulpin_i_jarvis_seq, zero_points_validation_false) {
 
 TEST(shulpin_i_jarvis_seq, circle_r10_p100) {
   shulpin_i_jarvis_seq::Point center{0, 0};
-  shulpin_i_jarvis_seq::CircleParams params{10.0, 100};
 
-  std::vector<shulpin_i_jarvis_seq::Point> input = shulpin_i_jarvis_seq::GeneratePointsInCircle(center, params);
+  double radius = 10.0;
+  size_t num_points = 100;
+
+  std::vector<shulpin_i_jarvis_seq::Point> input =
+      shulpin_i_jarvis_seq::GeneratePointsInCircle(num_points, center, radius);
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;
 
-  TestBodyRandomCircle(input, expected, params.num_points);
+  TestBodyRandomCircle(input, expected, num_points);
 }
 
 TEST(shulpin_i_jarvis_seq, circle_r10_p1000) {
   shulpin_i_jarvis_seq::Point center{0, 0};
-  shulpin_i_jarvis_seq::CircleParams params{10.0, 1000};
 
-  std::vector<shulpin_i_jarvis_seq::Point> input = shulpin_i_jarvis_seq::GeneratePointsInCircle(center, params);
+  double radius = 10.0;
+  size_t num_points = 1000;
+
+  std::vector<shulpin_i_jarvis_seq::Point> input =
+      shulpin_i_jarvis_seq::GeneratePointsInCircle(num_points, center, radius);
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;
 
-  TestBodyRandomCircle(input, expected, params.num_points);
+  TestBodyRandomCircle(input, expected, num_points);
 }

--- a/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/func_tests/main.cpp
@@ -11,7 +11,7 @@
 #include "seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp"
 
 namespace {
-static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(size_t num_points,
+std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(size_t num_points,
                                                                        const shulpin_i_jarvis_seq::Point& center,
                                                                        double radius) {
   std::vector<shulpin_i_jarvis_seq::Point> points;

--- a/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
@@ -32,7 +32,7 @@ class JarvisSequential : public ppc::core::Task {
   bool PostProcessingImpl() override;
   static int Orientation(const Point& p, const Point& q, const Point& r);
   static void MakeJarvisPassage(std::vector<shulpin_i_jarvis_seq::Point>& input,
-                         std::vector<shulpin_i_jarvis_seq::Point>& output);
+                                std::vector<shulpin_i_jarvis_seq::Point>& output);
 
  private:
   std::vector<shulpin_i_jarvis_seq::Point> input_, output_;

--- a/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
@@ -10,7 +10,7 @@ namespace shulpin_i_jarvis_seq {
 struct Point {
   double x, y;
   Point() : x(0), y(0) {}
-  Point(double xCoordinate, double yCoordinate) : x(xCoordinate), y(yCoordinate) {}
+  Point(double x_coordinate, double y_coordinate) : x(x_coordinate), y(y_coordinate) {}
 };
 
 class JarvisSequential : public ppc::core::Task {
@@ -20,9 +20,9 @@ class JarvisSequential : public ppc::core::Task {
   bool ValidationImpl() override;
   bool RunImpl() override;
   bool PostProcessingImpl() override;
-  int Orientation(const Point& p, const Point& q, const Point& r);
-  void MakeJarvisPassage(std::vector<shulpin_i_jarvis_seq::Point>& input_,
-                         std::vector<shulpin_i_jarvis_seq::Point>& output_);
+  static int Orientation(const Point& p, const Point& q, const Point& r);
+  void MakeJarvisPassage(std::vector<shulpin_i_jarvis_seq::Point>& input,
+                         std::vector<shulpin_i_jarvis_seq::Point>& output);
 
  private:
   std::vector<shulpin_i_jarvis_seq::Point> input_, output_;

--- a/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
@@ -5,8 +5,6 @@
 
 #include "core/task/include/task.hpp"
 
-using NumPoint = size_t;
-
 namespace shulpin_i_jarvis_seq {
 
 struct Point {

--- a/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
@@ -23,7 +23,6 @@ class JarvisSequential : public ppc::core::Task {
   int Orientation(const Point& p, const Point& q, const Point& r);
   void MakeJarvisPassage(std::vector<shulpin_i_jarvis_seq::Point>& input_,
                          std::vector<shulpin_i_jarvis_seq::Point>& output_);
-  /*bool comparePoints(const shulpin_i_jarvis_seq::Point& a, const shulpin_i_jarvis_seq::Point& b);*/
 
  private:
   std::vector<shulpin_i_jarvis_seq::Point> input_, output_;

--- a/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace shulpin_i_Jarvis_seq {
+
+struct Point {
+  double x, y;
+  Point() : x(0), y(0) {}
+  Point(double x, double y) : x(x), y(y) {}
+};
+
+class JarvisSequential : public ppc::core::Task {
+ public:
+  explicit JarvisSequential(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+  int orientation(const Point& p, const Point& q, const Point& r);
+  void makeJarvisPassage(std::vector<shulpin_i_Jarvis_seq::Point>& input, std::vector<shulpin_i_Jarvis_seq::Point>& output);
+ private:
+  std::vector<shulpin_i_Jarvis_seq::Point> input, output;
+};
+
+}  // namespace shulpin_i_Jarvis_seq

--- a/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
@@ -13,6 +13,16 @@ struct Point {
   Point(double x_coordinate, double y_coordinate) : x(x_coordinate), y(y_coordinate) {}
 };
 
+struct CircleParams {
+  double radius;
+  size_t num_points;
+
+  CircleParams() : radius(0), num_points(0) {}
+  CircleParams(double new_radius, size_t new_num_points) : radius(new_radius), num_points(new_num_points) {}
+};
+
+void TestBody(std::vector<shulpin_i_jarvis_seq::Point>& input, std::vector<shulpin_i_jarvis_seq::Point>& expected);
+
 class JarvisSequential : public ppc::core::Task {
  public:
   explicit JarvisSequential(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
@@ -21,7 +31,7 @@ class JarvisSequential : public ppc::core::Task {
   bool RunImpl() override;
   bool PostProcessingImpl() override;
   static int Orientation(const Point& p, const Point& q, const Point& r);
-  void MakeJarvisPassage(std::vector<shulpin_i_jarvis_seq::Point>& input,
+  static void MakeJarvisPassage(std::vector<shulpin_i_jarvis_seq::Point>& input,
                          std::vector<shulpin_i_jarvis_seq::Point>& output);
 
  private:

--- a/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cstddef>
 #include <utility>
 #include <vector>
 
@@ -14,14 +13,6 @@ struct Point {
   double x, y;
   Point() : x(0), y(0) {}
   Point(double x_coordinate, double y_coordinate) : x(x_coordinate), y(y_coordinate) {}
-};
-
-struct CircleParams {
-  double radius;
-  NumPoint num_points;
-
-  CircleParams() : radius(0), num_points(0) {}
-  CircleParams(double new_radius, NumPoint new_num_points) : radius(new_radius), num_points(new_num_points) {}
 };
 
 class JarvisSequential : public ppc::core::Task {

--- a/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
@@ -24,7 +24,7 @@ class JarvisSequential : public ppc::core::Task {
   void makeJarvisPassage(std::vector<shulpin_i_Jarvis_seq::Point>& input,
                          std::vector<shulpin_i_Jarvis_seq::Point>& output);
  
-private:
+ private:
   std::vector<shulpin_i_Jarvis_seq::Point> input, output;
 };
 

--- a/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
@@ -21,7 +21,8 @@ class JarvisSequential : public ppc::core::Task {
   bool RunImpl() override;
   bool PostProcessingImpl() override;
   int orientation(const Point& p, const Point& q, const Point& r);
-  void makeJarvisPassage(std::vector<shulpin_i_Jarvis_seq::Point>& input, std::vector<shulpin_i_Jarvis_seq::Point>& output);
+  void makeJarvisPassage(std::vector<shulpin_i_Jarvis_seq::Point>& input,
+                         std::vector<shulpin_i_Jarvis_seq::Point>& output);
  private:
   std::vector<shulpin_i_Jarvis_seq::Point> input, output;
 };

--- a/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <cstddef>
 #include <utility>
 #include <vector>
 
 #include "core/task/include/task.hpp"
+
+using NumPoint = size_t;
 
 namespace shulpin_i_jarvis_seq {
 
@@ -15,13 +18,11 @@ struct Point {
 
 struct CircleParams {
   double radius;
-  size_t num_points;
+  NumPoint num_points;
 
   CircleParams() : radius(0), num_points(0) {}
-  CircleParams(double new_radius, size_t new_num_points) : radius(new_radius), num_points(new_num_points) {}
+  CircleParams(double new_radius, NumPoint new_num_points) : radius(new_radius), num_points(new_num_points) {}
 };
-
-void TestBody(std::vector<shulpin_i_jarvis_seq::Point>& input, std::vector<shulpin_i_jarvis_seq::Point>& expected);
 
 class JarvisSequential : public ppc::core::Task {
  public:

--- a/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
@@ -23,7 +23,7 @@ class JarvisSequential : public ppc::core::Task {
   int orientation(const Point& p, const Point& q, const Point& r);
   void makeJarvisPassage(std::vector<shulpin_i_Jarvis_seq::Point>& input,
                          std::vector<shulpin_i_Jarvis_seq::Point>& output);
- 
+
  private:
   std::vector<shulpin_i_Jarvis_seq::Point> input, output;
 };

--- a/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
@@ -23,7 +23,8 @@ class JarvisSequential : public ppc::core::Task {
   int orientation(const Point& p, const Point& q, const Point& r);
   void makeJarvisPassage(std::vector<shulpin_i_Jarvis_seq::Point>& input,
                          std::vector<shulpin_i_Jarvis_seq::Point>& output);
- private:
+ 
+private:
   std::vector<shulpin_i_Jarvis_seq::Point> input, output;
 };
 

--- a/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp
@@ -5,12 +5,12 @@
 
 #include "core/task/include/task.hpp"
 
-namespace shulpin_i_Jarvis_seq {
+namespace shulpin_i_jarvis_seq {
 
 struct Point {
   double x, y;
   Point() : x(0), y(0) {}
-  Point(double x, double y) : x(x), y(y) {}
+  Point(double xCoordinate, double yCoordinate) : x(xCoordinate), y(yCoordinate) {}
 };
 
 class JarvisSequential : public ppc::core::Task {
@@ -20,12 +20,13 @@ class JarvisSequential : public ppc::core::Task {
   bool ValidationImpl() override;
   bool RunImpl() override;
   bool PostProcessingImpl() override;
-  int orientation(const Point& p, const Point& q, const Point& r);
-  void makeJarvisPassage(std::vector<shulpin_i_Jarvis_seq::Point>& input,
-                         std::vector<shulpin_i_Jarvis_seq::Point>& output);
+  int Orientation(const Point& p, const Point& q, const Point& r);
+  void MakeJarvisPassage(std::vector<shulpin_i_jarvis_seq::Point>& input_,
+                         std::vector<shulpin_i_jarvis_seq::Point>& output_);
+  /*bool comparePoints(const shulpin_i_jarvis_seq::Point& a, const shulpin_i_jarvis_seq::Point& b);*/
 
  private:
-  std::vector<shulpin_i_Jarvis_seq::Point> input, output;
+  std::vector<shulpin_i_jarvis_seq::Point> input_, output_;
 };
 
-}  // namespace shulpin_i_Jarvis_seq
+}  // namespace shulpin_i_jarvis_seq

--- a/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
@@ -42,9 +42,9 @@ TEST(shulpin_i_Jarvis_seq, test_pipeline_run) {
   std::vector<shulpin_i_Jarvis_seq::Point> expected = input;
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
-  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
   task_data_seq->inputs_count.emplace_back(input.size());
-  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_seq->outputs_count.emplace_back(out.size());
 
   auto test_task_sequential = std::make_shared<shulpin_i_Jarvis_seq::JarvisSequential>(task_data_seq);

--- a/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
@@ -34,7 +34,7 @@ TEST(shulpin_i_jarvis_seq, test_pipeline_run) {
   size_t num_points = 10000;
 
   std::vector<shulpin_i_jarvis_seq::Point> input =
-      shulpin_i_jarvis_seq::GeneratePointsInCircle(center,num_points, radius);
+      shulpin_i_jarvis_seq::GeneratePointsInCircle(center, num_points, radius);
 
   std::vector<shulpin_i_jarvis_seq::Point> out(input.size());
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;

--- a/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
@@ -13,13 +13,14 @@
 #include "seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp"
 
 namespace shulpin_i_jarvis_seq {
-static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(const shulpin_i_jarvis_seq::Point &center,
-                                                                       const CircleParams &params) {
+static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(size_t num_points,
+                                                                       const shulpin_i_jarvis_seq::Point &center,
+                                                                       double radius) {
   std::vector<shulpin_i_jarvis_seq::Point> points;
-  for (size_t i = 0; i < params.num_points; ++i) {
-    double angle = 2.0 * std::numbers::pi * static_cast<double>(i) / static_cast<double>(params.num_points);
-    double x = center.x + (params.radius * std::cos(angle));
-    double y = center.y + (params.radius * std::sin(angle));
+  for (size_t i = 0; i < num_points; ++i) {
+    double angle = 2.0 * std::numbers::pi * static_cast<double>(i) / static_cast<double>(num_points);
+    double x = center.x + (radius * std::cos(angle));
+    double y = center.y + (radius * std::sin(angle));
     points.emplace_back(x, y);
   }
   return points;
@@ -28,9 +29,10 @@ static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(const shu
 
 TEST(shulpin_i_jarvis_seq, test_pipeline_run) {
   shulpin_i_jarvis_seq::Point center{0, 0};
-  shulpin_i_jarvis_seq::CircleParams params{10.0, 10000};
-
-  std::vector<shulpin_i_jarvis_seq::Point> input = shulpin_i_jarvis_seq::GeneratePointsInCircle(center, params);
+  double radius = 10.0;
+  size_t num_points = 10000;
+  std::vector<shulpin_i_jarvis_seq::Point> input =
+      shulpin_i_jarvis_seq::GeneratePointsInCircle(num_points, center, radius);
 
   std::vector<shulpin_i_jarvis_seq::Point> out(input.size());
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;
@@ -58,7 +60,7 @@ TEST(shulpin_i_jarvis_seq, test_pipeline_run) {
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
-  size_t tmp = params.num_points >> 1;
+  size_t tmp = num_points >> 1;
 
   for (size_t i = 0; i < out.size(); ++i) {
     size_t idx = (i < tmp) ? (i + tmp) : (i - tmp);
@@ -69,9 +71,11 @@ TEST(shulpin_i_jarvis_seq, test_pipeline_run) {
 
 TEST(shulpin_i_jarvis_seq, test_task_run) {
   shulpin_i_jarvis_seq::Point center{0, 0};
-  shulpin_i_jarvis_seq::CircleParams params{10.0, 10000};
+  double radius = 10.0;
+  size_t num_points = 10000;
 
-  std::vector<shulpin_i_jarvis_seq::Point> input = shulpin_i_jarvis_seq::GeneratePointsInCircle(center, params);
+  std::vector<shulpin_i_jarvis_seq::Point> input =
+      shulpin_i_jarvis_seq::GeneratePointsInCircle(num_points, center, radius);
 
   std::vector<shulpin_i_jarvis_seq::Point> out(input.size());
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;
@@ -99,7 +103,7 @@ TEST(shulpin_i_jarvis_seq, test_task_run) {
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
-  size_t tmp = params.num_points >> 1;
+  size_t tmp = num_points >> 1;
 
   for (size_t i = 0; i < out.size(); ++i) {
     size_t idx = (i < tmp) ? (i + tmp) : (i - tmp);

--- a/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
@@ -4,8 +4,8 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <vector>
 #include <numbers>
+#include <vector>
 
 #include "core/perf/include/perf.hpp"
 #include "core/task/include/task.hpp"
@@ -25,7 +25,7 @@ static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(const shu
 
   return points;
 }
-}  // namespace shulpin_i_Jarvis_seq
+}  // namespace shulpin_i_jarvis_seq
 
 TEST(shulpin_i_jarvis_seq, test_pipeline_run) {
   shulpin_i_jarvis_seq::Point center{0, 0};

--- a/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
@@ -23,7 +23,7 @@ std::vector<shulpin_i_Jarvis_seq::Point> generatePointsInCircle(const shulpin_i_
     double angle = 2.0 * M_PI * i / numPoints;
     double x = center.x + radius * cos(angle);
     double y = center.y + radius * sin(angle);
-    points.push_back({x,y});
+    points.push_back({x, y});
   }
 
   return points;
@@ -42,9 +42,9 @@ TEST(shulpin_i_Jarvis_seq, test_pipeline_run) {
   std::vector<shulpin_i_Jarvis_seq::Point> expected = input;
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
-  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
   task_data_seq->inputs_count.emplace_back(input.size());
-  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
   task_data_seq->outputs_count.emplace_back(out.size());
 
   auto test_task_sequential = std::make_shared<shulpin_i_Jarvis_seq::JarvisSequential>(task_data_seq);

--- a/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
@@ -14,27 +14,24 @@
 
 namespace shulpin_i_jarvis_seq {
 static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(const shulpin_i_jarvis_seq::Point &center,
-                                                                       size_t num_points, double radius) {
+                                                                       const CircleParams &params) {
   std::vector<shulpin_i_jarvis_seq::Point> points;
-
-  for (size_t i = 0; i < num_points; ++i) {
-    double angle = 2.0 * std::numbers::pi * static_cast<double>(i) / static_cast<double>(num_points);
-    double x = center.x + (radius * std::cos(angle));
-    double y = center.y + (radius * std::sin(angle));
+  for (size_t i = 0; i < params.num_points; ++i) {
+    double angle = 2.0 * std::numbers::pi * static_cast<double>(i) / static_cast<double>(params.num_points);
+    double x = center.x + (params.radius * std::cos(angle));
+    double y = center.y + (params.radius * std::sin(angle));
     points.emplace_back(x, y);
   }
-
   return points;
 }
 }  // namespace shulpin_i_jarvis_seq
 
 TEST(shulpin_i_jarvis_seq, test_pipeline_run) {
   shulpin_i_jarvis_seq::Point center{0, 0};
-  double radius = 10.0;
-  size_t num_points = 10000;
+  shulpin_i_jarvis_seq::CircleParams params{10.0, 10000};
 
   std::vector<shulpin_i_jarvis_seq::Point> input =
-      shulpin_i_jarvis_seq::GeneratePointsInCircle(center, num_points, radius);
+      shulpin_i_jarvis_seq::GeneratePointsInCircle(center, params);
 
   std::vector<shulpin_i_jarvis_seq::Point> out(input.size());
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;
@@ -62,7 +59,7 @@ TEST(shulpin_i_jarvis_seq, test_pipeline_run) {
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
-  size_t tmp = num_points >> 1;
+  size_t tmp = params.num_points >> 1;
 
   for (size_t i = 0; i < out.size(); ++i) {
     size_t idx = (i < tmp) ? (i + tmp) : (i - tmp);
@@ -73,11 +70,9 @@ TEST(shulpin_i_jarvis_seq, test_pipeline_run) {
 
 TEST(shulpin_i_jarvis_seq, test_task_run) {
   shulpin_i_jarvis_seq::Point center{0, 0};
-  double radius = 10.0;
-  size_t num_points = 10000;
+  shulpin_i_jarvis_seq::CircleParams params{10.0, 10000};
 
-  std::vector<shulpin_i_jarvis_seq::Point> input =
-      shulpin_i_jarvis_seq::GeneratePointsInCircle(center, num_points, radius);
+  std::vector<shulpin_i_jarvis_seq::Point> input = shulpin_i_jarvis_seq::GeneratePointsInCircle(center, params);
 
   std::vector<shulpin_i_jarvis_seq::Point> out(input.size());
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;
@@ -105,7 +100,7 @@ TEST(shulpin_i_jarvis_seq, test_task_run) {
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
-  size_t tmp = num_points >> 1;
+  size_t tmp = params.num_points >> 1;
 
   for (size_t i = 0; i < out.size(); ++i) {
     size_t idx = (i < tmp) ? (i + tmp) : (i - tmp);

--- a/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
@@ -30,8 +30,7 @@ TEST(shulpin_i_jarvis_seq, test_pipeline_run) {
   shulpin_i_jarvis_seq::Point center{0, 0};
   shulpin_i_jarvis_seq::CircleParams params{10.0, 10000};
 
-  std::vector<shulpin_i_jarvis_seq::Point> input =
-      shulpin_i_jarvis_seq::GeneratePointsInCircle(center, params);
+  std::vector<shulpin_i_jarvis_seq::Point> input = shulpin_i_jarvis_seq::GeneratePointsInCircle(center, params);
 
   std::vector<shulpin_i_jarvis_seq::Point> out(input.size());
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;

--- a/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
@@ -14,8 +14,8 @@
 
 namespace {
 std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(size_t num_points,
-                                                                       const shulpin_i_jarvis_seq::Point &center,
-                                                                       double radius) {
+                                                                const shulpin_i_jarvis_seq::Point &center,
+                                                                double radius) {
   std::vector<shulpin_i_jarvis_seq::Point> points;
   for (size_t i = 0; i < num_points; ++i) {
     double angle = 2.0 * std::numbers::pi * static_cast<double>(i) / static_cast<double>(num_points);

--- a/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
@@ -1,0 +1,117 @@
+#include <gtest/gtest.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp"
+
+namespace shulpin_i_Jarvis_seq {
+std::vector<shulpin_i_Jarvis_seq::Point> generatePointsInCircle(const shulpin_i_Jarvis_seq::Point &center,
+                                                                double radius, size_t numPoints) {
+  std::vector<shulpin_i_Jarvis_seq::Point> points;
+
+  for (size_t i = 0; i < numPoints; ++i) {
+    double angle = 2.0 * M_PI * i / numPoints;
+    double x = center.x + radius * cos(angle);
+    double y = center.y + radius * sin(angle);
+    points.push_back({x,y});
+  }
+
+  return points;
+}
+}  // namespace shulpin_i_Jarvis_seq
+
+TEST(shulpin_i_Jarvis_seq, test_pipeline_run) {
+  shulpin_i_Jarvis_seq::Point center{0, 0};
+  double radius = 10.0;
+  size_t numPoints = 10000;
+
+  std::vector<shulpin_i_Jarvis_seq::Point> input =
+      shulpin_i_Jarvis_seq::generatePointsInCircle(center, radius, numPoints);
+
+  std::vector<shulpin_i_Jarvis_seq::Point> out(input.size());
+  std::vector<shulpin_i_Jarvis_seq::Point> expected = input;
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_seq->inputs_count.emplace_back(input.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  auto test_task_sequential = std::make_shared<shulpin_i_Jarvis_seq::JarvisSequential>(task_data_seq);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  size_t tmp = numPoints >> 1;
+
+  for (size_t i = 0; i < out.size(); ++i) {
+    size_t idx = (i < tmp) ? (i + tmp) : (i - tmp);
+    EXPECT_EQ(expected[i].x, out[idx].x);
+    EXPECT_EQ(expected[i].y, out[idx].y);
+  }
+}
+
+TEST(shulpin_i_Jarvis_seq, test_task_run) {
+  shulpin_i_Jarvis_seq::Point center{0, 0};
+  double radius = 10.0;
+  size_t numPoints = 10000;
+
+  std::vector<shulpin_i_Jarvis_seq::Point> input =
+      shulpin_i_Jarvis_seq::generatePointsInCircle(center, radius, numPoints);
+
+  std::vector<shulpin_i_Jarvis_seq::Point> out(input.size());
+  std::vector<shulpin_i_Jarvis_seq::Point> expected = input;
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_seq->inputs_count.emplace_back(input.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  auto test_task_sequential = std::make_shared<shulpin_i_Jarvis_seq::JarvisSequential>(task_data_seq);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  size_t tmp = numPoints >> 1;
+
+  for (size_t i = 0; i < out.size(); ++i) {
+    size_t idx = (i < tmp) ? (i + tmp) : (i - tmp);
+    EXPECT_EQ(expected[i].x, out[idx].x);
+    EXPECT_EQ(expected[i].y, out[idx].y);
+  }
+}

--- a/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -13,11 +14,11 @@
 
 namespace shulpin_i_jarvis_seq {
 static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(const shulpin_i_jarvis_seq::Point &center,
-                                                                       double radius, size_t num_points) {
+                                                                       size_t num_points, double radius) {
   std::vector<shulpin_i_jarvis_seq::Point> points;
 
   for (size_t i = 0; i < num_points; ++i) {
-    double angle = 2.0 * std::numbers::pi * i / num_points;
+    double angle = 2.0 * std::numbers::pi * static_cast<double>(i) / static_cast<double>(num_points);
     double x = center.x + (radius * std::cos(angle));
     double y = center.y + (radius * std::sin(angle));
     points.emplace_back(x, y);
@@ -33,7 +34,7 @@ TEST(shulpin_i_jarvis_seq, test_pipeline_run) {
   size_t num_points = 10000;
 
   std::vector<shulpin_i_jarvis_seq::Point> input =
-      shulpin_i_jarvis_seq::GeneratePointsInCircle(center, radius, num_points);
+      shulpin_i_jarvis_seq::GeneratePointsInCircle(center,num_points, radius);
 
   std::vector<shulpin_i_jarvis_seq::Point> out(input.size());
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;
@@ -76,7 +77,7 @@ TEST(shulpin_i_jarvis_seq, test_task_run) {
   size_t num_points = 10000;
 
   std::vector<shulpin_i_jarvis_seq::Point> input =
-      shulpin_i_jarvis_seq::GeneratePointsInCircle(center, radius, num_points);
+      shulpin_i_jarvis_seq::GeneratePointsInCircle(center, num_points, radius);
 
   std::vector<shulpin_i_jarvis_seq::Point> out(input.size());
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;

--- a/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
@@ -1,45 +1,42 @@
 #include <gtest/gtest.h>
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <vector>
+#include <numbers>
 
 #include "core/perf/include/perf.hpp"
 #include "core/task/include/task.hpp"
 #include "seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp"
 
-namespace shulpin_i_Jarvis_seq {
-std::vector<shulpin_i_Jarvis_seq::Point> generatePointsInCircle(const shulpin_i_Jarvis_seq::Point &center,
-                                                                double radius, size_t numPoints) {
-  std::vector<shulpin_i_Jarvis_seq::Point> points;
+namespace shulpin_i_jarvis_seq {
+static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(const shulpin_i_jarvis_seq::Point &center,
+                                                                       double radius, size_t num_points) {
+  std::vector<shulpin_i_jarvis_seq::Point> points;
 
-  for (size_t i = 0; i < numPoints; ++i) {
-    double angle = 2.0 * M_PI * i / numPoints;
-    double x = center.x + radius * cos(angle);
-    double y = center.y + radius * sin(angle);
-    points.push_back({x, y});
+  for (size_t i = 0; i < num_points; ++i) {
+    double angle = 2.0 * std::numbers::pi * i / num_points;
+    double x = center.x + (radius * std::cos(angle));
+    double y = center.y + (radius * std::sin(angle));
+    points.emplace_back(x, y);
   }
 
   return points;
 }
 }  // namespace shulpin_i_Jarvis_seq
 
-TEST(shulpin_i_Jarvis_seq, test_pipeline_run) {
-  shulpin_i_Jarvis_seq::Point center{0, 0};
+TEST(shulpin_i_jarvis_seq, test_pipeline_run) {
+  shulpin_i_jarvis_seq::Point center{0, 0};
   double radius = 10.0;
-  size_t numPoints = 10000;
+  size_t num_points = 10000;
 
-  std::vector<shulpin_i_Jarvis_seq::Point> input =
-      shulpin_i_Jarvis_seq::generatePointsInCircle(center, radius, numPoints);
+  std::vector<shulpin_i_jarvis_seq::Point> input =
+      shulpin_i_jarvis_seq::GeneratePointsInCircle(center, radius, num_points);
 
-  std::vector<shulpin_i_Jarvis_seq::Point> out(input.size());
-  std::vector<shulpin_i_Jarvis_seq::Point> expected = input;
+  std::vector<shulpin_i_jarvis_seq::Point> out(input.size());
+  std::vector<shulpin_i_jarvis_seq::Point> expected = input;
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
@@ -47,7 +44,7 @@ TEST(shulpin_i_Jarvis_seq, test_pipeline_run) {
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_seq->outputs_count.emplace_back(out.size());
 
-  auto test_task_sequential = std::make_shared<shulpin_i_Jarvis_seq::JarvisSequential>(task_data_seq);
+  auto test_task_sequential = std::make_shared<shulpin_i_jarvis_seq::JarvisSequential>(task_data_seq);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;
@@ -64,7 +61,7 @@ TEST(shulpin_i_Jarvis_seq, test_pipeline_run) {
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
-  size_t tmp = numPoints >> 1;
+  size_t tmp = num_points >> 1;
 
   for (size_t i = 0; i < out.size(); ++i) {
     size_t idx = (i < tmp) ? (i + tmp) : (i - tmp);
@@ -73,16 +70,16 @@ TEST(shulpin_i_Jarvis_seq, test_pipeline_run) {
   }
 }
 
-TEST(shulpin_i_Jarvis_seq, test_task_run) {
-  shulpin_i_Jarvis_seq::Point center{0, 0};
+TEST(shulpin_i_jarvis_seq, test_task_run) {
+  shulpin_i_jarvis_seq::Point center{0, 0};
   double radius = 10.0;
-  size_t numPoints = 10000;
+  size_t num_points = 10000;
 
-  std::vector<shulpin_i_Jarvis_seq::Point> input =
-      shulpin_i_Jarvis_seq::generatePointsInCircle(center, radius, numPoints);
+  std::vector<shulpin_i_jarvis_seq::Point> input =
+      shulpin_i_jarvis_seq::GeneratePointsInCircle(center, radius, num_points);
 
-  std::vector<shulpin_i_Jarvis_seq::Point> out(input.size());
-  std::vector<shulpin_i_Jarvis_seq::Point> expected = input;
+  std::vector<shulpin_i_jarvis_seq::Point> out(input.size());
+  std::vector<shulpin_i_jarvis_seq::Point> expected = input;
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
@@ -90,7 +87,7 @@ TEST(shulpin_i_Jarvis_seq, test_task_run) {
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_seq->outputs_count.emplace_back(out.size());
 
-  auto test_task_sequential = std::make_shared<shulpin_i_Jarvis_seq::JarvisSequential>(task_data_seq);
+  auto test_task_sequential = std::make_shared<shulpin_i_jarvis_seq::JarvisSequential>(task_data_seq);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;
@@ -107,7 +104,7 @@ TEST(shulpin_i_Jarvis_seq, test_task_run) {
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
-  size_t tmp = numPoints >> 1;
+  size_t tmp = num_points >> 1;
 
   for (size_t i = 0; i < out.size(); ++i) {
     size_t idx = (i < tmp) ? (i + tmp) : (i - tmp);

--- a/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
@@ -12,7 +12,7 @@
 #include "core/task/include/task.hpp"
 #include "seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp"
 
-namespace shulpin_i_jarvis_seq {
+namespace {
 static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(size_t num_points,
                                                                        const shulpin_i_jarvis_seq::Point &center,
                                                                        double radius) {
@@ -25,14 +25,13 @@ static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(size_t nu
   }
   return points;
 }
-}  // namespace shulpin_i_jarvis_seq
+}  // namespace
 
 TEST(shulpin_i_jarvis_seq, test_pipeline_run) {
   shulpin_i_jarvis_seq::Point center{0, 0};
   double radius = 10.0;
   size_t num_points = 10000;
-  std::vector<shulpin_i_jarvis_seq::Point> input =
-      shulpin_i_jarvis_seq::GeneratePointsInCircle(num_points, center, radius);
+  std::vector<shulpin_i_jarvis_seq::Point> input = GeneratePointsInCircle(num_points, center, radius);
 
   std::vector<shulpin_i_jarvis_seq::Point> out(input.size());
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;
@@ -74,8 +73,7 @@ TEST(shulpin_i_jarvis_seq, test_task_run) {
   double radius = 10.0;
   size_t num_points = 10000;
 
-  std::vector<shulpin_i_jarvis_seq::Point> input =
-      shulpin_i_jarvis_seq::GeneratePointsInCircle(num_points, center, radius);
+  std::vector<shulpin_i_jarvis_seq::Point> input = GeneratePointsInCircle(num_points, center, radius);
 
   std::vector<shulpin_i_jarvis_seq::Point> out(input.size());
   std::vector<shulpin_i_jarvis_seq::Point> expected = input;

--- a/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/perf_tests/main.cpp
@@ -13,7 +13,7 @@
 #include "seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp"
 
 namespace {
-static std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(size_t num_points,
+std::vector<shulpin_i_jarvis_seq::Point> GeneratePointsInCircle(size_t num_points,
                                                                        const shulpin_i_jarvis_seq::Point &center,
                                                                        double radius) {
   std::vector<shulpin_i_jarvis_seq::Point> points;

--- a/tasks/seq/shulpin_i_Jarvis_passage/src/ops_seq.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/src/ops_seq.cpp
@@ -1,7 +1,7 @@
 #include "seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp"
 
-#include <cmath>
 #include <algorithm>
+#include <cmath>
 #include <vector>
 
 int shulpin_i_jarvis_seq::JarvisSequential::Orientation(const Point& p, const Point& q, const Point& r) {

--- a/tasks/seq/shulpin_i_Jarvis_passage/src/ops_seq.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/src/ops_seq.cpp
@@ -30,7 +30,7 @@ void shulpin_i_jarvis_seq::JarvisSequential::MakeJarvisPassage(std::vector<shulp
   size_t active = start;
   do {
     output_jar.emplace_back(input_jar[active]);
-    int candidate = (active + 1) % total;
+    size_t candidate = (active + 1) % total;
 
     for (size_t index = 0; index < total; ++index) {
       if (Orientation(input_jar[active], input_jar[index], input_jar[candidate]) == 2) {

--- a/tasks/seq/shulpin_i_Jarvis_passage/src/ops_seq.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/src/ops_seq.cpp
@@ -16,7 +16,6 @@ int shulpin_i_jarvis_seq::JarvisSequential::Orientation(const Point& p, const Po
 void shulpin_i_jarvis_seq::JarvisSequential::MakeJarvisPassage(std::vector<shulpin_i_jarvis_seq::Point>& input_jar,
                                                                std::vector<shulpin_i_jarvis_seq::Point>& output_jar) {
   size_t total = input_jar.size();
-  std::vector<bool> used(total, false);
   output_jar.clear();
 
   size_t start = 0;
@@ -68,6 +67,7 @@ bool shulpin_i_jarvis_seq::JarvisSequential::RunImpl() {
 
 bool shulpin_i_jarvis_seq::JarvisSequential::PostProcessingImpl() {
   int* result = reinterpret_cast<int*>(task_data->outputs[0]);
-  std::copy(reinterpret_cast<int*>(output_.data()), reinterpret_cast<int*>(output_.data() + output_.size()), result);
+  std::ranges::copy(reinterpret_cast<int*>(output_.data()), reinterpret_cast<int*>(output_.data() + output_.size()),
+                    result);
   return true;
 }

--- a/tasks/seq/shulpin_i_Jarvis_passage/src/ops_seq.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/src/ops_seq.cpp
@@ -19,7 +19,7 @@ void shulpin_i_jarvis_seq::JarvisSequential::MakeJarvisPassage(std::vector<shulp
   std::vector<bool> used(total, false);
   output_jar.clear();
 
-  int start = 0;
+  size_t start = 0;
   for (size_t i = 1; i < total; ++i) {
     if (input_jar[i].x < input_jar[start].x ||
         (input_jar[i].x == input_jar[start].x && input_jar[i].y < input_jar[start].y)) {
@@ -27,7 +27,7 @@ void shulpin_i_jarvis_seq::JarvisSequential::MakeJarvisPassage(std::vector<shulp
     }
   }
 
-  int active = start;
+  size_t active = start;
   do {
     output_jar.emplace_back(input_jar[active]);
     int candidate = (active + 1) % total;

--- a/tasks/seq/shulpin_i_Jarvis_passage/src/ops_seq.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/src/ops_seq.cpp
@@ -40,7 +40,7 @@ void shulpin_i_Jarvis_seq::JarvisSequential::makeJarvisPassage(std::vector<shulp
 
 bool shulpin_i_Jarvis_seq::JarvisSequential::PreProcessingImpl() {
   std::vector<shulpin_i_Jarvis_seq::Point> tmp_input;
-    
+
   shulpin_i_Jarvis_seq::Point* tmp_data = reinterpret_cast<shulpin_i_Jarvis_seq::Point*>(task_data->inputs[0]);
   int tmp_size = task_data->inputs_count[0];
   tmp_input.assign(tmp_data, tmp_data + tmp_size);

--- a/tasks/seq/shulpin_i_Jarvis_passage/src/ops_seq.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/src/ops_seq.cpp
@@ -2,10 +2,11 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <vector>
 
 int shulpin_i_jarvis_seq::JarvisSequential::Orientation(const Point& p, const Point& q, const Point& r) {
-  int val = ((q.y - p.y) * (r.x - q.x)) - ((q.x - p.x) * (r.y - q.y));
+  int val = static_cast<int>(((q.y - p.y) * (r.x - q.x)) - ((q.x - p.x) * (r.y - q.y)));
   if (val == 0) {
     return 0;
   }
@@ -31,7 +32,7 @@ void shulpin_i_jarvis_seq::JarvisSequential::MakeJarvisPassage(std::vector<shulp
     output_jar.emplace_back(input_jar[active]);
     int candidate = (active + 1) % total;
 
-    for (int index = 0; index < total; ++index) {
+    for (size_t index = 0; index < total; ++index) {
       if (Orientation(input_jar[active], input_jar[index], input_jar[candidate]) == 2) {
         candidate = index;
       }

--- a/tasks/seq/shulpin_i_Jarvis_passage/src/ops_seq.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/src/ops_seq.cpp
@@ -57,12 +57,12 @@ bool shulpin_i_Jarvis_seq::JarvisSequential::ValidationImpl() {
   return (task_data->inputs_count[0] >= 3) && (task_data->inputs[0] != nullptr);
 }
 
-bool shulpin_i_Jarvis_seq::JarvisSequential::RunImpl() { 
+bool shulpin_i_Jarvis_seq::JarvisSequential::RunImpl() {
   makeJarvisPassage(input, output);
   return true;
 }
 
-bool shulpin_i_Jarvis_seq::JarvisSequential::PostProcessingImpl() { 
+bool shulpin_i_Jarvis_seq::JarvisSequential::PostProcessingImpl() {
   int* result = reinterpret_cast<int*>(task_data->outputs[0]);
   std::copy(reinterpret_cast<int*>(output.data()), reinterpret_cast<int*>(output.data() + output.size()), result);
   return true;

--- a/tasks/seq/shulpin_i_Jarvis_passage/src/ops_seq.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/src/ops_seq.cpp
@@ -14,7 +14,6 @@ int shulpin_i_jarvis_seq::JarvisSequential::Orientation(const Point& p, const Po
 
 void shulpin_i_jarvis_seq::JarvisSequential::MakeJarvisPassage(std::vector<shulpin_i_jarvis_seq::Point>& input_jar,
                                                                std::vector<shulpin_i_jarvis_seq::Point>& output_jar) {
-
   size_t total = input_jar.size();
   std::vector<bool> used(total, false);
   output_jar.clear();

--- a/tasks/seq/shulpin_i_Jarvis_passage/src/ops_seq.cpp
+++ b/tasks/seq/shulpin_i_Jarvis_passage/src/ops_seq.cpp
@@ -1,0 +1,69 @@
+#include "seq/shulpin_i_Jarvis_passage/include/ops_seq.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+int shulpin_i_Jarvis_seq::JarvisSequential::orientation(const Point& p, const Point& q, const Point& r) {
+  int val = (q.y - p.y) * (r.x - q.x) - (q.x - p.x) * (r.y - q.y);
+  if (val == 0) return 0;
+  return (val > 0) ? 1 : 2;
+}
+
+void shulpin_i_Jarvis_seq::JarvisSequential::makeJarvisPassage(std::vector<shulpin_i_Jarvis_seq::Point>& input_jar,
+                                                               std::vector<shulpin_i_Jarvis_seq::Point>& output_jar) {
+  int total = input_jar.size();
+  std::vector<bool> used(total, false);
+  output_jar.clear();
+
+  int start = std::min_element(input_jar.begin(), input_jar.end(),
+                               [](const auto& a, const auto& b) { return a.x < b.x || (a.x == b.x && a.y < b.y); }) -
+              input_jar.begin();
+
+  int active = start;
+
+  do {
+    output_jar.emplace_back(input_jar[active]);
+    used[active] = true;
+    int candidate = (active + 1) % total;
+
+    for (int index = 0; index < total; ++index) {
+      if (!used[index] && orientation(input_jar[active], input_jar[index], input_jar[candidate]) == 2) {
+        candidate = index;
+      }
+    }
+
+    active = candidate;
+
+  } while (active != start);
+}
+
+bool shulpin_i_Jarvis_seq::JarvisSequential::PreProcessingImpl() {
+  std::vector<shulpin_i_Jarvis_seq::Point> tmp_input;
+    
+  shulpin_i_Jarvis_seq::Point* tmp_data = reinterpret_cast<shulpin_i_Jarvis_seq::Point*>(task_data->inputs[0]);
+  int tmp_size = task_data->inputs_count[0];
+  tmp_input.assign(tmp_data, tmp_data + tmp_size);
+
+  input = tmp_input;
+
+  int output_size = task_data->outputs_count[0];
+  output.resize(output_size);
+
+  return true;
+}
+
+bool shulpin_i_Jarvis_seq::JarvisSequential::ValidationImpl() {
+  return (task_data->inputs_count[0] >= 3) && (task_data->inputs[0] != nullptr);
+}
+
+bool shulpin_i_Jarvis_seq::JarvisSequential::RunImpl() { 
+  makeJarvisPassage(input, output);
+  return true;
+}
+
+bool shulpin_i_Jarvis_seq::JarvisSequential::PostProcessingImpl() { 
+  int* result = reinterpret_cast<int*>(task_data->outputs[0]);
+  std::copy(reinterpret_cast<int*>(output.data()), reinterpret_cast<int*>(output.data() + output.size()), result);
+  return true;
+}


### PR DESCRIPTION
**Описание алгоритма**

1. **Инициализация**:
-  Определяем количество точек (total).
-  Очищаем output_jar, куда будем записывать результат.

2. Поиск начальной точки:
-  Ищем самую левую нижнюю точку (минимальная x, а если x одинаковые, то минимальная y).
-  Сохраняем её индекс в start и начинаем алгоритм с этой точки (active = start).

3. Основной цикл построения оболочки:
-  Добавляем текущую точку (active) в output_jar и помечаем её как использованную.
-  Выбираем первого кандидата (candidate), следующего по индексу.
-  Перебираем все остальные точки (index) и ищем наиболее левую относительно текущей (active).
-  Для этого используем функцию orientation(), которая проверяет, образуют ли три точки левый поворот.
-  - Если orientation(active, index, candidate) == 2, обновляем candidate.
- - После завершения поиска обновляем active на candidate.
4. Завершение: 
-  Повторяем цикл, пока active не вернётся в start (то есть построена полная выпуклая оболочка).

**Сложность алгоритма**
В худшем случае — O(nh), где n — количество точек, а h — количество точек в выпуклой оболочке.