### PR TITLE
Хасаньянов Кирилл. Задача 1. Вариант 10. Технология SEQ. Вычисление многомерных интегралов с использованием многошаговой схемы (метод трапеций).

### DIFF
--- a/tasks/seq/khasanyanov_k_trapezoid_method/func_tests/main.cpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/func_tests/main.cpp
@@ -1,0 +1,71 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <utility>
+#include <vector>
+
+#include "../include/integrator.hpp"
+
+using namespace khasanyanov_k_trapezoid_method_seq;
+
+TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_linear_function) {
+  // (5x + 2y - 3z)dxdydz;
+  auto f = [](const std::vector<double>& x) -> double { return (5 * x[0]) + (2 * x[1]) - (3 * x[2]); };
+
+  std::vector<std::pair<double, double>> bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
+
+  double precision = 1e-6;
+  double result = Integrator<kSequential>{}(f, bounds, precision);
+
+  ASSERT_NEAR(-21.0, result, precision);
+}
+
+TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_quad_function) {
+  // (x^2 + 2y - 6.5z^2)dxdydz;
+  auto f = [](const std::vector<double>& x) -> double { return (x[0] * x[0]) + (2 * x[1]) - (6.5 * x[2] * x[2]); };
+
+  std::vector<std::pair<double, double>> bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
+
+  double precision = 0.01;
+  double result = Integrator<kSequential>{}(f, bounds, precision);
+
+  ASSERT_NEAR(2.16666, result, precision);
+}
+
+TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_mixed_function) {
+  // (x^2 + 2xy + z)dxdydz;
+  auto f = [](const std::vector<double>& x) -> double { return (x[0] * x[0]) + (2 * x[1] * x[0]) + x[2]; };
+
+  std::vector<std::pair<double, double>> bounds = {{-2.5, 0.0}, {0.0, 3.0}, {2.0, 2.5}};
+
+  double precision = 0.001;
+  double result = Integrator<kSequential>{}(f, bounds, precision);
+
+  ASSERT_NEAR(2.1875, result, precision);
+}
+
+TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_trigonometric_function) {
+  // (5x + 2y - 3z)dxdydz;
+  auto f = [](const std::vector<double>& x) -> double { return (sin(x[0]))-x[1]; };
+
+  std::vector<std::pair<double, double>> bounds = {{0.0, 1.0}, {0.0, 2.0}};
+
+  double precision = 0.001;
+  double result = Integrator<kSequential>{}(f, bounds, precision);
+
+  ASSERT_NEAR(-1.08060, result, precision);
+}
+
+TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_long_function) {
+  // (5x + 2y - 3z)dxdydz;
+  auto f = [](const std::vector<double>& x) -> double {
+    return x[0] + (x[1] / 2.0) - (x[2] / 3.0) + (x[3] / 4.0) - (x[4] / 5.0);
+  };
+
+  std::vector<std::pair<double, double>> bounds = {{0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}};
+
+  double precision = 0.001;
+  double result = Integrator<kSequential>{}(f, bounds, precision);
+
+  ASSERT_NEAR(0.60833, result, precision);
+}

--- a/tasks/seq/khasanyanov_k_trapezoid_method/func_tests/main.cpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/func_tests/main.cpp
@@ -14,7 +14,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_linear_function) {
   // (5x + 2y - 3z)dxdydz;
   auto f = [](const std::vector<double>& x) -> double { return (5 * x[0]) + (2 * x[1]) - (3 * x[2]); };
 
-  IntegrateBounds bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
+  IntegrationBounds bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
 
   double precision = 1e-6;
   double result = Integrator<kSequential>{}(f, bounds, precision);
@@ -26,7 +26,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_quad_function) {
   // (x^2 + 2y - 6.5z^2)dxdydz;
   auto f = [](const std::vector<double>& x) -> double { return (x[0] * x[0]) + (2 * x[1]) - (6.5 * x[2]); };
 
-  IntegrateBounds bounds = {{-3.0, -2.0}, {0.0, 2.0}, {0.5, 1.0}};
+  IntegrationBounds bounds = {{-3.0, -2.0}, {0.0, 2.0}, {0.5, 1.0}};
 
   double precision = 0.01;
   double result = Integrator<kSequential>{}(f, bounds, precision);
@@ -38,7 +38,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_mixed_function) {
   // (x^2 + 2xy + z)dxdydz;
   auto f = [](const std::vector<double>& x) -> double { return (x[0] * x[0]) + (2 * x[1] * x[0]) + x[2]; };
 
-  IntegrateBounds bounds = {{-2.5, 0.0}, {0.0, 3.0}, {2.0, 2.5}};
+  IntegrationBounds bounds = {{-2.5, 0.0}, {0.0, 3.0}, {2.0, 2.5}};
 
   double precision = 0.001;
   double result = Integrator<kSequential>{}(f, bounds, precision);
@@ -50,7 +50,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_trigonometric_function)
   // (sin(x)-y)dxdy;
   auto f = [](const std::vector<double>& x) -> double { return sin(x[0]) - x[1]; };
 
-  IntegrateBounds bounds = {{0.0, 1.0}, {0.0, 2.0}};
+  IntegrationBounds bounds = {{0.0, 1.0}, {0.0, 2.0}};
 
   double precision = 0.001;
   double result = Integrator<kSequential>{}(f, bounds, precision);
@@ -64,12 +64,33 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_long_function) {
     return x[0] + (x[1] / 2.0) - (x[2] / 3.0) + (x[3] / 4.0) - (x[4] / 5.0);
   };
 
-  IntegrateBounds bounds = {{0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}};
+  IntegrationBounds bounds = {{0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}};
 
   double precision = 0.001;
   double result = Integrator<kSequential>{}(f, bounds, precision);
 
   ASSERT_NEAR(0.60833, result, precision);
