### PR TITLE
Ковалев Константин. Вариант 18. Технология SEQ. Поразрядная сортировка для целых чисел с четно-нечетным слиянием Бэтчера..

### DIFF
--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/func_tests/main_func.cpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/func_tests/main_func.cpp
@@ -1,13 +1,14 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
-#include <chrono>
 #include <cstdint>
 #include <cstdlib>
 #include <ctime>
 #include <limits>
+#include <memory>
 #include <random>
 #include <ranges>
+#include <vector>
 
 #include "core/task/include/task.hpp"
 #include "core/util/include/util.hpp"

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/func_tests/main_func.cpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/func_tests/main_func.cpp
@@ -1,36 +1,43 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
 #include <limits>
 #include <random>
+#include <ranges>
 
+#include "core/task/include/task.hpp"
+#include "core/util/include/util.hpp"
 #include "seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp"
 
-const long long int MinLL = std::numeric_limits<long long>::lowest(), MaxLL = std::numeric_limits<long long>::max();
+const long long int kMinLl = std::numeric_limits<long long>::lowest(), kMaxLl = std::numeric_limits<long long>::max();
 
 TEST(kovalev_k_radix_sort_batcher_merge_seq, zero_length) {
   std::vector<long long int> in;
   std::vector<long long int> out;
-  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
-  taskSeq->inputs_count.emplace_back(in.size());
-  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  taskSeq->outputs_count.emplace_back(out.size());
-  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
-  ASSERT_FALSE(tmpTaskSeq.ValidationImpl());
+  std::shared_ptr<ppc::core::TaskData> task_seq = std::make_shared<ppc::core::TaskData>();
+  task_seq->inputs_count.emplace_back(in.size());
+  task_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_seq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmp_task_seq(task_seq);
+  ASSERT_FALSE(tmp_task_seq.ValidationImpl());
 }
 
 TEST(kovalev_k_radix_sort_batcher_merge_seq, not_equal_lengths) {
   const unsigned int length = 10;
   std::vector<long long int> in(length);
   std::vector<long long int> out(2 * length);
-  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
-  taskSeq->inputs_count.emplace_back(in.size());
-  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  taskSeq->outputs_count.emplace_back(out.size());
-  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
-  ASSERT_FALSE(tmpTaskSeq.ValidationImpl());
+  std::shared_ptr<ppc::core::TaskData> task_seq = std::make_shared<ppc::core::TaskData>();
+  task_seq->inputs_count.emplace_back(in.size());
+  task_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_seq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmp_task_seq(task_seq);
+  ASSERT_FALSE(tmp_task_seq.ValidationImpl());
 }
 
 TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_No_viol_10_int) {
@@ -39,19 +46,21 @@ TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_No_viol_10_int) {
   const long long int alpha = rand();
   std::vector<long long int> in(length, alpha);
   std::vector<long long int> out(length);
-  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
-  taskSeq->inputs_count.emplace_back(in.size());
-  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  taskSeq->outputs_count.emplace_back(out.size());
-  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
-  ASSERT_TRUE(tmpTaskSeq.ValidationImpl());
-  tmpTaskSeq.PreProcessingImpl();
-  tmpTaskSeq.RunImpl();
-  tmpTaskSeq.PostProcessingImpl();
+  std::shared_ptr<ppc::core::TaskData> task_seq = std::make_shared<ppc::core::TaskData>();
+  task_seq->inputs_count.emplace_back(in.size());
+  task_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_seq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmp_task_seq(task_seq);
+  ASSERT_TRUE(tmp_task_seq.ValidationImpl());
+  tmp_task_seq.PreProcessingImpl();
+  tmp_task_seq.RunImpl();
+  tmp_task_seq.PostProcessingImpl();
   int count_viol = 0;
-  for (size_t i = 0; i < length; i++) {
-    if (out[i] != in[i]) count_viol++;
+  for (unsigned int i = 0; i < length; i++) {
+    if (out[i] != in[i]) {
+      count_viol++;
+    }
   }
   ASSERT_EQ(count_viol, 0);
 }
@@ -61,23 +70,25 @@ TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_793_int) {
   std::vector<long long int> in(length);
   std::random_device rd;
   std::mt19937 gen(rd());
-  std::uniform_int_distribution<long long int> dis(MinLL, MaxLL);
-  std::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::uniform_int_distribution<long long int> dis(kMinLl, kMaxLl);
+  std::ranges::generate(in.begin(), in.end(), [&]() { return dis(gen); });
   std::vector<long long int> out(length);
-  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
-  taskSeq->inputs_count.emplace_back(in.size());
-  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  taskSeq->outputs_count.emplace_back(out.size());
-  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
-  ASSERT_TRUE(tmpTaskSeq.ValidationImpl());
-  tmpTaskSeq.PreProcessingImpl();
-  tmpTaskSeq.RunImpl();
-  tmpTaskSeq.PostProcessingImpl();
-  std::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
+  std::shared_ptr<ppc::core::TaskData> task_seq = std::make_shared<ppc::core::TaskData>();
+  task_seq->inputs_count.emplace_back(in.size());
+  task_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_seq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmp_task_seq(task_seq);
+  ASSERT_TRUE(tmp_task_seq.ValidationImpl());
+  tmp_task_seq.PreProcessingImpl();
+  tmp_task_seq.RunImpl();
+  tmp_task_seq.PostProcessingImpl();
+  std::ranges::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
   int count_viol = 0;
-  for (size_t i = 0; i < length; i++) {
-    if (out[i] != in[i]) count_viol++;
+  for (unsigned int i = 0; i < length; i++) {
+    if (out[i] != in[i]) {
+      count_viol++;
+    }
   }
   ASSERT_EQ(count_viol, 0);
 }
@@ -87,23 +98,25 @@ TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_1000_int) {
   std::vector<long long int> in(length);
   std::random_device rd;
   std::mt19937 gen(rd());
-  std::uniform_int_distribution<long long int> dis(MinLL, MaxLL);
-  std::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::uniform_int_distribution<long long int> dis(kMinLl, kMaxLl);
+  std::ranges::generate(in.begin(), in.end(), [&]() { return dis(gen); });
   std::vector<long long int> out(length);
-  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
-  taskSeq->inputs_count.emplace_back(in.size());
-  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  taskSeq->outputs_count.emplace_back(out.size());
-  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
-  ASSERT_TRUE(tmpTaskSeq.ValidationImpl());
-  tmpTaskSeq.PreProcessingImpl();
-  tmpTaskSeq.RunImpl();
-  tmpTaskSeq.PostProcessingImpl();
-  std::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
+  std::shared_ptr<ppc::core::TaskData> task_seq = std::make_shared<ppc::core::TaskData>();
+  task_seq->inputs_count.emplace_back(in.size());
+  task_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_seq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmp_task_seq(task_seq);
+  ASSERT_TRUE(tmp_task_seq.ValidationImpl());
+  tmp_task_seq.PreProcessingImpl();
+  tmp_task_seq.RunImpl();
+  tmp_task_seq.PostProcessingImpl();
+  std::ranges::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
   int count_viol = 0;
-  for (size_t i = 0; i < length; i++) {
-    if (out[i] != in[i]) count_viol++;
+  for (unsigned int i = 0; i < length; i++) {
+    if (out[i] != in[i]) {
+      count_viol++;
+    }
   }
   ASSERT_EQ(count_viol, 0);
 }
@@ -113,23 +126,25 @@ TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_2158_int) {
   std::vector<long long int> in(length);
   std::random_device rd;
   std::mt19937 gen(rd());
-  std::uniform_int_distribution<long long int> dis(MinLL, MaxLL);
-  std::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::uniform_int_distribution<long long int> dis(kMinLl, kMaxLl);
+  std::ranges::generate(in.begin(), in.end(), [&]() { return dis(gen); });
   std::vector<long long int> out(length);
-  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
-  taskSeq->inputs_count.emplace_back(in.size());
-  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  taskSeq->outputs_count.emplace_back(out.size());
-  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
-  ASSERT_TRUE(tmpTaskSeq.ValidationImpl());
-  tmpTaskSeq.PreProcessingImpl();
-  tmpTaskSeq.RunImpl();
-  tmpTaskSeq.PostProcessingImpl();
-  std::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
+  std::shared_ptr<ppc::core::TaskData> task_seq = std::make_shared<ppc::core::TaskData>();
+  task_seq->inputs_count.emplace_back(in.size());
+  task_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_seq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmp_task_seq(task_seq);
+  ASSERT_TRUE(tmp_task_seq.ValidationImpl());
+  tmp_task_seq.PreProcessingImpl();
+  tmp_task_seq.RunImpl();
+  tmp_task_seq.PostProcessingImpl();
+  std::ranges::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
   int count_viol = 0;
-  for (size_t i = 0; i < length; i++) {
-    if (out[i] != in[i]) count_viol++;
+  for (unsigned int i = 0; i < length; i++) {
+    if (out[i] != in[i]) {
+      count_viol++;
+    }
   }
   ASSERT_EQ(count_viol, 0);
 }
@@ -139,23 +154,25 @@ TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_4763_int) {
   std::vector<long long int> in(length);
   std::random_device rd;
   std::mt19937 gen(rd());
-  std::uniform_int_distribution<long long int> dis(MinLL, MaxLL);
-  std::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::uniform_int_distribution<long long int> dis(kMinLl, kMaxLl);
+  std::ranges::generate(in.begin(), in.end(), [&]() { return dis(gen); });
   std::vector<long long int> out(length);
-  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
-  taskSeq->inputs_count.emplace_back(in.size());
-  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  taskSeq->outputs_count.emplace_back(out.size());
-  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
-  ASSERT_TRUE(tmpTaskSeq.ValidationImpl());
-  tmpTaskSeq.PreProcessingImpl();
-  tmpTaskSeq.RunImpl();
-  tmpTaskSeq.PostProcessingImpl();
-  std::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
+  std::shared_ptr<ppc::core::TaskData> task_seq = std::make_shared<ppc::core::TaskData>();
+  task_seq->inputs_count.emplace_back(in.size());
+  task_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_seq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmp_task_seq(task_seq);
+  ASSERT_TRUE(tmp_task_seq.ValidationImpl());
+  tmp_task_seq.PreProcessingImpl();
+  tmp_task_seq.RunImpl();
+  tmp_task_seq.PostProcessingImpl();
+  std::ranges::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
   int count_viol = 0;
-  for (size_t i = 0; i < length; i++) {
-    if (out[i] != in[i]) count_viol++;
+  for (unsigned int i = 0; i < length; i++) {
+    if (out[i] != in[i]) {
+      count_viol++;
+    }
   }
   ASSERT_EQ(count_viol, 0);
 }
@@ -165,23 +182,25 @@ TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_5000_int) {
   std::vector<long long int> in(length);
   std::random_device rd;
   std::mt19937 gen(rd());
-  std::uniform_int_distribution<long long int> dis(MinLL, MaxLL);
-  std::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::uniform_int_distribution<long long int> dis(kMinLl, kMaxLl);
+  std::ranges::generate(in.begin(), in.end(), [&]() { return dis(gen); });
   std::vector<long long int> out(length);
-  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
-  taskSeq->inputs_count.emplace_back(in.size());
-  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  taskSeq->outputs_count.emplace_back(out.size());
-  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
-  ASSERT_TRUE(tmpTaskSeq.ValidationImpl());
-  tmpTaskSeq.PreProcessingImpl();
-  tmpTaskSeq.RunImpl();
-  tmpTaskSeq.PostProcessingImpl();
-  std::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
+  std::shared_ptr<ppc::core::TaskData> task_seq = std::make_shared<ppc::core::TaskData>();
+  task_seq->inputs_count.emplace_back(in.size());
+  task_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_seq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmp_task_seq(task_seq);
+  ASSERT_TRUE(tmp_task_seq.ValidationImpl());
+  tmp_task_seq.PreProcessingImpl();
+  tmp_task_seq.RunImpl();
+  tmp_task_seq.PostProcessingImpl();
+  std::ranges::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
   int count_viol = 0;
-  for (size_t i = 0; i < length; i++) {
-    if (out[i] != in[i]) count_viol++;
+  for (unsigned int i = 0; i < length; i++) {
+    if (out[i] != in[i]) {
+      count_viol++;
+    }
   }
   ASSERT_EQ(count_viol, 0);
 }
@@ -191,23 +210,25 @@ TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_178892_int) {
   std::vector<long long int> in(length);
   std::random_device rd;
   std::mt19937 gen(rd());
-  std::uniform_int_distribution<long long int> dis(MinLL, MaxLL);
-  std::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::uniform_int_distribution<long long int> dis(kMinLl, kMaxLl);
+  std::ranges::generate(in.begin(), in.end(), [&]() { return dis(gen); });
   std::vector<long long int> out(length);
-  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
-  taskSeq->inputs_count.emplace_back(in.size());
-  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  taskSeq->outputs_count.emplace_back(out.size());
-  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
-  ASSERT_TRUE(tmpTaskSeq.ValidationImpl());
-  tmpTaskSeq.PreProcessingImpl();
-  tmpTaskSeq.RunImpl();
-  tmpTaskSeq.PostProcessingImpl();
-  std::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
+  std::shared_ptr<ppc::core::TaskData> task_seq = std::make_shared<ppc::core::TaskData>();
+  task_seq->inputs_count.emplace_back(in.size());
+  task_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_seq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmp_task_seq(task_seq);
+  ASSERT_TRUE(tmp_task_seq.ValidationImpl());
+  tmp_task_seq.PreProcessingImpl();
+  tmp_task_seq.RunImpl();
+  tmp_task_seq.PostProcessingImpl();
+  std::ranges::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
   int count_viol = 0;
-  for (size_t i = 0; i < length; i++) {
-    if (out[i] != in[i]) count_viol++;
+  for (unsigned int i = 0; i < length; i++) {
+    if (out[i] != in[i]) {
+      count_viol++;
+    }
   }
   ASSERT_EQ(count_viol, 0);
 }
@@ -217,23 +238,25 @@ TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_215718_int) {
   std::vector<long long int> in(length);
   std::random_device rd;
   std::mt19937 gen(rd());
-  std::uniform_int_distribution<long long int> dis(MinLL, MaxLL);
-  std::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::uniform_int_distribution<long long int> dis(kMinLl, kMaxLl);
+  std::ranges::generate(in.begin(), in.end(), [&]() { return dis(gen); });
   std::vector<long long int> out(length);
-  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
-  taskSeq->inputs_count.emplace_back(in.size());
-  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  taskSeq->outputs_count.emplace_back(out.size());
-  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
-  ASSERT_TRUE(tmpTaskSeq.ValidationImpl());
-  tmpTaskSeq.PreProcessingImpl();
-  tmpTaskSeq.RunImpl();
-  tmpTaskSeq.PostProcessingImpl();
-  std::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
+  std::shared_ptr<ppc::core::TaskData> task_seq = std::make_shared<ppc::core::TaskData>();
+  task_seq->inputs_count.emplace_back(in.size());
+  task_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_seq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmp_task_seq(task_seq);
+  ASSERT_TRUE(tmp_task_seq.ValidationImpl());
+  tmp_task_seq.PreProcessingImpl();
+  tmp_task_seq.RunImpl();
+  tmp_task_seq.PostProcessingImpl();
+  std::ranges::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
   int count_viol = 0;
-  for (size_t i = 0; i < length; i++) {
-    if (out[i] != in[i]) count_viol++;
+  for (unsigned int i = 0; i < length; i++) {
+    if (out[i] != in[i]) {
+      count_viol++;
+    }
   }
   ASSERT_EQ(count_viol, 0);
 }
@@ -243,23 +266,25 @@ TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_5000000_int) {
   std::vector<long long int> in(length);
   std::random_device rd;
   std::mt19937 gen(rd());
-  std::uniform_int_distribution<long long int> dis(MinLL, MaxLL);
-  std::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::uniform_int_distribution<long long int> dis(kMinLl, kMaxLl);
+  std::ranges::generate(in.begin(), in.end(), [&]() { return dis(gen); });
   std::vector<long long int> out(length);
-  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
-  taskSeq->inputs_count.emplace_back(in.size());
-  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  taskSeq->outputs_count.emplace_back(out.size());
-  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
-  ASSERT_TRUE(tmpTaskSeq.ValidationImpl());
-  tmpTaskSeq.PreProcessingImpl();
-  tmpTaskSeq.RunImpl();
-  tmpTaskSeq.PostProcessingImpl();
-  std::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
+  std::shared_ptr<ppc::core::TaskData> task_seq = std::make_shared<ppc::core::TaskData>();
+  task_seq->inputs_count.emplace_back(in.size());
+  task_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_seq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmp_task_seq(task_seq);
+  ASSERT_TRUE(tmp_task_seq.ValidationImpl());
+  tmp_task_seq.PreProcessingImpl();
+  tmp_task_seq.RunImpl();
+  tmp_task_seq.PostProcessingImpl();
+  std::ranges::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
   int count_viol = 0;
-  for (size_t i = 0; i < length; i++) {
-    if (out[i] != in[i]) count_viol++;
+  for (unsigned int i = 0; i < length; i++) {
+    if (out[i] != in[i]) {
+      count_viol++;
+    }
   }
   ASSERT_EQ(count_viol, 0);
 }
@@ -269,23 +294,25 @@ TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_244852_int) {
   std::vector<long long int> in(length);
   std::random_device rd;
   std::mt19937 gen(rd());
-  std::uniform_int_distribution<long long int> dis(MinLL, MaxLL);
-  std::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::uniform_int_distribution<long long int> dis(kMinLl, kMaxLl);
+  std::ranges::generate(in.begin(), in.end(), [&]() { return dis(gen); });
   std::vector<long long int> out(length);
-  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
-  taskSeq->inputs_count.emplace_back(in.size());
-  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  taskSeq->outputs_count.emplace_back(out.size());
-  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
-  ASSERT_TRUE(tmpTaskSeq.ValidationImpl());
-  tmpTaskSeq.PreProcessingImpl();
-  tmpTaskSeq.RunImpl();
-  tmpTaskSeq.PostProcessingImpl();
-  std::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
+  std::shared_ptr<ppc::core::TaskData> task_seq = std::make_shared<ppc::core::TaskData>();
+  task_seq->inputs_count.emplace_back(in.size());
+  task_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_seq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmp_task_seq(task_seq);
+  ASSERT_TRUE(tmp_task_seq.ValidationImpl());
+  tmp_task_seq.PreProcessingImpl();
+  tmp_task_seq.RunImpl();
+  tmp_task_seq.PostProcessingImpl();
+  std::ranges::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
   int count_viol = 0;
-  for (size_t i = 0; i < length; i++) {
-    if (out[i] != in[i]) count_viol++;
+  for (unsigned int i = 0; i < length; i++) {
+    if (out[i] != in[i]) {
+      count_viol++;
+    }
   }
   ASSERT_EQ(count_viol, 0);
 }
@@ -295,23 +322,25 @@ TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_875014_int) {
   std::vector<long long int> in(length);
   std::random_device rd;
   std::mt19937 gen(rd());
-  std::uniform_int_distribution<long long int> dis(MinLL, MaxLL);
-  std::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::uniform_int_distribution<long long int> dis(kMinLl, kMaxLl);
+  std::ranges::generate(in.begin(), in.end(), [&]() { return dis(gen); });
   std::vector<long long int> out(length);
-  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
-  taskSeq->inputs_count.emplace_back(in.size());
-  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  taskSeq->outputs_count.emplace_back(out.size());
-  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
-  ASSERT_TRUE(tmpTaskSeq.ValidationImpl());
-  tmpTaskSeq.PreProcessingImpl();
-  tmpTaskSeq.RunImpl();
-  tmpTaskSeq.PostProcessingImpl();
-  std::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
+  std::shared_ptr<ppc::core::TaskData> task_seq = std::make_shared<ppc::core::TaskData>();
+  task_seq->inputs_count.emplace_back(in.size());
+  task_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_seq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmp_task_seq(task_seq);
+  ASSERT_TRUE(tmp_task_seq.ValidationImpl());
+  tmp_task_seq.PreProcessingImpl();
+  tmp_task_seq.RunImpl();
+  tmp_task_seq.PostProcessingImpl();
+  std::ranges::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
   int count_viol = 0;
-  for (size_t i = 0; i < length; i++) {
-    if (out[i] != in[i]) count_viol++;
+  for (unsigned int i = 0; i < length; i++) {
+    if (out[i] != in[i]) {
+      count_viol++;
+    }
   }
   ASSERT_EQ(count_viol, 0);
 }

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/func_tests/main_func.cpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/func_tests/main_func.cpp
@@ -1,0 +1,317 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <limits>
+#include <random>
+
+#include "seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp"
+
+const long long int MinLL = std::numeric_limits<long long>::lowest(), MaxLL = std::numeric_limits<long long>::max();
+
+TEST(kovalev_k_radix_sort_batcher_merge_seq, zero_length) {
+  std::vector<long long int> in;
+  std::vector<long long int> out;
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(in.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
+  ASSERT_FALSE(tmpTaskSeq.ValidationImpl());
+}
+
+TEST(kovalev_k_radix_sort_batcher_merge_seq, not_equal_lengths) {
+  const unsigned int length = 10;
+  std::vector<long long int> in(length);
+  std::vector<long long int> out(2 * length);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(in.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
+  ASSERT_FALSE(tmpTaskSeq.ValidationImpl());
+}
+
+TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_No_viol_10_int) {
+  const unsigned int length = 10;
+  std::srand(std::time(nullptr));
+  const long long int alpha = rand();
+  std::vector<long long int> in(length, alpha);
+  std::vector<long long int> out(length);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(in.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
+  ASSERT_TRUE(tmpTaskSeq.ValidationImpl());
+  tmpTaskSeq.PreProcessingImpl();
+  tmpTaskSeq.RunImpl();
+  tmpTaskSeq.PostProcessingImpl();
+  int count_viol = 0;
+  for (size_t i = 0; i < length; i++) {
+    if (out[i] != in[i]) count_viol++;
+  }
+  ASSERT_EQ(count_viol, 0);
+}
+
+TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_793_int) {
+  const unsigned int length = 793;
+  std::vector<long long int> in(length);
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<long long int> dis(MinLL, MaxLL);
+  std::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::vector<long long int> out(length);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(in.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
+  ASSERT_TRUE(tmpTaskSeq.ValidationImpl());
+  tmpTaskSeq.PreProcessingImpl();
+  tmpTaskSeq.RunImpl();
+  tmpTaskSeq.PostProcessingImpl();
+  std::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
+  int count_viol = 0;
+  for (size_t i = 0; i < length; i++) {
+    if (out[i] != in[i]) count_viol++;
+  }
+  ASSERT_EQ(count_viol, 0);
+}
+
+TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_1000_int) {
+  const unsigned int length = 1000;
+  std::vector<long long int> in(length);
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<long long int> dis(MinLL, MaxLL);
+  std::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::vector<long long int> out(length);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(in.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
+  ASSERT_TRUE(tmpTaskSeq.ValidationImpl());
+  tmpTaskSeq.PreProcessingImpl();
+  tmpTaskSeq.RunImpl();
+  tmpTaskSeq.PostProcessingImpl();
+  std::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
+  int count_viol = 0;
+  for (size_t i = 0; i < length; i++) {
+    if (out[i] != in[i]) count_viol++;
+  }
+  ASSERT_EQ(count_viol, 0);
+}
+
+TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_2158_int) {
+  const unsigned int length = 2158;
+  std::vector<long long int> in(length);
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<long long int> dis(MinLL, MaxLL);
+  std::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::vector<long long int> out(length);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(in.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
+  ASSERT_TRUE(tmpTaskSeq.ValidationImpl());
+  tmpTaskSeq.PreProcessingImpl();
+  tmpTaskSeq.RunImpl();
+  tmpTaskSeq.PostProcessingImpl();
+  std::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
+  int count_viol = 0;
+  for (size_t i = 0; i < length; i++) {
+    if (out[i] != in[i]) count_viol++;
+  }
+  ASSERT_EQ(count_viol, 0);
+}
+
+TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_4763_int) {
+  const unsigned int length = 4763;
+  std::vector<long long int> in(length);
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<long long int> dis(MinLL, MaxLL);
+  std::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::vector<long long int> out(length);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(in.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
+  ASSERT_TRUE(tmpTaskSeq.ValidationImpl());
+  tmpTaskSeq.PreProcessingImpl();
+  tmpTaskSeq.RunImpl();
+  tmpTaskSeq.PostProcessingImpl();
+  std::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
+  int count_viol = 0;
+  for (size_t i = 0; i < length; i++) {
+    if (out[i] != in[i]) count_viol++;
+  }
+  ASSERT_EQ(count_viol, 0);
+}
+
+TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_5000_int) {
+  const unsigned int length = 5000;
+  std::vector<long long int> in(length);
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<long long int> dis(MinLL, MaxLL);
+  std::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::vector<long long int> out(length);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(in.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
+  ASSERT_TRUE(tmpTaskSeq.ValidationImpl());
+  tmpTaskSeq.PreProcessingImpl();
+  tmpTaskSeq.RunImpl();
+  tmpTaskSeq.PostProcessingImpl();
+  std::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
+  int count_viol = 0;
+  for (size_t i = 0; i < length; i++) {
+    if (out[i] != in[i]) count_viol++;
+  }
+  ASSERT_EQ(count_viol, 0);
+}
+
+TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_178892_int) {
+  const unsigned int length = 178892;
+  std::vector<long long int> in(length);
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<long long int> dis(MinLL, MaxLL);
+  std::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::vector<long long int> out(length);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(in.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
+  ASSERT_TRUE(tmpTaskSeq.ValidationImpl());
+  tmpTaskSeq.PreProcessingImpl();
+  tmpTaskSeq.RunImpl();
+  tmpTaskSeq.PostProcessingImpl();
+  std::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
+  int count_viol = 0;
+  for (size_t i = 0; i < length; i++) {
+    if (out[i] != in[i]) count_viol++;
+  }
+  ASSERT_EQ(count_viol, 0);
+}
+
+TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_215718_int) {
+  const unsigned int length = 215718;
+  std::vector<long long int> in(length);
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<long long int> dis(MinLL, MaxLL);
+  std::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::vector<long long int> out(length);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(in.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
+  ASSERT_TRUE(tmpTaskSeq.ValidationImpl());
+  tmpTaskSeq.PreProcessingImpl();
+  tmpTaskSeq.RunImpl();
+  tmpTaskSeq.PostProcessingImpl();
+  std::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
+  int count_viol = 0;
+  for (size_t i = 0; i < length; i++) {
+    if (out[i] != in[i]) count_viol++;
+  }
+  ASSERT_EQ(count_viol, 0);
+}
+
+TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_5000000_int) {
+  const unsigned int length = 5000000;
+  std::vector<long long int> in(length);
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<long long int> dis(MinLL, MaxLL);
+  std::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::vector<long long int> out(length);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(in.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
+  ASSERT_TRUE(tmpTaskSeq.ValidationImpl());
+  tmpTaskSeq.PreProcessingImpl();
+  tmpTaskSeq.RunImpl();
+  tmpTaskSeq.PostProcessingImpl();
+  std::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
+  int count_viol = 0;
+  for (size_t i = 0; i < length; i++) {
+    if (out[i] != in[i]) count_viol++;
+  }
+  ASSERT_EQ(count_viol, 0);
+}
+
+TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_244852_int) {
+  const unsigned int length = 244852;
+  std::vector<long long int> in(length);
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<long long int> dis(MinLL, MaxLL);
+  std::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::vector<long long int> out(length);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(in.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
+  ASSERT_TRUE(tmpTaskSeq.ValidationImpl());
+  tmpTaskSeq.PreProcessingImpl();
+  tmpTaskSeq.RunImpl();
+  tmpTaskSeq.PostProcessingImpl();
+  std::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
+  int count_viol = 0;
+  for (size_t i = 0; i < length; i++) {
+    if (out[i] != in[i]) count_viol++;
+  }
+  ASSERT_EQ(count_viol, 0);
+}
+
+TEST(kovalev_k_radix_sort_batcher_merge_seq, Test_875014_int) {
+  const unsigned int length = 875014;
+  std::vector<long long int> in(length);
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<long long int> dis(MinLL, MaxLL);
+  std::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::vector<long long int> out(length);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs_count.emplace_back(in.size());
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge tmpTaskSeq(taskSeq);
+  ASSERT_TRUE(tmpTaskSeq.ValidationImpl());
+  tmpTaskSeq.PreProcessingImpl();
+  tmpTaskSeq.RunImpl();
+  tmpTaskSeq.PostProcessingImpl();
+  std::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
+  int count_viol = 0;
+  for (size_t i = 0; i < length; i++) {
+    if (out[i] != in[i]) count_viol++;
+  }
+  ASSERT_EQ(count_viol, 0);
+}

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/func_tests/main_func.cpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/func_tests/main_func.cpp
@@ -7,11 +7,9 @@
 #include <limits>
 #include <memory>
 #include <random>
-#include <ranges>
 #include <vector>
 
 #include "core/task/include/task.hpp"
-#include "core/util/include/util.hpp"
 #include "seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp"
 
 const long long int kMinLl = std::numeric_limits<long long>::lowest(), kMaxLl = std::numeric_limits<long long>::max();

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <utility>
+#include <vector>
 
 #include "core/task/include/task.hpp"
 
@@ -11,8 +12,8 @@ namespace kovalev_k_radix_sort_batcher_merge_seq {
 
 class RadixSortBatcherMerge : public ppc::core::Task {
  private:
-  std::vector<long long int> mas, tmp;
-  unsigned int n;
+  std::vector<long long int> mas_, tmp_;
+  unsigned int n_;
 
  public:
   explicit RadixSortBatcherMerge(std::shared_ptr<ppc::core::TaskData> task_data) : Task(std::move(task_data)) {}

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <utility>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "core/task/include/task.hpp"

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp
@@ -1,10 +1,7 @@
 #pragma once
 
-#include <cmath>
-#include <cstdlib>
-#include <cstring>
-#include <memory>
 #include <utility>
+#include <memory>
 #include <vector>
 
 #include "core/task/include/task.hpp"
@@ -18,7 +15,7 @@ class RadixSortBatcherMerge : public ppc::core::Task {
 
  public:
   explicit RadixSortBatcherMerge(std::shared_ptr<ppc::core::TaskData> task_data) : Task(std::move(task_data)) {}
-  bool RadixUnsigned(unsigned long long*, unsigned long long*);
+  bool RadixUnsigned(unsigned long long*, unsigned long long*) const;
   bool Countbyte(unsigned long long*, int*, unsigned int) const;
   bool PreProcessingImpl() override;
   bool ValidationImpl() override;

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
+#include <memory>
 #include <utility>
 #include <vector>
 

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp
@@ -18,8 +18,8 @@ class RadixSortBatcherMerge : public ppc::core::Task {
 
  public:
   explicit RadixSortBatcherMerge(std::shared_ptr<ppc::core::TaskData> task_data) : Task(std::move(task_data)) {}
-  bool radix_unsigned(unsigned long long*, unsigned long long*);
-  bool countbyte(unsigned long long*, int*, unsigned int);
+  bool RadixUnsigned(unsigned long long*, unsigned long long*);
+  bool Countbyte(unsigned long long*, int*, unsigned int) const;
   bool PreProcessingImpl() override;
   bool ValidationImpl() override;
   bool RunImpl() override;

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <utility>
+
+#include "core/task/include/task.hpp"
+
+namespace kovalev_k_radix_sort_batcher_merge_seq {
+
+class RadixSortBatcherMerge : public ppc::core::Task {
+ private:
+  std::vector<long long int> mas, tmp;
+  unsigned int n;
+
+ public:
+  explicit RadixSortBatcherMerge(std::shared_ptr<ppc::core::TaskData> task_data) : Task(std::move(task_data)) {}
+  bool radix_unsigned(unsigned long long*, unsigned long long*);
+  bool countbyte(unsigned long long*, int*, unsigned int);
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+};
+}  // namespace kovalev_k_radix_sort_batcher_merge_seq

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
@@ -17,7 +17,7 @@
 const long long int kMinLl = std::numeric_limits<long long>::lowest(), kMaxLl = std::numeric_limits<long long>::max();
 
 TEST(kovalev_k_radix_sort_batcher_merge_seq, test_pipeline_run) {
-  const unsigned int length = 10;
+  const unsigned int length = 1000000;
   std::srand(std::time(nullptr));
   const int alpha = rand();
   std::vector<long long int> in(length, alpha);
@@ -51,7 +51,7 @@ TEST(kovalev_k_radix_sort_batcher_merge_seq, test_pipeline_run) {
 }
 
 TEST(kovalev_k_radix_sort_batcher_merge_seq, test_task_run) {
-  const unsigned int length = 5000000;
+  const unsigned int length = 9000000;
   std::vector<long long int> in(length);
   std::vector<long long int> out(length);
   std::random_device rd;

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
@@ -81,7 +81,9 @@ TEST(kovalev_k_radix_sort_batcher_merge_seq, test_task_run) {
   auto *tmp = reinterpret_cast<long long int *>(out.data());
   int count_viol = 0;
   for (unsigned int i = 0; i < length; i++) {
-    if (tmp[i] != etalon[i]) count_viol++;
+    if (tmp[i] != etalon[i]) {
+      count_viol++;
+    }
   }
   ASSERT_EQ(count_viol, 0);
 }

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <limits>
+#include <random>
+
+#include "core/perf/include/perf.hpp"
+#include "seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp"
+
+const long long int MinLL = std::numeric_limits<long long>::lowest(), MaxLL = std::numeric_limits<long long>::max();
+
+TEST(kovalev_k_radix_sort_batcher_merge_seq, test_pipeline_run) {
+  const unsigned int length = 10;
+  std::srand(std::time(nullptr));
+  const int alpha = rand();
+  std::vector<long long int> in(length, alpha);
+  std::vector<long long int> out(length);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskSeq->inputs_count.emplace_back(in.size());
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  auto testTaskSequential = std::make_shared<kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge>(taskSeq);
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perfAnalyzer->PipelineRun(perfAttr, perfResults);
+  ppc::core::Perf::PrintPerfStatistic(perfResults);
+  long long int *tmp = reinterpret_cast<long long int *>(out.data());
+  int count_viol = 0;
+  for (size_t i = 0; i < length; i++) {
+    if (tmp[i] != in[i]) count_viol++;
+  }
+  ASSERT_EQ(count_viol, 0);
+}
+
+TEST(kovalev_k_radix_sort_batcher_merge_seq, test_task_run) {
+  const unsigned int length = 5000000;
+  std::vector<long long int> in(length);
+  std::vector<long long int> out(length);
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<long long int> dis(MinLL, MaxLL);
+  std::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::vector<long long int> etalon(in);
+  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
+  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskSeq->inputs_count.emplace_back(in.size());
+  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskSeq->outputs_count.emplace_back(out.size());
+  auto testTaskSequential = std::make_shared<kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge>(taskSeq);
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perfAttr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  perfAnalyzer->TaskRun(perfAttr, perfResults);
+  ppc::core::Perf::PrintPerfStatistic(perfResults);
+  std::sort(etalon.begin(), etalon.end(), [](long long int a, long long int b) { return a < b; });
+  auto *tmp = reinterpret_cast<long long int *>(out.data());
+  int count_viol = 0;
+  for (size_t i = 0; i < length; i++) {
+    if (tmp[i] != etalon[i]) count_viol++;
+  }
+  ASSERT_EQ(count_viol, 0);
+}

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
@@ -6,8 +6,9 @@
 #include <cstdlib>
 #include <ctime>
 #include <limits>
+#include <memory>
 #include <random>
-#include <ranges>
+#include <vector>
 
 #include "core/perf/include/perf.hpp"
 #include "core/task/include/task.hpp"
@@ -27,7 +28,7 @@ TEST(kovalev_k_radix_sort_batcher_merge_seq, test_pipeline_run) {
   task_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_seq->outputs_count.emplace_back(out.size());
   auto test_task_sequential = std::make_shared<kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge>(task_seq);
-  auto perf_attr = std::make_shared<ppc::core::perf_attr>();
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&] {
@@ -35,7 +36,7 @@ TEST(kovalev_k_radix_sort_batcher_merge_seq, test_pipeline_run) {
     auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
     return static_cast<double>(duration) * 1e-9;
   };
-  auto perf_results = std::make_shared<ppc::core::perf_results>();
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
@@ -64,7 +65,7 @@ TEST(kovalev_k_radix_sort_batcher_merge_seq, test_task_run) {
   task_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_seq->outputs_count.emplace_back(out.size());
   auto test_task_sequential = std::make_shared<kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge>(task_seq);
-  auto perf_attr = std::make_shared<ppc::core::perf_attr>();
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&] {
@@ -72,7 +73,7 @@ TEST(kovalev_k_radix_sort_batcher_merge_seq, test_task_run) {
     auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
     return static_cast<double>(duration) * 1e-9;
   };
-  auto perf_results = std::make_shared<ppc::core::perf_results>();
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
@@ -1,13 +1,19 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
 #include <limits>
 #include <random>
+#include <ranges>
 
 #include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
 #include "seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp"
 
-const long long int MinLL = std::numeric_limits<long long>::lowest(), MaxLL = std::numeric_limits<long long>::max();
+const long long int kMinLl = std::numeric_limits<long long>::lowest(), kMaxLl = std::numeric_limits<long long>::max();
 
 TEST(kovalev_k_radix_sort_batcher_merge_seq, test_pipeline_run) {
   const unsigned int length = 10;
@@ -15,28 +21,30 @@ TEST(kovalev_k_radix_sort_batcher_merge_seq, test_pipeline_run) {
   const int alpha = rand();
   std::vector<long long int> in(length, alpha);
   std::vector<long long int> out(length);
-  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
-  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  taskSeq->inputs_count.emplace_back(in.size());
-  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  taskSeq->outputs_count.emplace_back(out.size());
-  auto testTaskSequential = std::make_shared<kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge>(taskSeq);
-  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
-  perfAttr->num_running = 10;
+  std::shared_ptr<ppc::core::TaskData> task_seq = std::make_shared<ppc::core::TaskData>();
+  task_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_seq->inputs_count.emplace_back(in.size());
+  task_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_seq->outputs_count.emplace_back(out.size());
+  auto test_task_sequential = std::make_shared<kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge>(task_seq);
+  auto perf_attr = std::make_shared<ppc::core::perf_attr>();
+  perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
-  perfAttr->current_timer = [&] {
+  perf_attr->current_timer = [&] {
     auto current_time_point = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
     return static_cast<double>(duration) * 1e-9;
   };
-  auto perfResults = std::make_shared<ppc::core::PerfResults>();
-  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
-  perfAnalyzer->PipelineRun(perfAttr, perfResults);
-  ppc::core::Perf::PrintPerfStatistic(perfResults);
-  long long int *tmp = reinterpret_cast<long long int *>(out.data());
+  auto perf_results = std::make_shared<ppc::core::perf_results>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  auto *tmp = reinterpret_cast<long long int *>(out.data());
   int count_viol = 0;
-  for (size_t i = 0; i < length; i++) {
-    if (tmp[i] != in[i]) count_viol++;
+  for (unsigned int i = 0; i < length; i++) {
+    if (tmp[i] != in[i]) {
+      count_viol++;
+    }
   }
   ASSERT_EQ(count_viol, 0);
 }
@@ -47,31 +55,31 @@ TEST(kovalev_k_radix_sort_batcher_merge_seq, test_task_run) {
   std::vector<long long int> out(length);
   std::random_device rd;
   std::mt19937 gen(rd());
-  std::uniform_int_distribution<long long int> dis(MinLL, MaxLL);
-  std::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::uniform_int_distribution<long long int> dis(kMinLl, kMaxLl);
+  std::ranges::generate(in.begin(), in.end(), [&]() { return dis(gen); });
   std::vector<long long int> etalon(in);
-  std::shared_ptr<ppc::core::TaskData> taskSeq = std::make_shared<ppc::core::TaskData>();
-  taskSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  taskSeq->inputs_count.emplace_back(in.size());
-  taskSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  taskSeq->outputs_count.emplace_back(out.size());
-  auto testTaskSequential = std::make_shared<kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge>(taskSeq);
-  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
-  perfAttr->num_running = 10;
+  std::shared_ptr<ppc::core::TaskData> task_seq = std::make_shared<ppc::core::TaskData>();
+  task_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_seq->inputs_count.emplace_back(in.size());
+  task_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_seq->outputs_count.emplace_back(out.size());
+  auto test_task_sequential = std::make_shared<kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge>(task_seq);
+  auto perf_attr = std::make_shared<ppc::core::perf_attr>();
+  perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
-  perfAttr->current_timer = [&] {
+  perf_attr->current_timer = [&] {
     auto current_time_point = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
     return static_cast<double>(duration) * 1e-9;
   };
-  auto perfResults = std::make_shared<ppc::core::PerfResults>();
-  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
-  perfAnalyzer->TaskRun(perfAttr, perfResults);
-  ppc::core::Perf::PrintPerfStatistic(perfResults);
-  std::sort(etalon.begin(), etalon.end(), [](long long int a, long long int b) { return a < b; });
+  auto perf_results = std::make_shared<ppc::core::perf_results>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  std::ranges::sort(etalon.begin(), etalon.end(), [](long long int a, long long int b) { return a < b; });
   auto *tmp = reinterpret_cast<long long int *>(out.data());
   int count_viol = 0;
-  for (size_t i = 0; i < length; i++) {
+  for (unsigned int i = 0; i < length; i++) {
     if (tmp[i] != etalon[i]) count_viol++;
   }
   ASSERT_EQ(count_viol, 0);

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/src/sourse.cpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/src/sourse.cpp
@@ -1,25 +1,33 @@
 #include "seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp"
 
-bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::radix_unsigned(unsigned long long* inp_arr,
-                                                                                   unsigned long long* mas_tmp) {
-  unsigned char* masc = reinterpret_cast<unsigned char*>(inp_arr);
+bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::RadixUnsigned(unsigned long long* inp_arr,
+                                                                                  unsigned long long* mas_tmp) {
+  auto masc = reinterpret_cast<unsigned char*>(inp_arr);
   int count[256];
-  size_t sizetype = sizeof(unsigned long long), j, i;
-  for (i = 0; i < sizetype; i++) {
-    countbyte(inp_arr, count, i);
-    for (j = 0; j < n_; j++) mas_tmp[count[masc[j * sizetype + i]]++] = inp_arr[j];
+  unsigned int sizetype = sizeof(unsigned long long);
+  for (unsigned int i = 0; i < sizetype; i++) {
+    Countbyte(inp_arr, count, i);
+    for (unsigned int j = 0; j < n_; j++) {
+      mas_tmp[count[masc[(j * sizetype) + i]]++] = inp_arr[j];
+    }
     memcpy(inp_arr, mas_tmp, sizeof(unsigned long long) * n_);
   }
   return true;
 }
 
-bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::countbyte(unsigned long long* inp_arr, int* count,
-                                                                              unsigned int byte) {
-  unsigned char* masc = reinterpret_cast<unsigned char*>(inp_arr);
-  unsigned int i, bias = sizeof(unsigned long long);
-  int tmp1, tmp2;
-  for (i = 0; i < 256; i++) count[i] = 0;
-  for (i = 0; i < n_; i++) count[masc[i * bias + byte]]++;
+bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::Countbyte(unsigned long long* inp_arr, int* count,
+                                                                              unsigned int byte) const {
+  auto masc = reinterpret_cast<unsigned char*>(inp_arr);
+  unsigned int i;
+  unsigned int bias = sizeof(unsigned long long);
+  int tmp1;
+  int tmp2;
+  for (i = 0; i < 256; i++) {
+    count[i] = 0;
+  }
+  for (i = 0; i < n_; i++) {
+    count[masc[(i * bias) + byte]]++;
+  }
   tmp1 = count[0];
   count[0] = 0;
   for (i = 1; i < 256; i++) {
@@ -45,15 +53,24 @@ bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::PreProcessin
 }
 
 bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::RunImpl() {
-  unsigned int count = 0, i = 0;
-  bool ret = radix_unsigned(reinterpret_cast<unsigned long long*>(mas_.data()),
-                            reinterpret_cast<unsigned long long*>(tmp_.data()));
-  while (count < n_ && mas_[count++] >= 0);
-  if (count == n_) return ret;
+  unsigned int count = 0;
+  unsigned int i = 0;
+  bool ret = RadixUnsigned(reinterpret_cast<unsigned long long*>(mas_.data()),
+                           reinterpret_cast<unsigned long long*>(tmp_.data()));
+  while (count < n_ && mas_[count] >= 0) {
+    count++;
+  }
+  if (count == n_) {
+    return ret;
+  }
   count--;
-  for (; count < n_; count++) tmp_[i++] = mas_[count];
+  for (; count < n_; count++) {
+    tmp_[i++] = mas_[count];
+  }
   count = 0;
-  for (; i < n_; i++) tmp_[i] = mas_[count++];
+  for (; i < n_; i++) {
+    tmp_[i] = mas_[count++];
+  }
   memcpy(mas_.data(), tmp_.data(), sizeof(long long int) * n_);
   return ret;
 }

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/src/sourse.cpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/src/sourse.cpp
@@ -7,8 +7,8 @@ bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::radix_unsign
   size_t sizetype = sizeof(unsigned long long), j, i;
   for (i = 0; i < sizetype; i++) {
     countbyte(inp_arr, count, i);
-    for (j = 0; j < n; j++) mas_tmp[count[masc[j * sizetype + i]]++] = inp_arr[j];
-    memcpy(inp_arr, mas_tmp, sizeof(unsigned long long) * n);
+    for (j = 0; j < n_; j++) mas_tmp[count[masc[j * sizetype + i]]++] = inp_arr[j];
+    memcpy(inp_arr, mas_tmp, sizeof(unsigned long long) * n_);
   }
   return true;
 }
@@ -19,7 +19,7 @@ bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::countbyte(un
   unsigned int i, bias = sizeof(unsigned long long);
   int tmp1, tmp2;
   for (i = 0; i < 256; i++) count[i] = 0;
-  for (i = 0; i < n; i++) count[masc[i * bias + byte]]++;
+  for (i = 0; i < n_; i++) count[masc[i * bias + byte]]++;
   tmp1 = count[0];
   count[0] = 0;
   for (i = 1; i < 256; i++) {
@@ -35,30 +35,30 @@ bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::ValidationIm
 }
 
 bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::PreProcessingImpl() {
-  n = task_data->inputs_count[0];
-  mas = std::vector<long long int>(n);
-  tmp = std::vector<long long int>(n);
+  n_ = task_data->inputs_count[0];
+  mas_ = std::vector<long long int>(n_);
+  tmp_ = std::vector<long long int>(n_);
   void* ptr_input = task_data->inputs[0];
-  void* ptr_vec = mas.data();
-  memcpy(ptr_vec, ptr_input, sizeof(long long int) * n);
+  void* ptr_vec = mas_.data();
+  memcpy(ptr_vec, ptr_input, sizeof(long long int) * n_);
   return true;
 }
 
 bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::RunImpl() {
   unsigned int count = 0, i = 0;
-  bool ret = radix_unsigned(reinterpret_cast<unsigned long long*>(mas.data()),
-                            reinterpret_cast<unsigned long long*>(tmp.data()));
-  while (count < n && mas[count++] >= 0);
-  if (count == n) return ret;
+  bool ret = radix_unsigned(reinterpret_cast<unsigned long long*>(mas_.data()),
+                            reinterpret_cast<unsigned long long*>(tmp_.data()));
+  while (count < n_ && mas_[count++] >= 0);
+  if (count == n_) return ret;
   count--;
-  for (; count < n; count++) tmp[i++] = mas[count];
+  for (; count < n_; count++) tmp_[i++] = mas_[count];
   count = 0;
-  for (; i < n; i++) tmp[i] = mas[count++];
-  for (i = 0; i < n; i++) mas[i] = tmp[i];
+  for (; i < n_; i++) tmp_[i] = mas_[count++];
+  memcpy(mas_.data(), tmp_.data(), sizeof(long long int) * n_);
   return ret;
 }
 
 bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::PostProcessingImpl() {
-  memcpy(reinterpret_cast<long long int*>(task_data->outputs[0]), mas.data(), sizeof(long long int) * n);
+  memcpy(reinterpret_cast<long long int*>(task_data->outputs[0]), mas_.data(), sizeof(long long int) * n_);
   return true;
 }

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/src/sourse.cpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/src/sourse.cpp
@@ -64,9 +64,8 @@ bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::RunImpl() {
   if (count == n_) {
     return ret;
   }
-  for (; count < n_; count++) {
-    tmp_[i++] = mas_[count];
-  }
+  memcpy(tmp_.data(), mas_.data() + count, sizeof(long long int) * (n_-count));
+  i = (n_ - count);
   count = 0;
   for (; i < n_; i++) {
     tmp_[i] = mas_[count++];

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/src/sourse.cpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/src/sourse.cpp
@@ -1,8 +1,14 @@
 #include "seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp"
 
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <utility>
+#include <vector>
+
 bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::RadixUnsigned(unsigned long long* inp_arr,
-                                                                                  unsigned long long* mas_tmp) {
-  auto masc = reinterpret_cast<unsigned char*>(inp_arr);
+                                                                                  unsigned long long* mas_tmp) const {
+  auto *masc = reinterpret_cast<unsigned char*>(inp_arr);
   int count[256];
   unsigned int sizetype = sizeof(unsigned long long);
   for (unsigned int i = 0; i < sizetype; i++) {
@@ -17,21 +23,18 @@ bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::RadixUnsigne
 
 bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::Countbyte(unsigned long long* inp_arr, int* count,
                                                                               unsigned int byte) const {
-  auto masc = reinterpret_cast<unsigned char*>(inp_arr);
-  unsigned int i;
+  auto *masc = reinterpret_cast<unsigned char*>(inp_arr);
   unsigned int bias = sizeof(unsigned long long);
-  int tmp1;
-  int tmp2;
-  for (i = 0; i < 256; i++) {
+  for (unsigned int i = 0; i < 256; i++) {
     count[i] = 0;
   }
-  for (i = 0; i < n_; i++) {
+  for (unsigned int i = 0; i < n_; i++) {
     count[masc[(i * bias) + byte]]++;
   }
-  tmp1 = count[0];
+  int tmp1 = count[0];
   count[0] = 0;
-  for (i = 1; i < 256; i++) {
-    tmp2 = count[i];
+  for (unsigned int i = 1; i < 256; i++) {
+    int tmp2 = count[i];
     count[i] = count[i - 1] + tmp1;
     tmp1 = tmp2;
   }
@@ -63,7 +66,6 @@ bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::RunImpl() {
   if (count == n_) {
     return ret;
   }
-  count--;
   for (; count < n_; count++) {
     tmp_[i++] = mas_[count];
   }

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/src/sourse.cpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/src/sourse.cpp
@@ -1,0 +1,64 @@
+#include "seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp"
+
+bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::radix_unsigned(unsigned long long* inp_arr,
+                                                                                   unsigned long long* mas_tmp) {
+  unsigned char* masc = reinterpret_cast<unsigned char*>(inp_arr);
+  int count[256];
+  size_t sizetype = sizeof(unsigned long long), j, i;
+  for (i = 0; i < sizetype; i++) {
+    countbyte(inp_arr, count, i);
+    for (j = 0; j < n; j++) mas_tmp[count[masc[j * sizetype + i]]++] = inp_arr[j];
+    memcpy(inp_arr, mas_tmp, sizeof(unsigned long long) * n);
+  }
+  return true;
+}
+
+bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::countbyte(unsigned long long* inp_arr, int* count,
+                                                                              unsigned int byte) {
+  unsigned char* masc = reinterpret_cast<unsigned char*>(inp_arr);
+  unsigned int i, bias = sizeof(unsigned long long);
+  int tmp1, tmp2;
+  for (i = 0; i < 256; i++) count[i] = 0;
+  for (i = 0; i < n; i++) count[masc[i * bias + byte]]++;
+  tmp1 = count[0];
+  count[0] = 0;
+  for (i = 1; i < 256; i++) {
+    tmp2 = count[i];
+    count[i] = count[i - 1] + tmp1;
+    tmp1 = tmp2;
+  }
+  return true;
+}
+
+bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::ValidationImpl() {
+  return (task_data->inputs_count[0] > 0 && task_data->outputs_count[0] == task_data->inputs_count[0]);
+}
+
+bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::PreProcessingImpl() {
+  n = task_data->inputs_count[0];
+  mas = std::vector<long long int>(n);
+  tmp = std::vector<long long int>(n);
+  void* ptr_input = task_data->inputs[0];
+  void* ptr_vec = mas.data();
+  memcpy(ptr_vec, ptr_input, sizeof(long long int) * n);
+  return true;
+}
+
+bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::RunImpl() {
+  unsigned int count = 0, i = 0;
+  bool ret = radix_unsigned(reinterpret_cast<unsigned long long*>(mas.data()),
+                            reinterpret_cast<unsigned long long*>(tmp.data()));
+  while (count < n && mas[count++] >= 0);
+  if (count == n) return ret;
+  count--;
+  for (; count < n; count++) tmp[i++] = mas[count];
+  count = 0;
+  for (; i < n; i++) tmp[i] = mas[count++];
+  for (i = 0; i < n; i++) mas[i] = tmp[i];
+  return ret;
+}
+
+bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::PostProcessingImpl() {
+  memcpy(reinterpret_cast<long long int*>(task_data->outputs[0]), mas.data(), sizeof(long long int) * n);
+  return true;
+}

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/src/sourse.cpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/src/sourse.cpp
@@ -55,7 +55,6 @@ bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::PreProcessin
 
 bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::RunImpl() {
   unsigned int count = 0;
-  unsigned int i = 0;
   bool ret = RadixUnsigned(reinterpret_cast<unsigned long long*>(mas_.data()),
                            reinterpret_cast<unsigned long long*>(tmp_.data()));
   while (count < n_ && mas_[count] >= 0) {
@@ -65,11 +64,7 @@ bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::RunImpl() {
     return ret;
   }
   memcpy(tmp_.data(), mas_.data() + count, sizeof(long long int) * (n_ - count));
-  i = (n_ - count);
-  count = 0;
-  for (; i < n_; i++) {
-    tmp_[i] = mas_[count++];
-  }
+  memcpy(tmp_.data() + (n_ - count), mas_.data(), sizeof(long long int) * (count));
   memcpy(mas_.data(), tmp_.data(), sizeof(long long int) * n_);
   return ret;
 }

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/src/sourse.cpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/src/sourse.cpp
@@ -1,7 +1,5 @@
 #include <cstdlib>
 #include <cstring>
-#include <memory>
-#include <utility>
 #include <vector>
 
 #include "seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp"

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/src/sourse.cpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/src/sourse.cpp
@@ -64,7 +64,7 @@ bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::RunImpl() {
   if (count == n_) {
     return ret;
   }
-  memcpy(tmp_.data(), mas_.data() + count, sizeof(long long int) * (n_-count));
+  memcpy(tmp_.data(), mas_.data() + count, sizeof(long long int) * (n_ - count));
   i = (n_ - count);
   count = 0;
   for (; i < n_; i++) {

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/src/sourse.cpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/src/sourse.cpp
@@ -1,14 +1,14 @@
-#include "seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp"
-
 #include <cstdlib>
 #include <cstring>
 #include <memory>
 #include <utility>
 #include <vector>
 
+#include "seq/kovalev_k_radix_sort_batcher_merge/include/header.hpp"
+
 bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::RadixUnsigned(unsigned long long* inp_arr,
                                                                                   unsigned long long* mas_tmp) const {
-  auto *masc = reinterpret_cast<unsigned char*>(inp_arr);
+  auto* masc = reinterpret_cast<unsigned char*>(inp_arr);
   int count[256];
   unsigned int sizetype = sizeof(unsigned long long);
   for (unsigned int i = 0; i < sizetype; i++) {
@@ -23,7 +23,7 @@ bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::RadixUnsigne
 
 bool kovalev_k_radix_sort_batcher_merge_seq::RadixSortBatcherMerge::Countbyte(unsigned long long* inp_arr, int* count,
                                                                               unsigned int byte) const {
-  auto *masc = reinterpret_cast<unsigned char*>(inp_arr);
+  auto* masc = reinterpret_cast<unsigned char*>(inp_arr);
   unsigned int bias = sizeof(unsigned long long);
   for (unsigned int i = 0; i < 256; i++) {
     count[i] = 0;


### PR DESCRIPTION
Задача состоит в реализации поразрядной сортировки массива целых чисел (последовательная реализация, сортировка в порядке возрастания). 
Метод Сountbyte подсчитывает количество байтов в заданном представлении каждого элемента массива mas. Результаты записываются в массив count, где count[i] содержит количество байт со значением i в массиве.
Метод RadixUnsigned использует countbyte для сортировки массива беззнаковых целых чисел. Проходит по каждому байту числа и сортирует элементы по этому байту, используя накопительные подсчеты. Временная память mas_tmp используется для хранения отсортированных элементов на каждом этапе.
Метод RunImpl вызывает RadixUnsigned для исходного массива, приведённого к беззнаковому типу. Т.к. в двоичной записи отрицательного целого числа знак записывается в старший бит, отрицательные числа после завершения RadixUnsigned отсортированы по убыванию (т.к. хранятся в дополнительном коде) модуля и следуют за наибольшим положительным. RunImpl восстанавливает правильный порядок с использованием дополнительной памяти.