+}
+
+TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_wrong_bounds) {
+  auto f = [](const std::vector<double>& x) -> double {
+    return x[0] + (x[1] / 2.0) - (x[2] / 3.0) + (x[3] / 4.0) - (x[4] / 5.0);
+  };
+
+  IntegrationBounds bounds = {{0.0, 1.0}, {2.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}};
+
+  double precision = 0.001;
+  ASSERT_ANY_THROW(Integrator<kSequential>{}(f, bounds, precision));
+}
+
+TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_constant_function) {
+  auto f = [](const std::vector<double>& x) -> double { return 45; };
+
+  IntegrationBounds bounds = {{2.0, 3.0}};
+
+  double precision = 0.001;
+  double result = Integrator<kSequential>{}(f, bounds, precision);
+  ASSERT_NEAR(45.0, result, precision);
 }
 
 //-----------------------------------------------------------------------------------------------------------------------------------------//
@@ -79,7 +100,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_1) {
   double result{};
   auto f = [](const std::vector<double>& x) -> double { return (5 * x[0]) + (2 * x[1]) - (3 * x[2]); };
 
-  IntegrateBounds bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
+  IntegrationBounds bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   TaskContext context{.function = f, .bounds = bounds, .precision = kPrecision};
@@ -99,7 +120,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_2) {
   double result{};
   auto f = [](const std::vector<double>& x) -> double { return (x[0] * x[0]) + (2 * x[1]) - (6.5 * x[2]); };
 
-  IntegrateBounds bounds = {{-3, -2.0}, {0.0, 2.0}, {0.5, 1.0}};
+  IntegrationBounds bounds = {{-3, -2.0}, {0.0, 2.0}, {0.5, 1.0}};
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   TaskContext context{.function = f, .bounds = bounds, .precision = kPrecision};
@@ -119,7 +140,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_3) {
   double result{};
   auto f = [](const std::vector<double>& x) -> double { return sin(x[0]) - x[1]; };
 
-  IntegrateBounds bounds = {{0.0, 1.0}, {0.0, 2.0}};
+  IntegrationBounds bounds = {{0.0, 1.0}, {0.0, 2.0}};
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   TaskContext context{.function = f, .bounds = bounds, .precision = kPrecision};
@@ -134,11 +155,49 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_3) {
   ASSERT_NEAR(-1.08060, result, kPrecision);
 }
 
+TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_4) {
+  constexpr double kPrecision = 0.001;
+  double result{};
+  auto f = [](const std::vector<double>& x) -> double { return 7.4 * x[0] - x[1] * x[1]; };
+
+  IntegrationBounds bounds = {{-50.0, -47.0}, {-2.0, -1.0}};
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  TaskContext context{.function = f, .bounds = bounds, .precision = kPrecision};
+  TrapezoidalMethodSequential::CreateTaskData(task_data_seq, context, &result);
+  TrapezoidalMethodSequential task(task_data_seq);
+
+  ASSERT_TRUE(task.Validation());
+
+  task.PreProcessing();
+  task.Run();
+  task.PostProcessing();
+  ASSERT_NEAR(-1083.7, result, kPrecision);
+}
+
+TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_5) {
+  constexpr double kPrecision = 0.001;
+  double result{};
+  auto f = [](const std::vector<double>& x) -> double { return 1 / x[0]; };
+
+  IntegrationBounds bounds = {{-1.0, 1.0}};
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  TaskContext context{.function = f, .bounds = bounds, .precision = kPrecision};
+  TrapezoidalMethodSequential::CreateTaskData(task_data_seq, context, &result);
+  TrapezoidalMethodSequential task(task_data_seq);
+
+  ASSERT_TRUE(task.Validation());
+
+  task.PreProcessing();
+  ASSERT_ANY_THROW(task.Run());
+}
+
 TEST(khasanyanov_k_trapezoid_method_seq, test_invalid_input) {
   constexpr double kPrecision = 0.001;
   auto f = [](const std::vector<double>& x) -> double { return sin(x[0]) - x[1]; };
 
-  IntegrateBounds bounds;
+  IntegrationBounds bounds;
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   TaskContext context{.function = f, .bounds = bounds, .precision = kPrecision};

--- a/tasks/seq/khasanyanov_k_trapezoid_method/func_tests/main.cpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/func_tests/main.cpp
@@ -158,7 +158,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_3) {
 TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_4) {
   constexpr double kPrecision = 0.001;
   double result{};
-  auto f = [](const std::vector<double>& x) -> double { return 7.4 * x[0] - x[1] * x[1]; };
+  auto f = [](const std::vector<double>& x) -> double { return (7.4 * x[0]) - (x[1] * x[1]); };
 
   IntegrationBounds bounds = {{-50.0, -47.0}, {-2.0, -1.0}};
 

--- a/tasks/seq/khasanyanov_k_trapezoid_method/func_tests/main.cpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/func_tests/main.cpp
@@ -1,18 +1,12 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
-#include <cstddef>
-#include <cstdint>
-#include <fstream>
 #include <memory>
-#include <string>
-#include <utility>
 #include <vector>
 
 #include "../include/integrate_seq.hpp"
 #include "../include/integrator.hpp"
 #include "core/task/include/task.hpp"
-#include "core/util/include/util.hpp"
 
 using namespace khasanyanov_k_trapezoid_method_seq;
 
@@ -20,7 +14,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_linear_function) {
   // (5x + 2y - 3z)dxdydz;
   auto f = [](const std::vector<double>& x) -> double { return (5 * x[0]) + (2 * x[1]) - (3 * x[2]); };
 
-  std::vector<std::pair<double, double>> bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
+  IntegrateBounds bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
 
   double precision = 1e-6;
   double result = Integrator<kSequential>{}(f, bounds, precision);
@@ -32,7 +26,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_quad_function) {
   // (x^2 + 2y - 6.5z^2)dxdydz;
   auto f = [](const std::vector<double>& x) -> double { return (x[0] * x[0]) + (2 * x[1]) - (6.5 * x[2] * x[2]); };
 
-  std::vector<std::pair<double, double>> bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
+  IntegrateBounds bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
 
   double precision = 0.01;
   double result = Integrator<kSequential>{}(f, bounds, precision);
@@ -44,7 +38,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_mixed_function) {
   // (x^2 + 2xy + z)dxdydz;
   auto f = [](const std::vector<double>& x) -> double { return (x[0] * x[0]) + (2 * x[1] * x[0]) + x[2]; };
 
-  std::vector<std::pair<double, double>> bounds = {{-2.5, 0.0}, {0.0, 3.0}, {2.0, 2.5}};
+  IntegrateBounds bounds = {{-2.5, 0.0}, {0.0, 3.0}, {2.0, 2.5}};
 
   double precision = 0.001;
   double result = Integrator<kSequential>{}(f, bounds, precision);
@@ -56,7 +50,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_trigonometric_function)
   // (sin(x)-y)dxdy;
   auto f = [](const std::vector<double>& x) -> double { return (sin(x[0]))-x[1]; };
 
-  std::vector<std::pair<double, double>> bounds = {{0.0, 1.0}, {0.0, 2.0}};
+  IntegrateBounds bounds = {{0.0, 1.0}, {0.0, 2.0}};
 
   double precision = 0.001;
   double result = Integrator<kSequential>{}(f, bounds, precision);
@@ -70,7 +64,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_long_function) {
     return x[0] + (x[1] / 2.0) - (x[2] / 3.0) + (x[3] / 4.0) - (x[4] / 5.0);
   };
 
-  std::vector<std::pair<double, double>> bounds = {{0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}};
+  IntegrateBounds bounds = {{0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}};
 
   double precision = 0.001;
   double result = Integrator<kSequential>{}(f, bounds, precision);
@@ -85,7 +79,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_1) {
   double result{};
   auto f = [](const std::vector<double>& x) -> double { return (5 * x[0]) + (2 * x[1]) - (3 * x[2]); };
 
-  std::vector<std::pair<double, double>> bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
+  IntegrateBounds bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   TrapezoidalMethodSequential::CreateTaskData(task_data_seq, f, bounds, kPrecision, &result);
@@ -104,7 +98,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_2) {
   double result{};
   auto f = [](const std::vector<double>& x) -> double { return (x[0] * x[0]) + (2 * x[1]) - (6.5 * x[2] * x[2]); };
 
-  std::vector<std::pair<double, double>> bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
+  IntegrateBounds bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   TrapezoidalMethodSequential::CreateTaskData(task_data_seq, f, bounds, kPrecision, &result);
@@ -123,7 +117,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_3) {
   double result{};
   auto f = [](const std::vector<double>& x) -> double { return (sin(x[0]))-x[1]; };
 
-  std::vector<std::pair<double, double>> bounds = {{0.0, 1.0}, {0.0, 2.0}};
+  IntegrateBounds bounds = {{0.0, 1.0}, {0.0, 2.0}};
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   TrapezoidalMethodSequential::CreateTaskData(task_data_seq, f, bounds, kPrecision, &result);
@@ -141,7 +135,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_invalid_input) {
   constexpr double kPrecision = 0.001;
   auto f = [](const std::vector<double>& x) -> double { return (sin(x[0]))-x[1]; };
 
-  std::vector<std::pair<double, double>> bounds = {{0.0, 1.0}, {0.0, 2.0}};
+  IntegrateBounds bounds;
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   TrapezoidalMethodSequential::CreateTaskData(task_data_seq, f, bounds, kPrecision, nullptr);

--- a/tasks/seq/khasanyanov_k_trapezoid_method/func_tests/main.cpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/func_tests/main.cpp
@@ -93,15 +93,6 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_constant_function) {
   ASSERT_NEAR(45.0, result, precision);
 }
 
-TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_diverge_function) {
-  auto f = [](const std::vector<double>& x) -> double { return 1 / x[0]; };
-
-  IntegrationBounds bounds = {{-1.0, 1.0}};
-
-  double precision = 0.001;
-  ASSERT_ANY_THROW(Integrator<kSequential>{}(f, bounds, precision));
-}
-
 //-----------------------------------------------------------------------------------------------------------------------------------------//
 
 TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_1) {
@@ -182,23 +173,6 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_4) {
   task.Run();
   task.PostProcessing();
   ASSERT_NEAR(-1083.7, result, kPrecision);
-}
-
-TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_5) {
-  constexpr double kPrecision = 0.001;
-  double result{};
-  auto f = [](const std::vector<double>& x) -> double { return 1 / x[0]; };
-
-  IntegrationBounds bounds = {{-1.0, 1.0}};
-
-  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
-  TaskContext context{.function = f, .bounds = bounds, .precision = kPrecision};
-  TrapezoidalMethodSequential::CreateTaskData(task_data_seq, context, &result);
-  TrapezoidalMethodSequential task(task_data_seq);
-
-  ASSERT_TRUE(task.Validation());
-  task.PreProcessing();
-  ASSERT_FALSE(task.Run());
 }
 
 TEST(khasanyanov_k_trapezoid_method_seq, test_invalid_input) {

--- a/tasks/seq/khasanyanov_k_trapezoid_method/func_tests/main.cpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/func_tests/main.cpp
@@ -24,14 +24,14 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_linear_function) {
 
 TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_quad_function) {
   // (x^2 + 2y - 6.5z^2)dxdydz;
-  auto f = [](const std::vector<double>& x) -> double { return (x[0] * x[0]) + (2 * x[1]) - (6.5 * x[2] * x[2]); };
+  auto f = [](const std::vector<double>& x) -> double { return (x[0] * x[0]) + (2 * x[1]) - (6.5 * x[2]); };
 
-  IntegrateBounds bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
+  IntegrateBounds bounds = {{-3.0, -2.0}, {0.0, 2.0}, {0.5, 1.0}};
 
   double precision = 0.01;
   double result = Integrator<kSequential>{}(f, bounds, precision);
 
-  ASSERT_NEAR(2.16666, result, precision);
+  ASSERT_NEAR(3.4583, result, precision);
 }
 
 TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_mixed_function) {
@@ -82,7 +82,8 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_1) {
   IntegrateBounds bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
-  TrapezoidalMethodSequential::CreateTaskData(task_data_seq, f, bounds, kPrecision, &result);
+  TaskContext context{.function = f, .bounds = bounds, .precision = kPrecision};
+  TrapezoidalMethodSequential::CreateTaskData(task_data_seq, context, &result);
   TrapezoidalMethodSequential task(task_data_seq);
 
   ASSERT_TRUE(task.Validation());
@@ -96,12 +97,13 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_1) {
 TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_2) {
   constexpr double kPrecision = 0.01;
   double result{};
-  auto f = [](const std::vector<double>& x) -> double { return (x[0] * x[0]) + (2 * x[1]) - (6.5 * x[2] * x[2]); };
+  auto f = [](const std::vector<double>& x) -> double { return (x[0] * x[0]) + (2 * x[1]) - (6.5 * x[2]); };
 
-  IntegrateBounds bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
+  IntegrateBounds bounds = {{-3, -2.0}, {0.0, 2.0}, {0.5, 1.0}};
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
-  TrapezoidalMethodSequential::CreateTaskData(task_data_seq, f, bounds, kPrecision, &result);
+  TaskContext context{.function = f, .bounds = bounds, .precision = kPrecision};
+  TrapezoidalMethodSequential::CreateTaskData(task_data_seq, context, &result);
   TrapezoidalMethodSequential task(task_data_seq);
 
   ASSERT_TRUE(task.Validation());
@@ -109,7 +111,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_2) {
   task.PreProcessing();
   task.Run();
   task.PostProcessing();
-  ASSERT_NEAR(2.16666, result, kPrecision);
+  ASSERT_NEAR(3.4583, result, kPrecision);
 }
 
 TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_3) {
@@ -120,7 +122,8 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_3) {
   IntegrateBounds bounds = {{0.0, 1.0}, {0.0, 2.0}};
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
-  TrapezoidalMethodSequential::CreateTaskData(task_data_seq, f, bounds, kPrecision, &result);
+  TaskContext context{.function = f, .bounds = bounds, .precision = kPrecision};
+  TrapezoidalMethodSequential::CreateTaskData(task_data_seq, context, &result);
   TrapezoidalMethodSequential task(task_data_seq);
 
   ASSERT_TRUE(task.Validation());
@@ -138,7 +141,8 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_invalid_input) {
   IntegrateBounds bounds;
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
-  TrapezoidalMethodSequential::CreateTaskData(task_data_seq, f, bounds, kPrecision, nullptr);
+  TaskContext context{.function = f, .bounds = bounds, .precision = kPrecision};
+  TrapezoidalMethodSequential::CreateTaskData(task_data_seq, context, nullptr);
   TrapezoidalMethodSequential task(task_data_seq);
 
   ASSERT_FALSE(task.Validation());

--- a/tasks/seq/khasanyanov_k_trapezoid_method/func_tests/main.cpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/func_tests/main.cpp
@@ -93,6 +93,15 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_constant_function) {
   ASSERT_NEAR(45.0, result, precision);
 }
 
+TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_diverge_function) {
+  auto f = [](const std::vector<double>& x) -> double { return 1 / x[0]; };
+
+  IntegrationBounds bounds = {{-1.0, 1.0}};
+
+  double precision = 0.001;
+  ASSERT_ANY_THROW(Integrator<kSequential>{}(f, bounds, precision));
+}
+
 //-----------------------------------------------------------------------------------------------------------------------------------------//
 
 TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_1) {
@@ -188,9 +197,8 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_5) {
   TrapezoidalMethodSequential task(task_data_seq);
 
   ASSERT_TRUE(task.Validation());
-
   task.PreProcessing();
-  ASSERT_ANY_THROW(task.Run());
+  ASSERT_FALSE(task.Run());
 }
 
 TEST(khasanyanov_k_trapezoid_method_seq, test_invalid_input) {

--- a/tasks/seq/khasanyanov_k_trapezoid_method/func_tests/main.cpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/func_tests/main.cpp
@@ -48,7 +48,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_mixed_function) {
 
 TEST(khasanyanov_k_trapezoid_method_seq, test_integrator_trigonometric_function) {
   // (sin(x)-y)dxdy;
-  auto f = [](const std::vector<double>& x) -> double { return (sin(x[0]))-x[1]; };
+  auto f = [](const std::vector<double>& x) -> double { return sin(x[0]) - x[1]; };
 
   IntegrateBounds bounds = {{0.0, 1.0}, {0.0, 2.0}};
 
@@ -115,7 +115,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_2) {
 TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_3) {
   constexpr double kPrecision = 0.001;
   double result{};
-  auto f = [](const std::vector<double>& x) -> double { return (sin(x[0]))-x[1]; };
+  auto f = [](const std::vector<double>& x) -> double { return sin(x[0]) - x[1]; };
 
   IntegrateBounds bounds = {{0.0, 1.0}, {0.0, 2.0}};
 
@@ -133,7 +133,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_integrate_3) {
 
 TEST(khasanyanov_k_trapezoid_method_seq, test_invalid_input) {
   constexpr double kPrecision = 0.001;
-  auto f = [](const std::vector<double>& x) -> double { return (sin(x[0]))-x[1]; };
+  auto f = [](const std::vector<double>& x) -> double { return sin(x[0]) - x[1]; };
 
   IntegrateBounds bounds;
 

--- a/tasks/seq/khasanyanov_k_trapezoid_method/include/integrate_seq.hpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/include/integrate_seq.hpp
@@ -10,8 +10,8 @@
 namespace khasanyanov_k_trapezoid_method_seq {
 
 struct TaskContext {
-  IntegrateFunction function;
-  IntegrateBounds bounds;
+  IntegrationFunction function;
+  IntegrationBounds bounds;
   double precision;
 };
 

--- a/tasks/seq/khasanyanov_k_trapezoid_method/include/integrate_seq.hpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/include/integrate_seq.hpp
@@ -23,12 +23,13 @@ class TrapezoidalMethodSequential : public ppc::core::Task {
   bool ValidationImpl() override;
   bool RunImpl() override;
   bool PostProcessingImpl() override;
+  ~TrapezoidalMethodSequential() override;
 
-  [[nodiscard("New task data igrored")]] static std::shared_ptr<ppc::core::TaskData> CreateTaskData(
-      const IntegrateFunction&, const IntegrateBounds&, double, double*);
+  static void CreateTaskData(std::shared_ptr<ppc::core::TaskData>&, const IntegrateFunction&, const IntegrateBounds&,
+                             double, double*);
 
  private:
-  TaskContext data_;
+  TaskContext* data_{};
   double res_{};
 };
 

--- a/tasks/seq/khasanyanov_k_trapezoid_method/include/integrate_seq.hpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/include/integrate_seq.hpp
@@ -1,0 +1,37 @@
+#ifndef _INTEGRATE_SEQ_HPP_
+#define _INTEGRATE_SEQ_HPP_
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "seq/khasanyanov_k_trapezoid_method/include/integrator.hpp"
+
+namespace khasanyanov_k_trapezoid_method_seq {
+
+struct TaskContext {
+  IntegrateFunction function;
+  IntegrateBounds bounds;
+  double precision;
+};
+
+class TrapezoidalMethodSequential : public ppc::core::Task {
+ public:
+  explicit TrapezoidalMethodSequential(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+  [[nodiscard("New task data igrored")]] static std::shared_ptr<ppc::core::TaskData> CreateTaskData(
+      const IntegrateFunction&, const IntegrateBounds&, double, double*);
+
+ private:
+  TaskContext data_;
+  double res_{};
+};
+
+}  // namespace khasanyanov_k_trapezoid_method_seq
+
+#endif

--- a/tasks/seq/khasanyanov_k_trapezoid_method/include/integrate_seq.hpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/include/integrate_seq.hpp
@@ -1,9 +1,8 @@
-#ifndef _INTEGRATE_SEQ_HPP_
-#define _INTEGRATE_SEQ_HPP_
+#ifndef INTEGRATE_SEQ_HPP
+#define INTEGRATE_SEQ_HPP
 
 #include <memory>
 #include <utility>
-#include <vector>
 
 #include "core/task/include/task.hpp"
 #include "seq/khasanyanov_k_trapezoid_method/include/integrator.hpp"

--- a/tasks/seq/khasanyanov_k_trapezoid_method/include/integrate_seq.hpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/include/integrate_seq.hpp
@@ -23,13 +23,11 @@ class TrapezoidalMethodSequential : public ppc::core::Task {
   bool ValidationImpl() override;
   bool RunImpl() override;
   bool PostProcessingImpl() override;
-  ~TrapezoidalMethodSequential() override;
 
-  static void CreateTaskData(std::shared_ptr<ppc::core::TaskData>&, const IntegrateFunction&, const IntegrateBounds&,
-                             double, double*);
+  static void CreateTaskData(std::shared_ptr<ppc::core::TaskData> &, TaskContext &context, double *);
 
  private:
-  TaskContext* data_{};
+  TaskContext data_;
   double res_{};
 };
 

--- a/tasks/seq/khasanyanov_k_trapezoid_method/include/integrator.hpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/include/integrator.hpp
@@ -122,7 +122,7 @@ double Integrator<technology>::TrapezoidalMethod(const IntegrationFunction& f, c
 }
 
 template <IntegrationTechnology technology>
-double Integrator<technology>::calculate_weight(const std::vector<int>& indices, int steps) {
+double Integrator<technology>::CalculateWeight(const std::vector<int>& indices, int steps) {
   double weight = 1.0;
   for (int idx : indices) {
     weight *= (idx == 0 || idx == steps) ? 0.5 : 1.0;

--- a/tasks/seq/khasanyanov_k_trapezoid_method/include/integrator.hpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/include/integrator.hpp
@@ -102,7 +102,7 @@ double Integrator<technology>::trapezoidal_method(const IntegrationFunction& f, 
 
     double weight = calculate_weight(indices, steps);
     double res = f(point);
-    if (res == std::numeric_limits<double>::infinity()) {
+    if (std::abs(res) == std::numeric_limits<double>::infinity()) {
       throw std::runtime_error("The integral diverges");
     }
     total += weight * f(point);

--- a/tasks/seq/khasanyanov_k_trapezoid_method/include/integrator.hpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/include/integrator.hpp
@@ -5,7 +5,6 @@
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
-#include <limits>
 #include <stdexcept>
 #include <utility>
 #include <vector>
@@ -101,10 +100,6 @@ double Integrator<technology>::trapezoidal_method(const IntegrationFunction& f, 
     }
 
     double weight = calculate_weight(indices, steps);
-    double res = f(point);
-    if (std::abs(res) == std::numeric_limits<double>::infinity()) {
-      throw std::runtime_error("The integral diverges");
-    }
     total += weight * f(point);
 
     size_t j = 0;

--- a/tasks/seq/khasanyanov_k_trapezoid_method/include/integrator.hpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/include/integrator.hpp
@@ -44,8 +44,7 @@ const int Integrator<technology>::kMaxSteps = 250;
 
 template <IntegrationTechnology technology>
 double Integrator<technology>::operator()(const IntegrationFunction& f, const IntegrationBounds& bounds,
-                                          double precision,  // NOLINT(bugprone-easily-swappable-parameters)
-                                          int init_steps, int max_steps) const {
+                                          double precision, int init_steps, int max_steps) const {
   switch (technology) {
     case kSequential:
       return trapezoidal_method_sequential(f, bounds, precision, init_steps, max_steps);
@@ -59,10 +58,9 @@ double Integrator<technology>::operator()(const IntegrationFunction& f, const In
 }
 
 template <IntegrationTechnology technology>
-double Integrator<technology>::trapezoidal_method_sequential(
-    const IntegrationFunction& f, const IntegrationBounds& bounds,
-    double precision,  // NOLINT(bugprone-easily-swappable-parameters)
-    int init_steps, int max_steps) {
+double Integrator<technology>::trapezoidal_method_sequential(const IntegrationFunction& f,
+                                                             const IntegrationBounds& bounds, double precision,
+                                                             int init_steps, int max_steps) {
   int steps = init_steps;
   double prev_result = trapezoidal_method(f, bounds, steps);
   while (steps <= max_steps) {

--- a/tasks/seq/khasanyanov_k_trapezoid_method/include/integrator.hpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/include/integrator.hpp
@@ -1,0 +1,122 @@
+#ifndef _INTEGRATOR_H_
+#define _INTEGRATOR_H_
+#include <cstdint>
+#include <functional>
+#include <stdexcept>
+namespace khasanyanov_k_trapezoid_method_seq {
+
+enum IntegrateTechnology : std::uint8_t { kSequential, kOpenMP, kTBB, kSTL, kMPI };
+
+using IntegrateFunction = std::function<double(const std::vector<double>&)>;
+using IntegrateBounds = std::pair<double, double>;
+
+template <IntegrateTechnology technology>
+class Integrator {
+  static const int kDefaultParts;
+
+  [[nodiscard]] static double calculate_weight(  // NOLINT(readability-identifier-naming)
+      const std::vector<int>& indices, int steps);
+
+  [[nodiscard]] static double trapezoidal_method(  // NOLINT(readability-identifier-naming)
+      const IntegrateFunction& f, const std::vector<IntegrateBounds>& bounds, int steps);
+
+  [[nodiscard]] static double trapezoidal_method_sequential(  // NOLINT(readability-identifier-naming)
+      const IntegrateFunction&, const std::vector<IntegrateBounds>&, double, int, int);
+
+ public:
+  double operator()(const IntegrateFunction&, const std::vector<IntegrateBounds>&, double, int = kDefaultParts,
+                    int = 1024) const;
+};
+
+//----------------------------------------------------------------------------------------------------------
+
+template <IntegrateTechnology technology>
+const int Integrator<technology>::kDefaultParts = 5;
+
+template <IntegrateTechnology technology>
+double Integrator<technology>::operator()(const IntegrateFunction& f, const std::vector<IntegrateBounds>& bounds,
+                                          double precision,  // NOLINT(bugprone-easily-swappable-parameters)
+                                          int init_steps, int max_steps) const {
+  switch (technology) {
+    case kSequential:
+      return trapezoidal_method_sequential(f, bounds, precision, init_steps, max_steps);
+    default:
+      throw std::runtime_error("Technology not available");
+  }
+}
+
+template <IntegrateTechnology technology>
+double Integrator<technology>::trapezoidal_method_sequential(
+    const IntegrateFunction& f, const std::vector<IntegrateBounds>& bounds,
+    double precision,  // NOLINT(bugprone-easily-swappable-parameters)
+    int init_steps, int max_steps) {
+  int steps = init_steps;
+  double prev_result = trapezoidal_method(f, bounds, steps);
+  while (steps <= max_steps) {
+    steps *= 2;
+    double current_result = trapezoidal_method(f, bounds, steps);
+    if (std::abs(current_result - prev_result) < precision) {
+      return current_result;
+    }
+    prev_result = current_result;
+  }
+  return prev_result;
+}
+
+template <IntegrateTechnology technology>
+double Integrator<technology>::trapezoidal_method(const IntegrateFunction& f,
+                                                  const std::vector<IntegrateBounds>& bounds, int steps) {
+  size_t dims = bounds.size();
+  std::vector<double> dx(dims);
+
+  for (size_t i = 0; i < dims; ++i) {
+    dx[i] = (bounds[i].second - bounds[i].first) / steps;
+  }
+
+  double total = 0.0;
+  std::vector<int> indices(dims, 0);
+  bool done = false;
+
+  while (!done) {
+    std::vector<double> point(dims);
+    for (size_t i = 0; i < dims; ++i) {
+      point[i] = bounds[i].first + indices[i] * dx[i];
+    }
+
+    double weight = calculate_weight(indices, steps);
+    total += weight * f(point);
+
+    int j = 0;
+    while (j < dims) {
+      indices[j]++;
+      if (indices[j] <= steps) {
+        break;
+      }
+
+      indices[j] = 0;
+      ++j;
+    }
+    if (j == dims) {
+      done = true;
+    }
+  }
+
+  double factor = 1.0;
+  for (int i = 0; i < dims; ++i) {
+    factor *= dx[i];
+  }
+  return total * factor;
+}
+
+template <IntegrateTechnology technology>
+double Integrator<technology>::calculate_weight(const std::vector<int>& indices, int steps) {
+  double weight = 1.0;
+  for (int idx : indices) {
+    weight *= (idx == 0 || idx == steps) ? 0.5 : 1.0;
+  }
+  return weight;
+}
+
+}  // namespace khasanyanov_k_trapezoid_method_seq
+
+#endif

--- a/tasks/seq/khasanyanov_k_trapezoid_method/include/integrator.hpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/include/integrator.hpp
@@ -20,14 +20,13 @@ template <IntegrationTechnology technology>
 class Integrator {
   static const int kDefaultSteps, kMaxSteps;
 
-  [[nodiscard]] static double calculate_weight(  // NOLINT(readability-identifier-naming)
-      const std::vector<int>& indices, int steps);
+  [[nodiscard]] static double CalculateWeight(const std::vector<int>& indices, int steps);
 
-  [[nodiscard]] static double trapezoidal_method(  // NOLINT(readability-identifier-naming)
-      const IntegrationFunction& f, const IntegrationBounds& bounds, int steps);
+  [[nodiscard]] static double TrapezoidalMethod(const IntegrationFunction& f, const IntegrationBounds& bounds,
+                                                int steps);
 
-  [[nodiscard]] static double trapezoidal_method_sequential(  // NOLINT(readability-identifier-naming)
-      const IntegrationFunction&, const IntegrationBounds&, double, int, int);
+  [[nodiscard]] static double TrapezoidalMethodSequential(const IntegrationFunction&, const IntegrationBounds&, double,
+                                                          int, int);
 
  public:
   double operator()(const IntegrationFunction&, const IntegrationBounds&, double, int = kDefaultSteps,
@@ -47,7 +46,7 @@ double Integrator<technology>::operator()(const IntegrationFunction& f, const In
                                           double precision, int init_steps, int max_steps) const {
   switch (technology) {
     case kSequential:
-      return trapezoidal_method_sequential(f, bounds, precision, init_steps, max_steps);
+      return TrapezoidalMethodSequential(f, bounds, precision, init_steps, max_steps);
     case kTBB:
     case kMPI:
     case kOpenMP:
@@ -58,14 +57,14 @@ double Integrator<technology>::operator()(const IntegrationFunction& f, const In
 }
 
 template <IntegrationTechnology technology>
-double Integrator<technology>::trapezoidal_method_sequential(const IntegrationFunction& f,
-                                                             const IntegrationBounds& bounds, double precision,
-                                                             int init_steps, int max_steps) {
+double Integrator<technology>::TrapezoidalMethodSequential(const IntegrationFunction& f,
+                                                           const IntegrationBounds& bounds, double precision,
+                                                           int init_steps, int max_steps) {
   int steps = init_steps;
-  double prev_result = trapezoidal_method(f, bounds, steps);
+  double prev_result = TrapezoidalMethod(f, bounds, steps);
   while (steps <= max_steps) {
     steps *= 2;
-    double current_result = trapezoidal_method(f, bounds, steps);
+    double current_result = TrapezoidalMethod(f, bounds, steps);
     if (std::abs(current_result - prev_result) < precision) {
       return current_result;
     }
@@ -75,8 +74,8 @@ double Integrator<technology>::trapezoidal_method_sequential(const IntegrationFu
 }
 
 template <IntegrationTechnology technology>
-double Integrator<technology>::trapezoidal_method(const IntegrationFunction& f, const IntegrationBounds& bounds,
-                                                  int steps) {
+double Integrator<technology>::TrapezoidalMethod(const IntegrationFunction& f, const IntegrationBounds& bounds,
+                                                 int steps) {
   size_t dims = bounds.size();
   std::vector<double> dx(dims);
 
@@ -97,7 +96,7 @@ double Integrator<technology>::trapezoidal_method(const IntegrationFunction& f, 
       point[i] = bounds[i].first + indices[i] * dx[i];
     }
 
-    double weight = calculate_weight(indices, steps);
+    double weight = CalculateWeight(indices, steps);
     total += weight * f(point);
 
     size_t j = 0;

--- a/tasks/seq/khasanyanov_k_trapezoid_method/perf_tests/main.cpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/perf_tests/main.cpp
@@ -16,7 +16,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_pipeline_run) {
   double result{};
   auto f = [](const std::vector<double>& x) -> double { return (x[0] * x[0]) + (2 * x[1]) - (6.5 * x[2] * x[2]); };
 
-  IntegrateBounds bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
+  IntegrationBounds bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   TaskContext context{.function = f, .bounds = bounds, .precision = kPrecision};
@@ -45,7 +45,7 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_task_run) {
   double result{};
   auto f = [](const std::vector<double>& x) -> double { return (x[0] * x[0]) + (2 * x[1]) - (6.5 * x[2] * x[2]); };
 
-  IntegrateBounds bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
+  IntegrationBounds bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   TaskContext context{.function = f, .bounds = bounds, .precision = kPrecision};

--- a/tasks/seq/khasanyanov_k_trapezoid_method/perf_tests/main.cpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/perf_tests/main.cpp
@@ -19,7 +19,8 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_pipeline_run) {
   IntegrateBounds bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
-  TrapezoidalMethodSequential::CreateTaskData(task_data_seq, f, bounds, kPrecision, &result);
+  TaskContext context{.function = f, .bounds = bounds, .precision = kPrecision};
+  TrapezoidalMethodSequential::CreateTaskData(task_data_seq, context, &result);
 
   auto task = std::make_shared<TrapezoidalMethodSequential>(task_data_seq);
 
@@ -47,7 +48,8 @@ TEST(khasanyanov_k_trapezoid_method_seq, test_task_run) {
   IntegrateBounds bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
-  TrapezoidalMethodSequential::CreateTaskData(task_data_seq, f, bounds, kPrecision, &result);
+  TaskContext context{.function = f, .bounds = bounds, .precision = kPrecision};
+  TrapezoidalMethodSequential::CreateTaskData(task_data_seq, context, &result);
 
   auto task = std::make_shared<TrapezoidalMethodSequential>(task_data_seq);
 

--- a/tasks/seq/khasanyanov_k_trapezoid_method/perf_tests/main.cpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/perf_tests/main.cpp
@@ -1,0 +1,68 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <vector>
+
+#include "../include/integrate_seq.hpp"
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "seq/khasanyanov_k_trapezoid_method/include/integrator.hpp"
+
+using namespace khasanyanov_k_trapezoid_method_seq;
+
+TEST(khasanyanov_k_trapezoid_method_seq, test_pipeline_run) {
+  constexpr double kPrecision = 0.01;
+  double result{};
+  auto f = [](const std::vector<double>& x) -> double { return (x[0] * x[0]) + (2 * x[1]) - (6.5 * x[2] * x[2]); };
+
+  IntegrateBounds bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  TrapezoidalMethodSequential::CreateTaskData(task_data_seq, f, bounds, kPrecision, &result);
+
+  auto task = std::make_shared<TrapezoidalMethodSequential>(task_data_seq);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(task);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}
+
+TEST(khasanyanov_k_trapezoid_method_seq, test_task_run) {
+  constexpr double kPrecision = 0.01;
+  double result{};
+  auto f = [](const std::vector<double>& x) -> double { return (x[0] * x[0]) + (2 * x[1]) - (6.5 * x[2] * x[2]); };
+
+  IntegrateBounds bounds = {{-3, 1.0}, {0.0, 2.0}, {0.5, 1.0}};
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  TrapezoidalMethodSequential::CreateTaskData(task_data_seq, f, bounds, kPrecision, &result);
+
+  auto task = std::make_shared<TrapezoidalMethodSequential>(task_data_seq);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(task);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}

--- a/tasks/seq/khasanyanov_k_trapezoid_method/src/integrate_seq.cpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/src/integrate_seq.cpp
@@ -27,12 +27,7 @@ bool TrapezoidalMethodSequential::PreProcessingImpl() {
   return true;
 }
 bool TrapezoidalMethodSequential::RunImpl() {
-  try {
-    res_ = Integrator<kSequential>{}(data_.function, data_.bounds, data_.precision);
-  } catch (const std::exception &e) {
-    std::cerr << e.what() << '\n';
-    return false;
-  }
+  res_ = Integrator<kSequential>{}(data_.function, data_.bounds, data_.precision);
   return true;
 }
 bool TrapezoidalMethodSequential::PostProcessingImpl() {

--- a/tasks/seq/khasanyanov_k_trapezoid_method/src/integrate_seq.cpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/src/integrate_seq.cpp
@@ -1,0 +1,40 @@
+#include "../include/integrate_seq.hpp"
+
+#include <cstdint>
+#include <memory>
+
+#include "core/task/include/task.hpp"
+#include "seq/khasanyanov_k_trapezoid_method/include/integrator.hpp"
+
+using namespace khasanyanov_k_trapezoid_method_seq;
+
+std::shared_ptr<ppc::core::TaskData> TrapezoidalMethodSequential::CreateTaskData(
+    const IntegrateFunction &f, const IntegrateBounds &bounds,
+    double precision,  // NOLINT(bugprone-easily-swappable-parameters)
+    double *out) {
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  TaskContext context{.function = f, .bounds = bounds, .precision = precision};
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(&context));
+  task_data->inputs_count.emplace_back(bounds.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out));
+  task_data->outputs_count.emplace_back(1);
+  return task_data;
+}
+
+bool TrapezoidalMethodSequential::ValidationImpl() {
+  auto *data = reinterpret_cast<TaskContext *>(task_data->inputs[0]);
+  return data != nullptr && !data->bounds.empty() && !task_data->outputs.empty();
+}
+
+bool TrapezoidalMethodSequential::PreProcessingImpl() {
+  data_ = *reinterpret_cast<TaskContext *>(task_data->inputs[0]);
+  return true;
+}
+bool TrapezoidalMethodSequential::RunImpl() {
+  res_ = Integrator<kSequential>{}(data_.function, data_.bounds, data_.precision);
+  return true;
+}
+bool TrapezoidalMethodSequential::PostProcessingImpl() {
+  *reinterpret_cast<double *>(task_data->outputs[0]) = res_;
+  return true;
+}

--- a/tasks/seq/khasanyanov_k_trapezoid_method/src/integrate_seq.cpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/src/integrate_seq.cpp
@@ -1,6 +1,7 @@
 #include "../include/integrate_seq.hpp"
 
 #include <cstdint>
+#include <iostream>
 #include <memory>
 
 #include "core/task/include/task.hpp"
@@ -26,7 +27,12 @@ bool TrapezoidalMethodSequential::PreProcessingImpl() {
   return true;
 }
 bool TrapezoidalMethodSequential::RunImpl() {
-  res_ = Integrator<kSequential>{}(data_.function, data_.bounds, data_.precision);
+  try {
+    res_ = Integrator<kSequential>{}(data_.function, data_.bounds, data_.precision);
+  } catch (const std::exception &e) {
+    std::cerr << e.what() << '\n';
+    return false;
+  }
   return true;
 }
 bool TrapezoidalMethodSequential::PostProcessingImpl() {

--- a/tasks/seq/khasanyanov_k_trapezoid_method/src/integrate_seq.cpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/src/integrate_seq.cpp
@@ -9,14 +9,10 @@
 
 using namespace khasanyanov_k_trapezoid_method_seq;
 
-void TrapezoidalMethodSequential::CreateTaskData(std::shared_ptr<ppc::core::TaskData> &task_data,
-                                                 const IntegrateFunction &f, const IntegrateBounds &bounds,
-                                                 double precision,  // NOLINT(bugprone-easily-swappable-parameters)
+void TrapezoidalMethodSequential::CreateTaskData(std::shared_ptr<ppc::core::TaskData> &task_data, TaskContext &context,
                                                  double *out) {
-  // TaskContext context{.function = f, .bounds = bounds, .precision = precision};
-  task_data->inputs.emplace_back(
-      reinterpret_cast<uint8_t *>(new TaskContext{.function = f, .bounds = bounds, .precision = precision}));
-  task_data->inputs_count.emplace_back(bounds.size());
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(&context));
+  task_data->inputs_count.emplace_back(context.bounds.size());
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out));
   task_data->outputs_count.emplace_back(1);
 }
@@ -28,16 +24,14 @@ bool TrapezoidalMethodSequential::ValidationImpl() {
 }
 
 bool TrapezoidalMethodSequential::PreProcessingImpl() {
-  data_ = reinterpret_cast<TaskContext *>(task_data->inputs[0]);
+  data_ = *reinterpret_cast<TaskContext *>(task_data->inputs[0]);
   return true;
 }
 bool TrapezoidalMethodSequential::RunImpl() {
-  res_ = Integrator<kSequential>{}(data_->function, data_->bounds, data_->precision);
+  res_ = Integrator<kSequential>{}(data_.function, data_.bounds, data_.precision);
   return true;
 }
 bool TrapezoidalMethodSequential::PostProcessingImpl() {
   *reinterpret_cast<double *>(task_data->outputs[0]) = res_;
   return true;
 }
-
-TrapezoidalMethodSequential::~TrapezoidalMethodSequential() { delete data_; }

--- a/tasks/seq/khasanyanov_k_trapezoid_method/src/integrate_seq.cpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/src/integrate_seq.cpp
@@ -19,7 +19,6 @@ void TrapezoidalMethodSequential::CreateTaskData(std::shared_ptr<ppc::core::Task
 
 bool TrapezoidalMethodSequential::ValidationImpl() {
   auto *data = reinterpret_cast<TaskContext *>(task_data->inputs[0]);
-  std::cout << data;
   return data != nullptr && task_data->inputs_count[0] > 0 && task_data->outputs[0] != nullptr;
 }
 

--- a/tasks/seq/khasanyanov_k_trapezoid_method/src/integrate_seq.cpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/src/integrate_seq.cpp
@@ -1,7 +1,6 @@
 #include "../include/integrate_seq.hpp"
 
 #include <cstdint>
-#include <iostream>
 #include <memory>
 
 #include "core/task/include/task.hpp"

--- a/tasks/seq/khasanyanov_k_trapezoid_method/src/integrator.cpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/src/integrator.cpp
@@ -1,1 +1,0 @@
-// no code here

--- a/tasks/seq/khasanyanov_k_trapezoid_method/src/integrator.cpp
+++ b/tasks/seq/khasanyanov_k_trapezoid_method/src/integrator.cpp
@@ -1,0 +1,1 @@
+// no code here


### PR DESCRIPTION
Для вычисления многомерных интегралов используется метод трапеций, который заменяет интеграл конечной суммой по каждой из осей интегрирования. Интеграл вычисляется до получения заданной точности путём увеличения количества частей, на которые делится отрезок интегрирования. Так же для каждой точки вычисляется её вклад в результат путём вычисления веса заданной точки по определённой оси.