### PR TITLE
Борисов Сергей. Задача 1. Вариант 3. Технология SEQ. Умножение плотных матриц. Элементы типа double. Алгоритм Штрассена.

### DIFF
--- a/tasks/seq/borisov_s_strassen_seq/func_tests/main.cpp
+++ b/tasks/seq/borisov_s_strassen_seq/func_tests/main.cpp
@@ -1,0 +1,672 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "seq/borisov_s_strassen_seq/include/ops_seq.hpp"
+
+namespace {
+
+std::vector<double> MultiplyNaiveDouble(const std::vector<double>& A, const std::vector<double>& B, int rowsA,
+                                        int colsA, int colsB) {
+  std::vector<double> C(rowsA * colsB, 0.0);
+  for (int i = 0; i < rowsA; ++i) {
+    for (int j = 0; j < colsB; ++j) {
+      double sum = 0.0;
+      for (int k = 0; k < colsA; ++k) {
+        sum += A[(i * colsA) + k] * B[(k * colsB) + j];
+      }
+      C[(i * colsB) + j] = sum;
+    }
+  }
+  return C;
+}
+
+}  // namespace
+
+TEST(borisov_s_strassen_seq, OneByOne) {
+  std::vector<double> in_data = {1.0, 1.0, 1.0, 1.0, 7.5, 2.5};
+
+  size_t output_count = 3;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());  // Число элементов (double)
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_seq::SequentialStrassenSeq task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], 1.0);
+  EXPECT_DOUBLE_EQ(out_ptr[1], 1.0);
+  EXPECT_DOUBLE_EQ(out_ptr[2], 18.75);
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, TwoByTwo) {
+  std::vector<double> A = {1.0, 2.5, 3.0, 4.0};
+  std::vector<double> B = {1.5, 2.0, 0.5, 3.5};
+  std::vector<double> C_expected = {2.75, 10.75, 6.5, 20.0};
+
+  std::vector<double> in_data = {2.0, 2.0, 2.0, 2.0};
+  in_data.insert(in_data.end(), A.begin(), A.end());
+  in_data.insert(in_data.end(), B.begin(), B.end());
+
+  size_t output_count = 2 + 4;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_seq::SequentialStrassenSeq task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], 2.0);
+  EXPECT_DOUBLE_EQ(out_ptr[1], 2.0);
+  for (int i = 0; i < 4; ++i) {
+    EXPECT_NEAR(out_ptr[2 + i], C_expected[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Rectangular2x3_3x4) {
+  std::vector<double> A = {1.0, 2.5, 3.0, 4.0, 5.5, 6.0};
+  std::vector<double> B = {0.5, 1.0, 2.0, 1.5, 2.0, 0.5, 1.0, 3.0, 4.0, 2.5, 0.5, 1.0};
+
+  auto C_expected = MultiplyNaiveDouble(A, B, 2, 3, 4);
+
+  std::vector<double> in_data = {2.0, 3.0, 3.0, 4.0};
+  in_data.insert(in_data.end(), A.begin(), A.end());
+  in_data.insert(in_data.end(), B.begin(), B.end());
+
+  size_t output_count = 2 + (2 * 4);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_seq::SequentialStrassenSeq task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], 2.0);
+  EXPECT_DOUBLE_EQ(out_ptr[1], 4.0);
+
+  std::vector<double> C_result(2 * 4);
+  for (int i = 0; i < 2 * 4; ++i) {
+    C_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(C_expected.size(), C_result.size());
+  for (size_t i = 0; i < C_expected.size(); ++i) {
+    EXPECT_NEAR(C_expected[i], C_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Square5x5_Random) {
+  const int n = 5;
+  std::mt19937 rng(12345);
+  std::uniform_real_distribution<double> dist(0.0, 10.0);
+
+  std::vector<double> A(n * n);
+  std::vector<double> B(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    A[i] = dist(rng);
+    B[i] = dist(rng);
+  }
+
+  auto C_expected = MultiplyNaiveDouble(A, B, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), A.begin(), A.end());
+  in_data.insert(in_data.end(), B.begin(), B.end());
+
+  size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_seq::SequentialStrassenSeq task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], 5.0);
+  EXPECT_DOUBLE_EQ(out_ptr[1], 5.0);
+
+  std::vector<double> C_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    C_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(C_expected.size(), C_result.size());
+  for (size_t i = 0; i < C_expected.size(); ++i) {
+    EXPECT_NEAR(C_expected[i], C_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Square20x20_Random) {
+  const int n = 20;
+  std::mt19937 rng(7777);
+  std::uniform_real_distribution<double> dist(0.0, 1.0);
+
+  std::vector<double> A(n * n);
+  std::vector<double> B(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    A[i] = dist(rng);
+    B[i] = dist(rng);
+  }
+
+  auto C_expected = MultiplyNaiveDouble(A, B, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), A.begin(), A.end());
+  in_data.insert(in_data.end(), B.begin(), B.end());
+
+  size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_seq::SequentialStrassenSeq task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+  std::vector<double> C_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    C_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(C_expected.size(), C_result.size());
+  for (size_t i = 0; i < C_expected.size(); ++i) {
+    EXPECT_NEAR(C_expected[i], C_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Square32x32_Random) {
+  const int n = 32;
+  std::mt19937 rng(7777);
+  std::uniform_real_distribution<double> dist(0.0, 1.0);
+
+  std::vector<double> A(n * n);
+  std::vector<double> B(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    A[i] = dist(rng);
+    B[i] = dist(rng);
+  }
+
+  auto C_expected = MultiplyNaiveDouble(A, B, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), A.begin(), A.end());
+  in_data.insert(in_data.end(), B.begin(), B.end());
+
+  size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_seq::SequentialStrassenSeq task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+  std::vector<double> C_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    C_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(C_expected.size(), C_result.size());
+  for (size_t i = 0; i < C_expected.size(); ++i) {
+    EXPECT_NEAR(C_expected[i], C_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Square128x128_Random) {
+  const int n = 128;
+  std::mt19937 rng(7777);
+  std::uniform_real_distribution<double> dist(0.0, 1.0);
+
+  std::vector<double> A(n * n);
+  std::vector<double> B(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    A[i] = dist(rng);
+    B[i] = dist(rng);
+  }
+
+  auto C_expected = MultiplyNaiveDouble(A, B, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), A.begin(), A.end());
+  in_data.insert(in_data.end(), B.begin(), B.end());
+
+  size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_seq::SequentialStrassenSeq task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+  std::vector<double> C_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    C_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(C_expected.size(), C_result.size());
+  for (size_t i = 0; i < C_expected.size(); ++i) {
+    EXPECT_NEAR(C_expected[i], C_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Square129x129_Random) {
+  const int n = 129;
+  std::mt19937 rng(7777);
+  std::uniform_real_distribution<double> dist(0.0, 1.0);
+
+  std::vector<double> A(n * n);
+  std::vector<double> B(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    A[i] = dist(rng);
+    B[i] = dist(rng);
+  }
+
+  auto C_expected = MultiplyNaiveDouble(A, B, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), A.begin(), A.end());
+  in_data.insert(in_data.end(), B.begin(), B.end());
+
+  size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_seq::SequentialStrassenSeq task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+  std::vector<double> C_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    C_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(C_expected.size(), C_result.size());
+  for (size_t i = 0; i < C_expected.size(); ++i) {
+    EXPECT_NEAR(C_expected[i], C_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Square240x240_Random) {
+  const int n = 240;
+  std::mt19937 rng(7777);
+  std::uniform_real_distribution<double> dist(0.0, 1.0);
+
+  std::vector<double> A(n * n);
+  std::vector<double> B(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    A[i] = dist(rng);
+    B[i] = dist(rng);
+  }
+
+  auto C_expected = MultiplyNaiveDouble(A, B, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), A.begin(), A.end());
+  in_data.insert(in_data.end(), B.begin(), B.end());
+
+  size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_seq::SequentialStrassenSeq task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+  std::vector<double> C_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    C_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(C_expected.size(), C_result.size());
+  for (size_t i = 0; i < C_expected.size(); ++i) {
+    EXPECT_NEAR(C_expected[i], C_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, ValidCase) {
+  std::vector<int> input_data = {2, 3, 3, 2};
+  input_data.insert(input_data.end(), {1, 2, 3, 4, 5, 6});
+  input_data.insert(input_data.end(), {7, 8, 9, 10, 11, 12});
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(input_data.data()));
+  task_data->inputs_count.push_back(input_data.size());
+
+  task_data->outputs.push_back(nullptr);
+  task_data->outputs_count.push_back(0);
+
+  borisov_s_strassen_seq::SequentialStrassenSeq task(task_data);
+
+  task.PreProcessingImpl();
+
+  EXPECT_TRUE(task.ValidationImpl());
+}
+
+TEST(borisov_s_strassen_seq, MismatchCase) {
+  std::vector<double> input_data = {
+      2.0,
+      2.0,
+      3.0,
+      3.0,
+  };
+  input_data.insert(input_data.end(), {1.0, 2.0, 3.0, 4.0});
+  input_data.insert(input_data.end(), {5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0});
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(input_data.data()));
+  task_data->inputs_count.push_back(input_data.size());
+
+  task_data->outputs.push_back(nullptr);
+  task_data->outputs_count.push_back(0);
+
+  borisov_s_strassen_seq::SequentialStrassenSeq task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_FALSE(task.ValidationImpl());
+}
+
+TEST(borisov_s_strassen_seq, NotEnoughDataCase) {
+  std::vector<double> input_data = {2.0, 2.0, 2.0, 2.0};
+  input_data.insert(input_data.end(), {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(input_data.data()));
+  task_data->inputs_count.push_back(input_data.size());
+
+  task_data->outputs.push_back(nullptr);
+  task_data->outputs_count.push_back(0);
+
+  borisov_s_strassen_seq::SequentialStrassenSeq task(task_data);
+
+  task.PreProcessingImpl();
+
+  EXPECT_FALSE(task.ValidationImpl());
+}
+
+TEST(borisov_s_strassen_seq, Rectangular16x17_Random) {
+  const int rowsA = 32;
+  const int colsA = 34;
+  const int colsB = 35;
+
+  std::mt19937 rng(7777);
+  std::uniform_real_distribution<double> dist(0.0, 1.0);
+
+  std::vector<double> A(rowsA * colsA);
+  std::vector<double> B(colsA * colsB);
+  for (double& x : A) {
+    x = dist(rng);
+  }
+  for (double& x : B) {
+    x = dist(rng);
+  }
+
+  auto C_expected = MultiplyNaiveDouble(A, B, rowsA, colsA, colsB);
+
+  std::vector<double> in_data = {static_cast<double>(rowsA), static_cast<double>(colsA), static_cast<double>(colsA),
+                                 static_cast<double>(colsB)};
+  in_data.insert(in_data.end(), A.begin(), A.end());
+  in_data.insert(in_data.end(), B.begin(), B.end());
+
+  size_t output_count = 2 + (rowsA * colsB);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_seq::SequentialStrassenSeq task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(rowsA));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(colsB));
+
+  std::vector<double> C_result(rowsA * colsB);
+  for (int i = 0; i < rowsA * colsB; ++i) {
+    C_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(C_expected.size(), C_result.size());
+  for (size_t i = 0; i < C_expected.size(); ++i) {
+    EXPECT_NEAR(C_expected[i], C_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Rectangular19x23_Random) {
+  const int rowsA = 19;
+  const int colsA = 23;
+  const int colsB = 21;
+
+  std::mt19937 rng(777);
+  std::uniform_real_distribution<double> dist(0.0, 1.0);
+
+  std::vector<double> A(rowsA * colsA);
+  std::vector<double> B(colsA * colsB);
+  for (double& x : A) {
+    x = dist(rng);
+  }
+  for (double& x : B) {
+    x = dist(rng);
+  }
+
+  auto C_expected = MultiplyNaiveDouble(A, B, rowsA, colsA, colsB);
+
+  std::vector<double> in_data = {static_cast<double>(rowsA), static_cast<double>(colsA), static_cast<double>(colsA),
+                                 static_cast<double>(colsB)};
+  in_data.insert(in_data.end(), A.begin(), A.end());
+  in_data.insert(in_data.end(), B.begin(), B.end());
+
+  size_t output_count = 2 + (rowsA * colsB);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_seq::SequentialStrassenSeq task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(rowsA));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(colsB));
+
+  std::vector<double> C_result(rowsA * colsB);
+  for (int i = 0; i < rowsA * colsB; ++i) {
+    C_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(C_expected.size(), C_result.size());
+  for (size_t i = 0; i < C_expected.size(); ++i) {
+    EXPECT_NEAR(C_expected[i], C_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Rectangular32x64_Random) {
+  const int rowsA = 32;
+  const int colsA = 64;
+  const int colsB = 32;
+
+  std::mt19937 rng(7777);
+  std::uniform_real_distribution<double> dist(0.0, 1.0);
+
+  std::vector<double> A(rowsA * colsA);
+  std::vector<double> B(colsA * colsB);
+  for (double& x : A) {
+    x = dist(rng);
+  }
+  for (double& x : B) {
+    x = dist(rng);
+  }
+
+  auto C_expected = MultiplyNaiveDouble(A, B, rowsA, colsA, colsB);
+
+  std::vector<double> in_data = {static_cast<double>(rowsA), static_cast<double>(colsA), static_cast<double>(colsA),
+                                 static_cast<double>(colsB)};
+  in_data.insert(in_data.end(), A.begin(), A.end());
+  in_data.insert(in_data.end(), B.begin(), B.end());
+
+  size_t output_count = 2 + (rowsA * colsB);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  borisov_s_strassen_seq::SequentialStrassenSeq task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(rowsA));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(colsB));
+
+  std::vector<double> C_result(rowsA * colsB);
+  for (int i = 0; i < rowsA * colsB; ++i) {
+    C_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(C_expected.size(), C_result.size());
+  for (size_t i = 0; i < C_expected.size(); ++i) {
+    EXPECT_NEAR(C_expected[i], C_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}

--- a/tasks/seq/borisov_s_strassen_seq/func_tests/main.cpp
+++ b/tasks/seq/borisov_s_strassen_seq/func_tests/main.cpp
@@ -648,6 +648,10 @@ TEST(borisov_s_strassen_seq, Rectangular32x64_Random) {
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
   task_data->inputs_count.push_back(in_data.size());
 
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
   borisov_s_strassen_seq::SequentialStrassenSeq task(task_data);
 
   task.PreProcessingImpl();

--- a/tasks/seq/borisov_s_strassen_seq/func_tests/main.cpp
+++ b/tasks/seq/borisov_s_strassen_seq/func_tests/main.cpp
@@ -445,9 +445,9 @@ TEST(borisov_s_strassen_seq, Square240x240_Random) {
 }
 
 TEST(borisov_s_strassen_seq, ValidCase) {
-  std::vector<int> input_data = {2, 3, 3, 2};
-  input_data.insert(input_data.end(), {1, 2, 3, 4, 5, 6});
-  input_data.insert(input_data.end(), {7, 8, 9, 10, 11, 12});
+  std::vector<double> input_data = {2.0, 3.0, 3.0, 2.0};
+  input_data.insert(input_data.end(), {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
+  input_data.insert(input_data.end(), {7.0, 8.0, 9.0, 10.0, 11.0, 12.0});
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(input_data.data()));

--- a/tasks/seq/borisov_s_strassen_seq/func_tests/main.cpp
+++ b/tasks/seq/borisov_s_strassen_seq/func_tests/main.cpp
@@ -27,7 +27,6 @@ std::vector<double> MultiplyNaiveDouble(const std::vector<double>& a, const std:
   return c;
 }
 
-// Вынесем генерацию случайной матрицы:
 std::vector<double> GenerateRandomMatrix(int rows, int cols, std::mt19937& rng, double min_val = 0.0,
                                          double max_val = 1.0) {
   std::uniform_real_distribution<double> dist(min_val, max_val);
@@ -149,8 +148,6 @@ TEST(borisov_s_strassen_seq, Square5x5_Random) {
   const int n = 5;
   int tmp = 7777;
   std::mt19937 rng(tmp);
-  // Вместо std::uniform_real_distribution везде, используем GenerateRandomMatrix:
-  // Но оставим пример, если нужно:
   std::uniform_real_distribution<double> dist(0.0, 10.0);
 
   std::vector<double> a(n * n);

--- a/tasks/seq/borisov_s_strassen_seq/func_tests/main.cpp
+++ b/tasks/seq/borisov_s_strassen_seq/func_tests/main.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <random>
@@ -25,12 +26,23 @@ std::vector<double> MultiplyNaiveDouble(const std::vector<double>& a, const std:
   return c;
 }
 
+// Вынесем генерацию случайной матрицы:
+std::vector<double> GenerateRandomMatrix(int rows, int cols, std::mt19937& rng, double min_val = 0.0,
+                                         double max_val = 1.0) {
+  std::uniform_real_distribution<double> dist(min_val, max_val);
+  std::vector<double> matrix(rows * cols);
+  for (double& x : matrix) {
+    x = dist(rng);
+  }
+  return matrix;
+}
+
 }  // namespace
 
 TEST(borisov_s_strassen_seq, OneByOne) {
   std::vector<double> in_data = {1.0, 1.0, 1.0, 1.0, 7.5, 2.5};
 
-  size_t output_count = 3;
+  std::size_t output_count = 3;
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -63,7 +75,7 @@ TEST(borisov_s_strassen_seq, TwoByTwo) {
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), b.begin(), b.end());
 
-  size_t output_count = 2 + 4;
+  std::size_t output_count = 2 + 4;
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -99,7 +111,7 @@ TEST(borisov_s_strassen_seq, Rectangular2x3_3x4) {
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), b.begin(), b.end());
 
-  size_t output_count = 2 + (2 * 4);
+  std::size_t output_count = 2 + (2 * 4);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -125,7 +137,7 @@ TEST(borisov_s_strassen_seq, Rectangular2x3_3x4) {
   }
 
   ASSERT_EQ(c_expected.size(), c_result.size());
-  for (size_t i = 0; i < c_expected.size(); ++i) {
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
     EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
   }
 
@@ -136,6 +148,8 @@ TEST(borisov_s_strassen_seq, Square5x5_Random) {
   const int n = 5;
   int tmp = 7777;
   std::mt19937 rng(tmp);
+  // Вместо std::uniform_real_distribution везде, используем GenerateRandomMatrix:
+  // Но оставим пример, если нужно:
   std::uniform_real_distribution<double> dist(0.0, 10.0);
 
   std::vector<double> a(n * n);
@@ -152,7 +166,7 @@ TEST(borisov_s_strassen_seq, Square5x5_Random) {
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), b.begin(), b.end());
 
-  size_t output_count = 2 + (n * n);
+  std::size_t output_count = 2 + (n * n);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -169,8 +183,8 @@ TEST(borisov_s_strassen_seq, Square5x5_Random) {
   task.RunImpl();
   task.PostProcessingImpl();
 
-  EXPECT_DOUBLE_EQ(out_ptr[0], 5.0);
-  EXPECT_DOUBLE_EQ(out_ptr[1], 5.0);
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
 
   std::vector<double> c_result(n * n);
   for (int i = 0; i < n * n; ++i) {
@@ -178,7 +192,7 @@ TEST(borisov_s_strassen_seq, Square5x5_Random) {
   }
 
   ASSERT_EQ(c_expected.size(), c_result.size());
-  for (size_t i = 0; i < c_expected.size(); ++i) {
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
     EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
   }
 
@@ -205,7 +219,7 @@ TEST(borisov_s_strassen_seq, Square20x20_Random) {
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), b.begin(), b.end());
 
-  size_t output_count = 2 + (n * n);
+  std::size_t output_count = 2 + (n * n);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -231,7 +245,7 @@ TEST(borisov_s_strassen_seq, Square20x20_Random) {
   }
 
   ASSERT_EQ(c_expected.size(), c_result.size());
-  for (size_t i = 0; i < c_expected.size(); ++i) {
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
     EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
   }
 
@@ -258,7 +272,7 @@ TEST(borisov_s_strassen_seq, Square32x32_Random) {
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), b.begin(), b.end());
 
-  size_t output_count = 2 + (n * n);
+  std::size_t output_count = 2 + (n * n);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -284,7 +298,7 @@ TEST(borisov_s_strassen_seq, Square32x32_Random) {
   }
 
   ASSERT_EQ(c_expected.size(), c_result.size());
-  for (size_t i = 0; i < c_expected.size(); ++i) {
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
     EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
   }
 
@@ -311,7 +325,7 @@ TEST(borisov_s_strassen_seq, Square128x128_Random) {
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), b.begin(), b.end());
 
-  size_t output_count = 2 + (n * n);
+  std::size_t output_count = 2 + (n * n);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -337,7 +351,7 @@ TEST(borisov_s_strassen_seq, Square128x128_Random) {
   }
 
   ASSERT_EQ(c_expected.size(), c_result.size());
-  for (size_t i = 0; i < c_expected.size(); ++i) {
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
     EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
   }
 
@@ -364,7 +378,7 @@ TEST(borisov_s_strassen_seq, Square129x129_Random) {
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), b.begin(), b.end());
 
-  size_t output_count = 2 + (n * n);
+  std::size_t output_count = 2 + (n * n);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -390,7 +404,7 @@ TEST(borisov_s_strassen_seq, Square129x129_Random) {
   }
 
   ASSERT_EQ(c_expected.size(), c_result.size());
-  for (size_t i = 0; i < c_expected.size(); ++i) {
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
     EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
   }
 
@@ -417,7 +431,7 @@ TEST(borisov_s_strassen_seq, Square240x240_Random) {
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), b.begin(), b.end());
 
-  size_t output_count = 2 + (n * n);
+  std::size_t output_count = 2 + (n * n);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -443,7 +457,7 @@ TEST(borisov_s_strassen_seq, Square240x240_Random) {
   }
 
   ASSERT_EQ(c_expected.size(), c_result.size());
-  for (size_t i = 0; i < c_expected.size(); ++i) {
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
     EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
   }
 
@@ -511,22 +525,15 @@ TEST(borisov_s_strassen_seq, NotEnoughDataCase) {
 }
 
 TEST(borisov_s_strassen_seq, Rectangular16x17_Random) {
-  const int rows_a = 32;
-  const int cols_a = 34;
-  const int cols_b = 35;
+  const int rows_a = 16;
+  const int cols_a = 17;
+  const int cols_b = 18;
 
   int tmp = 7777;
   std::mt19937 rng(tmp);
-  std::uniform_real_distribution<double> dist(0.0, 1.0);
 
-  std::vector<double> a(rows_a * cols_a);
-  std::vector<double> b(cols_a * cols_b);
-  for (double& x : a) {
-    x = dist(rng);
-  }
-  for (double& x : b) {
-    x = dist(rng);
-  }
+  std::vector<double> a = GenerateRandomMatrix(rows_a, cols_a, rng);
+  std::vector<double> b = GenerateRandomMatrix(cols_a, cols_b, rng);
 
   auto c_expected = MultiplyNaiveDouble(a, b, rows_a, cols_a, cols_b);
 
@@ -535,7 +542,7 @@ TEST(borisov_s_strassen_seq, Rectangular16x17_Random) {
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), b.begin(), b.end());
 
-  size_t output_count = 2 + (rows_a * cols_b);
+  std::size_t output_count = 2 + (rows_a * cols_b);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -561,7 +568,7 @@ TEST(borisov_s_strassen_seq, Rectangular16x17_Random) {
   }
 
   ASSERT_EQ(c_expected.size(), c_result.size());
-  for (size_t i = 0; i < c_expected.size(); ++i) {
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
     EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
   }
 
@@ -575,16 +582,9 @@ TEST(borisov_s_strassen_seq, Rectangular19x23_Random) {
 
   int tmp = 7777;
   std::mt19937 rng(tmp);
-  std::uniform_real_distribution<double> dist(0.0, 1.0);
 
-  std::vector<double> a(rows_a * cols_a);
-  std::vector<double> b(cols_a * cols_b);
-  for (double& x : a) {
-    x = dist(rng);
-  }
-  for (double& x : b) {
-    x = dist(rng);
-  }
+  std::vector<double> a = GenerateRandomMatrix(rows_a, cols_a, rng);
+  std::vector<double> b = GenerateRandomMatrix(cols_a, cols_b, rng);
 
   auto c_expected = MultiplyNaiveDouble(a, b, rows_a, cols_a, cols_b);
 
@@ -593,7 +593,7 @@ TEST(borisov_s_strassen_seq, Rectangular19x23_Random) {
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), b.begin(), b.end());
 
-  size_t output_count = 2 + (rows_a * cols_b);
+  std::size_t output_count = 2 + (rows_a * cols_b);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -619,7 +619,7 @@ TEST(borisov_s_strassen_seq, Rectangular19x23_Random) {
   }
 
   ASSERT_EQ(c_expected.size(), c_result.size());
-  for (size_t i = 0; i < c_expected.size(); ++i) {
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
     EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
   }
 
@@ -633,16 +633,9 @@ TEST(borisov_s_strassen_seq, Rectangular32x64_Random) {
 
   int tmp = 7777;
   std::mt19937 rng(tmp);
-  std::uniform_real_distribution<double> dist(0.0, 1.0);
 
-  std::vector<double> a(rows_a * cols_a);
-  std::vector<double> b(cols_a * cols_b);
-  for (double& x : a) {
-    x = dist(rng);
-  }
-  for (double& x : b) {
-    x = dist(rng);
-  }
+  std::vector<double> a = GenerateRandomMatrix(rows_a, cols_a, rng);
+  std::vector<double> b = GenerateRandomMatrix(cols_a, cols_b, rng);
 
   auto c_expected = MultiplyNaiveDouble(a, b, rows_a, cols_a, cols_b);
 
@@ -651,7 +644,7 @@ TEST(borisov_s_strassen_seq, Rectangular32x64_Random) {
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), b.begin(), b.end());
 
-  size_t output_count = 2 + (rows_a * cols_b);
+  std::size_t output_count = 2 + (rows_a * cols_b);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -677,7 +670,7 @@ TEST(borisov_s_strassen_seq, Rectangular32x64_Random) {
   }
 
   ASSERT_EQ(c_expected.size(), c_result.size());
-  for (size_t i = 0; i < c_expected.size(); ++i) {
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
     EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
   }
 

--- a/tasks/seq/borisov_s_strassen_seq/func_tests/main.cpp
+++ b/tasks/seq/borisov_s_strassen_seq/func_tests/main.cpp
@@ -329,6 +329,54 @@ TEST(borisov_s_strassen_seq, Square128x128_Random) {
   delete[] out_ptr;
 }
 
+TEST(borisov_s_strassen_seq, Square128x128_IdentityMatrix) {
+  const int n = 128;
+
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777, 0.0, 1.0);
+
+  std::vector<double> e(n * n, 0.0);
+  for (int i = 0; i < n; ++i) {
+    e[(i * n) + i] = 1.0;
+  }
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), e.begin(), e.end());
+
+  std::size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_seq::SequentialStrassenSeq task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+  std::vector<double> c_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(a.size(), c_result.size());
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    EXPECT_NEAR(a[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
 TEST(borisov_s_strassen_seq, Square129x129_Random) {
   const int n = 129;
 

--- a/tasks/seq/borisov_s_strassen_seq/func_tests/main.cpp
+++ b/tasks/seq/borisov_s_strassen_seq/func_tests/main.cpp
@@ -7,6 +7,7 @@
 #include <random>
 #include <vector>
 
+#include "core/task/include/task.hpp"
 #include "seq/borisov_s_strassen_seq/include/ops_seq.hpp"
 
 namespace {

--- a/tasks/seq/borisov_s_strassen_seq/func_tests/main.cpp
+++ b/tasks/seq/borisov_s_strassen_seq/func_tests/main.cpp
@@ -10,19 +10,19 @@
 
 namespace {
 
-std::vector<double> MultiplyNaiveDouble(const std::vector<double>& A, const std::vector<double>& B, int rowsA,
-                                        int colsA, int colsB) {
-  std::vector<double> C(rowsA * colsB, 0.0);
-  for (int i = 0; i < rowsA; ++i) {
-    for (int j = 0; j < colsB; ++j) {
+std::vector<double> MultiplyNaiveDouble(const std::vector<double>& a, const std::vector<double>& b, int rows_a,
+                                        int cols_a, int cols_b) {
+  std::vector<double> c(rows_a * cols_b, 0.0);
+  for (int i = 0; i < rows_a; ++i) {
+    for (int j = 0; j < cols_b; ++j) {
       double sum = 0.0;
-      for (int k = 0; k < colsA; ++k) {
-        sum += A[(i * colsA) + k] * B[(k * colsB) + j];
+      for (int k = 0; k < cols_a; ++k) {
+        sum += a[(i * cols_a) + k] * b[(k * cols_b) + j];
       }
-      C[(i * colsB) + j] = sum;
+      c[(i * cols_b) + j] = sum;
     }
   }
-  return C;
+  return c;
 }
 
 }  // namespace
@@ -34,7 +34,7 @@ TEST(borisov_s_strassen_seq, OneByOne) {
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
-  task_data->inputs_count.push_back(in_data.size());  // Число элементов (double)
+  task_data->inputs_count.push_back(in_data.size());
 
   auto* out_ptr = new double[output_count]();
   task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
@@ -55,13 +55,13 @@ TEST(borisov_s_strassen_seq, OneByOne) {
 }
 
 TEST(borisov_s_strassen_seq, TwoByTwo) {
-  std::vector<double> A = {1.0, 2.5, 3.0, 4.0};
-  std::vector<double> B = {1.5, 2.0, 0.5, 3.5};
-  std::vector<double> C_expected = {2.75, 10.75, 6.5, 20.0};
+  std::vector<double> a = {1.0, 2.5, 3.0, 4.0};
+  std::vector<double> b = {1.5, 2.0, 0.5, 3.5};
+  std::vector<double> c_expected = {2.75, 10.75, 6.5, 20.0};
 
   std::vector<double> in_data = {2.0, 2.0, 2.0, 2.0};
-  in_data.insert(in_data.end(), A.begin(), A.end());
-  in_data.insert(in_data.end(), B.begin(), B.end());
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
 
   size_t output_count = 2 + 4;
 
@@ -83,21 +83,21 @@ TEST(borisov_s_strassen_seq, TwoByTwo) {
   EXPECT_DOUBLE_EQ(out_ptr[0], 2.0);
   EXPECT_DOUBLE_EQ(out_ptr[1], 2.0);
   for (int i = 0; i < 4; ++i) {
-    EXPECT_NEAR(out_ptr[2 + i], C_expected[i], 1e-9);
+    EXPECT_NEAR(out_ptr[2 + i], c_expected[i], 1e-9);
   }
 
   delete[] out_ptr;
 }
 
 TEST(borisov_s_strassen_seq, Rectangular2x3_3x4) {
-  std::vector<double> A = {1.0, 2.5, 3.0, 4.0, 5.5, 6.0};
-  std::vector<double> B = {0.5, 1.0, 2.0, 1.5, 2.0, 0.5, 1.0, 3.0, 4.0, 2.5, 0.5, 1.0};
+  std::vector<double> a = {1.0, 2.5, 3.0, 4.0, 5.5, 6.0};
+  std::vector<double> b = {0.5, 1.0, 2.0, 1.5, 2.0, 0.5, 1.0, 3.0, 4.0, 2.5, 0.5, 1.0};
 
-  auto C_expected = MultiplyNaiveDouble(A, B, 2, 3, 4);
+  auto c_expected = MultiplyNaiveDouble(a, b, 2, 3, 4);
 
   std::vector<double> in_data = {2.0, 3.0, 3.0, 4.0};
-  in_data.insert(in_data.end(), A.begin(), A.end());
-  in_data.insert(in_data.end(), B.begin(), B.end());
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
 
   size_t output_count = 2 + (2 * 4);
 
@@ -119,14 +119,14 @@ TEST(borisov_s_strassen_seq, Rectangular2x3_3x4) {
   EXPECT_DOUBLE_EQ(out_ptr[0], 2.0);
   EXPECT_DOUBLE_EQ(out_ptr[1], 4.0);
 
-  std::vector<double> C_result(2 * 4);
+  std::vector<double> c_result(2 * 4);
   for (int i = 0; i < 2 * 4; ++i) {
-    C_result[i] = out_ptr[2 + i];
+    c_result[i] = out_ptr[2 + i];
   }
 
-  ASSERT_EQ(C_expected.size(), C_result.size());
-  for (size_t i = 0; i < C_expected.size(); ++i) {
-    EXPECT_NEAR(C_expected[i], C_result[i], 1e-9);
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
   }
 
   delete[] out_ptr;
@@ -134,22 +134,23 @@ TEST(borisov_s_strassen_seq, Rectangular2x3_3x4) {
 
 TEST(borisov_s_strassen_seq, Square5x5_Random) {
   const int n = 5;
-  std::mt19937 rng(12345);
+  int tmp = 7777;
+  std::mt19937 rng(tmp);
   std::uniform_real_distribution<double> dist(0.0, 10.0);
 
-  std::vector<double> A(n * n);
-  std::vector<double> B(n * n);
+  std::vector<double> a(n * n);
+  std::vector<double> b(n * n);
   for (int i = 0; i < n * n; ++i) {
-    A[i] = dist(rng);
-    B[i] = dist(rng);
+    a[i] = dist(rng);
+    b[i] = dist(rng);
   }
 
-  auto C_expected = MultiplyNaiveDouble(A, B, n, n, n);
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
 
   std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
                                  static_cast<double>(n)};
-  in_data.insert(in_data.end(), A.begin(), A.end());
-  in_data.insert(in_data.end(), B.begin(), B.end());
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
 
   size_t output_count = 2 + (n * n);
 
@@ -171,14 +172,14 @@ TEST(borisov_s_strassen_seq, Square5x5_Random) {
   EXPECT_DOUBLE_EQ(out_ptr[0], 5.0);
   EXPECT_DOUBLE_EQ(out_ptr[1], 5.0);
 
-  std::vector<double> C_result(n * n);
+  std::vector<double> c_result(n * n);
   for (int i = 0; i < n * n; ++i) {
-    C_result[i] = out_ptr[2 + i];
+    c_result[i] = out_ptr[2 + i];
   }
 
-  ASSERT_EQ(C_expected.size(), C_result.size());
-  for (size_t i = 0; i < C_expected.size(); ++i) {
-    EXPECT_NEAR(C_expected[i], C_result[i], 1e-9);
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
   }
 
   delete[] out_ptr;
@@ -186,22 +187,23 @@ TEST(borisov_s_strassen_seq, Square5x5_Random) {
 
 TEST(borisov_s_strassen_seq, Square20x20_Random) {
   const int n = 20;
-  std::mt19937 rng(7777);
+  int tmp = 7777;
+  std::mt19937 rng(tmp);
   std::uniform_real_distribution<double> dist(0.0, 1.0);
 
-  std::vector<double> A(n * n);
-  std::vector<double> B(n * n);
+  std::vector<double> a(n * n);
+  std::vector<double> b(n * n);
   for (int i = 0; i < n * n; ++i) {
-    A[i] = dist(rng);
-    B[i] = dist(rng);
+    a[i] = dist(rng);
+    b[i] = dist(rng);
   }
 
-  auto C_expected = MultiplyNaiveDouble(A, B, n, n, n);
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
 
   std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
                                  static_cast<double>(n)};
-  in_data.insert(in_data.end(), A.begin(), A.end());
-  in_data.insert(in_data.end(), B.begin(), B.end());
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
 
   size_t output_count = 2 + (n * n);
 
@@ -223,14 +225,14 @@ TEST(borisov_s_strassen_seq, Square20x20_Random) {
   EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
   EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
 
-  std::vector<double> C_result(n * n);
+  std::vector<double> c_result(n * n);
   for (int i = 0; i < n * n; ++i) {
-    C_result[i] = out_ptr[2 + i];
+    c_result[i] = out_ptr[2 + i];
   }
 
-  ASSERT_EQ(C_expected.size(), C_result.size());
-  for (size_t i = 0; i < C_expected.size(); ++i) {
-    EXPECT_NEAR(C_expected[i], C_result[i], 1e-9);
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
   }
 
   delete[] out_ptr;
@@ -238,22 +240,23 @@ TEST(borisov_s_strassen_seq, Square20x20_Random) {
 
 TEST(borisov_s_strassen_seq, Square32x32_Random) {
   const int n = 32;
-  std::mt19937 rng(7777);
+  int tmp = 7777;
+  std::mt19937 rng(tmp);
   std::uniform_real_distribution<double> dist(0.0, 1.0);
 
-  std::vector<double> A(n * n);
-  std::vector<double> B(n * n);
+  std::vector<double> a(n * n);
+  std::vector<double> b(n * n);
   for (int i = 0; i < n * n; ++i) {
-    A[i] = dist(rng);
-    B[i] = dist(rng);
+    a[i] = dist(rng);
+    b[i] = dist(rng);
   }
 
-  auto C_expected = MultiplyNaiveDouble(A, B, n, n, n);
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
 
   std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
                                  static_cast<double>(n)};
-  in_data.insert(in_data.end(), A.begin(), A.end());
-  in_data.insert(in_data.end(), B.begin(), B.end());
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
 
   size_t output_count = 2 + (n * n);
 
@@ -275,14 +278,14 @@ TEST(borisov_s_strassen_seq, Square32x32_Random) {
   EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
   EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
 
-  std::vector<double> C_result(n * n);
+  std::vector<double> c_result(n * n);
   for (int i = 0; i < n * n; ++i) {
-    C_result[i] = out_ptr[2 + i];
+    c_result[i] = out_ptr[2 + i];
   }
 
-  ASSERT_EQ(C_expected.size(), C_result.size());
-  for (size_t i = 0; i < C_expected.size(); ++i) {
-    EXPECT_NEAR(C_expected[i], C_result[i], 1e-9);
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
   }
 
   delete[] out_ptr;
@@ -290,22 +293,23 @@ TEST(borisov_s_strassen_seq, Square32x32_Random) {
 
 TEST(borisov_s_strassen_seq, Square128x128_Random) {
   const int n = 128;
-  std::mt19937 rng(7777);
+  int tmp = 7777;
+  std::mt19937 rng(tmp);
   std::uniform_real_distribution<double> dist(0.0, 1.0);
 
-  std::vector<double> A(n * n);
-  std::vector<double> B(n * n);
+  std::vector<double> a(n * n);
+  std::vector<double> b(n * n);
   for (int i = 0; i < n * n; ++i) {
-    A[i] = dist(rng);
-    B[i] = dist(rng);
+    a[i] = dist(rng);
+    b[i] = dist(rng);
   }
 
-  auto C_expected = MultiplyNaiveDouble(A, B, n, n, n);
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
 
   std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
                                  static_cast<double>(n)};
-  in_data.insert(in_data.end(), A.begin(), A.end());
-  in_data.insert(in_data.end(), B.begin(), B.end());
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
 
   size_t output_count = 2 + (n * n);
 
@@ -327,14 +331,14 @@ TEST(borisov_s_strassen_seq, Square128x128_Random) {
   EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
   EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
 
-  std::vector<double> C_result(n * n);
+  std::vector<double> c_result(n * n);
   for (int i = 0; i < n * n; ++i) {
-    C_result[i] = out_ptr[2 + i];
+    c_result[i] = out_ptr[2 + i];
   }
 
-  ASSERT_EQ(C_expected.size(), C_result.size());
-  for (size_t i = 0; i < C_expected.size(); ++i) {
-    EXPECT_NEAR(C_expected[i], C_result[i], 1e-9);
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
   }
 
   delete[] out_ptr;
@@ -342,22 +346,23 @@ TEST(borisov_s_strassen_seq, Square128x128_Random) {
 
 TEST(borisov_s_strassen_seq, Square129x129_Random) {
   const int n = 129;
-  std::mt19937 rng(7777);
+  int tmp = 7777;
+  std::mt19937 rng(tmp);
   std::uniform_real_distribution<double> dist(0.0, 1.0);
 
-  std::vector<double> A(n * n);
-  std::vector<double> B(n * n);
+  std::vector<double> a(n * n);
+  std::vector<double> b(n * n);
   for (int i = 0; i < n * n; ++i) {
-    A[i] = dist(rng);
-    B[i] = dist(rng);
+    a[i] = dist(rng);
+    b[i] = dist(rng);
   }
 
-  auto C_expected = MultiplyNaiveDouble(A, B, n, n, n);
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
 
   std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
                                  static_cast<double>(n)};
-  in_data.insert(in_data.end(), A.begin(), A.end());
-  in_data.insert(in_data.end(), B.begin(), B.end());
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
 
   size_t output_count = 2 + (n * n);
 
@@ -379,14 +384,14 @@ TEST(borisov_s_strassen_seq, Square129x129_Random) {
   EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
   EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
 
-  std::vector<double> C_result(n * n);
+  std::vector<double> c_result(n * n);
   for (int i = 0; i < n * n; ++i) {
-    C_result[i] = out_ptr[2 + i];
+    c_result[i] = out_ptr[2 + i];
   }
 
-  ASSERT_EQ(C_expected.size(), C_result.size());
-  for (size_t i = 0; i < C_expected.size(); ++i) {
-    EXPECT_NEAR(C_expected[i], C_result[i], 1e-9);
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
   }
 
   delete[] out_ptr;
@@ -394,22 +399,23 @@ TEST(borisov_s_strassen_seq, Square129x129_Random) {
 
 TEST(borisov_s_strassen_seq, Square240x240_Random) {
   const int n = 240;
-  std::mt19937 rng(7777);
+  int tmp = 7777;
+  std::mt19937 rng(tmp);
   std::uniform_real_distribution<double> dist(0.0, 1.0);
 
-  std::vector<double> A(n * n);
-  std::vector<double> B(n * n);
+  std::vector<double> a(n * n);
+  std::vector<double> b(n * n);
   for (int i = 0; i < n * n; ++i) {
-    A[i] = dist(rng);
-    B[i] = dist(rng);
+    a[i] = dist(rng);
+    b[i] = dist(rng);
   }
 
-  auto C_expected = MultiplyNaiveDouble(A, B, n, n, n);
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
 
   std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
                                  static_cast<double>(n)};
-  in_data.insert(in_data.end(), A.begin(), A.end());
-  in_data.insert(in_data.end(), B.begin(), B.end());
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
 
   size_t output_count = 2 + (n * n);
 
@@ -431,14 +437,14 @@ TEST(borisov_s_strassen_seq, Square240x240_Random) {
   EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
   EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
 
-  std::vector<double> C_result(n * n);
+  std::vector<double> c_result(n * n);
   for (int i = 0; i < n * n; ++i) {
-    C_result[i] = out_ptr[2 + i];
+    c_result[i] = out_ptr[2 + i];
   }
 
-  ASSERT_EQ(C_expected.size(), C_result.size());
-  for (size_t i = 0; i < C_expected.size(); ++i) {
-    EXPECT_NEAR(C_expected[i], C_result[i], 1e-9);
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
   }
 
   delete[] out_ptr;
@@ -505,30 +511,31 @@ TEST(borisov_s_strassen_seq, NotEnoughDataCase) {
 }
 
 TEST(borisov_s_strassen_seq, Rectangular16x17_Random) {
-  const int rowsA = 32;
-  const int colsA = 34;
-  const int colsB = 35;
+  const int rows_a = 32;
+  const int cols_a = 34;
+  const int cols_b = 35;
 
-  std::mt19937 rng(7777);
+  int tmp = 7777;
+  std::mt19937 rng(tmp);
   std::uniform_real_distribution<double> dist(0.0, 1.0);
 
-  std::vector<double> A(rowsA * colsA);
-  std::vector<double> B(colsA * colsB);
-  for (double& x : A) {
+  std::vector<double> a(rows_a * cols_a);
+  std::vector<double> b(cols_a * cols_b);
+  for (double& x : a) {
     x = dist(rng);
   }
-  for (double& x : B) {
+  for (double& x : b) {
     x = dist(rng);
   }
 
-  auto C_expected = MultiplyNaiveDouble(A, B, rowsA, colsA, colsB);
+  auto c_expected = MultiplyNaiveDouble(a, b, rows_a, cols_a, cols_b);
 
-  std::vector<double> in_data = {static_cast<double>(rowsA), static_cast<double>(colsA), static_cast<double>(colsA),
-                                 static_cast<double>(colsB)};
-  in_data.insert(in_data.end(), A.begin(), A.end());
-  in_data.insert(in_data.end(), B.begin(), B.end());
+  std::vector<double> in_data = {static_cast<double>(rows_a), static_cast<double>(cols_a), static_cast<double>(cols_a),
+                                 static_cast<double>(cols_b)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
 
-  size_t output_count = 2 + (rowsA * colsB);
+  size_t output_count = 2 + (rows_a * cols_b);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -545,47 +552,48 @@ TEST(borisov_s_strassen_seq, Rectangular16x17_Random) {
   task.RunImpl();
   task.PostProcessingImpl();
 
-  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(rowsA));
-  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(colsB));
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(rows_a));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(cols_b));
 
-  std::vector<double> C_result(rowsA * colsB);
-  for (int i = 0; i < rowsA * colsB; ++i) {
-    C_result[i] = out_ptr[2 + i];
+  std::vector<double> c_result(rows_a * cols_b);
+  for (int i = 0; i < rows_a * cols_b; ++i) {
+    c_result[i] = out_ptr[2 + i];
   }
 
-  ASSERT_EQ(C_expected.size(), C_result.size());
-  for (size_t i = 0; i < C_expected.size(); ++i) {
-    EXPECT_NEAR(C_expected[i], C_result[i], 1e-9);
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
   }
 
   delete[] out_ptr;
 }
 
 TEST(borisov_s_strassen_seq, Rectangular19x23_Random) {
-  const int rowsA = 19;
-  const int colsA = 23;
-  const int colsB = 21;
+  const int rows_a = 19;
+  const int cols_a = 23;
+  const int cols_b = 21;
 
-  std::mt19937 rng(777);
+  int tmp = 7777;
+  std::mt19937 rng(tmp);
   std::uniform_real_distribution<double> dist(0.0, 1.0);
 
-  std::vector<double> A(rowsA * colsA);
-  std::vector<double> B(colsA * colsB);
-  for (double& x : A) {
+  std::vector<double> a(rows_a * cols_a);
+  std::vector<double> b(cols_a * cols_b);
+  for (double& x : a) {
     x = dist(rng);
   }
-  for (double& x : B) {
+  for (double& x : b) {
     x = dist(rng);
   }
 
-  auto C_expected = MultiplyNaiveDouble(A, B, rowsA, colsA, colsB);
+  auto c_expected = MultiplyNaiveDouble(a, b, rows_a, cols_a, cols_b);
 
-  std::vector<double> in_data = {static_cast<double>(rowsA), static_cast<double>(colsA), static_cast<double>(colsA),
-                                 static_cast<double>(colsB)};
-  in_data.insert(in_data.end(), A.begin(), A.end());
-  in_data.insert(in_data.end(), B.begin(), B.end());
+  std::vector<double> in_data = {static_cast<double>(rows_a), static_cast<double>(cols_a), static_cast<double>(cols_a),
+                                 static_cast<double>(cols_b)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
 
-  size_t output_count = 2 + (rowsA * colsB);
+  size_t output_count = 2 + (rows_a * cols_b);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -602,47 +610,48 @@ TEST(borisov_s_strassen_seq, Rectangular19x23_Random) {
   task.RunImpl();
   task.PostProcessingImpl();
 
-  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(rowsA));
-  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(colsB));
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(rows_a));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(cols_b));
 
-  std::vector<double> C_result(rowsA * colsB);
-  for (int i = 0; i < rowsA * colsB; ++i) {
-    C_result[i] = out_ptr[2 + i];
+  std::vector<double> c_result(rows_a * cols_b);
+  for (int i = 0; i < rows_a * cols_b; ++i) {
+    c_result[i] = out_ptr[2 + i];
   }
 
-  ASSERT_EQ(C_expected.size(), C_result.size());
-  for (size_t i = 0; i < C_expected.size(); ++i) {
-    EXPECT_NEAR(C_expected[i], C_result[i], 1e-9);
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
   }
 
   delete[] out_ptr;
 }
 
 TEST(borisov_s_strassen_seq, Rectangular32x64_Random) {
-  const int rowsA = 32;
-  const int colsA = 64;
-  const int colsB = 32;
+  const int rows_a = 32;
+  const int cols_a = 64;
+  const int cols_b = 32;
 
-  std::mt19937 rng(7777);
+  int tmp = 7777;
+  std::mt19937 rng(tmp);
   std::uniform_real_distribution<double> dist(0.0, 1.0);
 
-  std::vector<double> A(rowsA * colsA);
-  std::vector<double> B(colsA * colsB);
-  for (double& x : A) {
+  std::vector<double> a(rows_a * cols_a);
+  std::vector<double> b(cols_a * cols_b);
+  for (double& x : a) {
     x = dist(rng);
   }
-  for (double& x : B) {
+  for (double& x : b) {
     x = dist(rng);
   }
 
-  auto C_expected = MultiplyNaiveDouble(A, B, rowsA, colsA, colsB);
+  auto c_expected = MultiplyNaiveDouble(a, b, rows_a, cols_a, cols_b);
 
-  std::vector<double> in_data = {static_cast<double>(rowsA), static_cast<double>(colsA), static_cast<double>(colsA),
-                                 static_cast<double>(colsB)};
-  in_data.insert(in_data.end(), A.begin(), A.end());
-  in_data.insert(in_data.end(), B.begin(), B.end());
+  std::vector<double> in_data = {static_cast<double>(rows_a), static_cast<double>(cols_a), static_cast<double>(cols_a),
+                                 static_cast<double>(cols_b)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
 
-  size_t output_count = 2 + (rowsA * colsB);
+  size_t output_count = 2 + (rows_a * cols_b);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -659,17 +668,17 @@ TEST(borisov_s_strassen_seq, Rectangular32x64_Random) {
   task.RunImpl();
   task.PostProcessingImpl();
 
-  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(rowsA));
-  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(colsB));
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(rows_a));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(cols_b));
 
-  std::vector<double> C_result(rowsA * colsB);
-  for (int i = 0; i < rowsA * colsB; ++i) {
-    C_result[i] = out_ptr[2 + i];
+  std::vector<double> c_result(rows_a * cols_b);
+  for (int i = 0; i < rows_a * cols_b; ++i) {
+    c_result[i] = out_ptr[2 + i];
   }
 
-  ASSERT_EQ(C_expected.size(), C_result.size());
-  for (size_t i = 0; i < C_expected.size(); ++i) {
-    EXPECT_NEAR(C_expected[i], C_result[i], 1e-9);
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
   }
 
   delete[] out_ptr;

--- a/tasks/seq/borisov_s_strassen_seq/func_tests/main.cpp
+++ b/tasks/seq/borisov_s_strassen_seq/func_tests/main.cpp
@@ -27,8 +27,9 @@ std::vector<double> MultiplyNaiveDouble(const std::vector<double>& a, const std:
   return c;
 }
 
-std::vector<double> GenerateRandomMatrix(int rows, int cols, std::mt19937& rng, double min_val = 0.0,
-                                         double max_val = 1.0) {
+std::vector<double> GenerateRandomMatrix(int rows, int cols, int seed, double min_val = 0.0, double max_val = 1.0) {
+  std::mt19937 rng(seed);
+
   std::uniform_real_distribution<double> dist(min_val, max_val);
   std::vector<double> matrix(rows * cols);
   for (double& x : matrix) {
@@ -146,16 +147,9 @@ TEST(borisov_s_strassen_seq, Rectangular2x3_3x4) {
 
 TEST(borisov_s_strassen_seq, Square5x5_Random) {
   const int n = 5;
-  int tmp = 7777;
-  std::mt19937 rng(tmp);
-  std::uniform_real_distribution<double> dist(0.0, 10.0);
 
-  std::vector<double> a(n * n);
-  std::vector<double> b(n * n);
-  for (int i = 0; i < n * n; ++i) {
-    a[i] = dist(rng);
-    b[i] = dist(rng);
-  }
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777, 0.0, 1.0);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777, 0.0, 1.0);
 
   auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
 
@@ -199,16 +193,9 @@ TEST(borisov_s_strassen_seq, Square5x5_Random) {
 
 TEST(borisov_s_strassen_seq, Square20x20_Random) {
   const int n = 20;
-  int tmp = 7777;
-  std::mt19937 rng(tmp);
-  std::uniform_real_distribution<double> dist(0.0, 1.0);
 
-  std::vector<double> a(n * n);
-  std::vector<double> b(n * n);
-  for (int i = 0; i < n * n; ++i) {
-    a[i] = dist(rng);
-    b[i] = dist(rng);
-  }
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777, 0.0, 1.0);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777, 0.0, 1.0);
 
   auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
 
@@ -252,16 +239,9 @@ TEST(borisov_s_strassen_seq, Square20x20_Random) {
 
 TEST(borisov_s_strassen_seq, Square32x32_Random) {
   const int n = 32;
-  int tmp = 7777;
-  std::mt19937 rng(tmp);
-  std::uniform_real_distribution<double> dist(0.0, 1.0);
 
-  std::vector<double> a(n * n);
-  std::vector<double> b(n * n);
-  for (int i = 0; i < n * n; ++i) {
-    a[i] = dist(rng);
-    b[i] = dist(rng);
-  }
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777, 0.0, 1.0);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777, 0.0, 1.0);
 
   auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
 
@@ -305,16 +285,9 @@ TEST(borisov_s_strassen_seq, Square32x32_Random) {
 
 TEST(borisov_s_strassen_seq, Square128x128_Random) {
   const int n = 128;
-  int tmp = 7777;
-  std::mt19937 rng(tmp);
-  std::uniform_real_distribution<double> dist(0.0, 1.0);
 
-  std::vector<double> a(n * n);
-  std::vector<double> b(n * n);
-  for (int i = 0; i < n * n; ++i) {
-    a[i] = dist(rng);
-    b[i] = dist(rng);
-  }
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777, 0.0, 1.0);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777, 0.0, 1.0);
 
   auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
 
@@ -358,16 +331,9 @@ TEST(borisov_s_strassen_seq, Square128x128_Random) {
 
 TEST(borisov_s_strassen_seq, Square129x129_Random) {
   const int n = 129;
-  int tmp = 7777;
-  std::mt19937 rng(tmp);
-  std::uniform_real_distribution<double> dist(0.0, 1.0);
 
-  std::vector<double> a(n * n);
-  std::vector<double> b(n * n);
-  for (int i = 0; i < n * n; ++i) {
-    a[i] = dist(rng);
-    b[i] = dist(rng);
-  }
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777, 0.0, 1.0);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777, 0.0, 1.0);
 
   auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
 
@@ -411,16 +377,9 @@ TEST(borisov_s_strassen_seq, Square129x129_Random) {
 
 TEST(borisov_s_strassen_seq, Square240x240_Random) {
   const int n = 240;
-  int tmp = 7777;
-  std::mt19937 rng(tmp);
-  std::uniform_real_distribution<double> dist(0.0, 1.0);
 
-  std::vector<double> a(n * n);
-  std::vector<double> b(n * n);
-  for (int i = 0; i < n * n; ++i) {
-    a[i] = dist(rng);
-    b[i] = dist(rng);
-  }
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777, 0.0, 1.0);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777, 0.0, 1.0);
 
   auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
 
@@ -527,11 +486,8 @@ TEST(borisov_s_strassen_seq, Rectangular16x17_Random) {
   const int cols_a = 17;
   const int cols_b = 18;
 
-  int tmp = 7777;
-  std::mt19937 rng(tmp);
-
-  std::vector<double> a = GenerateRandomMatrix(rows_a, cols_a, rng);
-  std::vector<double> b = GenerateRandomMatrix(cols_a, cols_b, rng);
+  std::vector<double> a = GenerateRandomMatrix(rows_a, cols_a, 7777);
+  std::vector<double> b = GenerateRandomMatrix(cols_a, cols_b, 7777);
 
   auto c_expected = MultiplyNaiveDouble(a, b, rows_a, cols_a, cols_b);
 
@@ -578,11 +534,8 @@ TEST(borisov_s_strassen_seq, Rectangular19x23_Random) {
   const int cols_a = 23;
   const int cols_b = 21;
 
-  int tmp = 7777;
-  std::mt19937 rng(tmp);
-
-  std::vector<double> a = GenerateRandomMatrix(rows_a, cols_a, rng);
-  std::vector<double> b = GenerateRandomMatrix(cols_a, cols_b, rng);
+  std::vector<double> a = GenerateRandomMatrix(rows_a, cols_a, 7777);
+  std::vector<double> b = GenerateRandomMatrix(cols_a, cols_b, 7777);
 
   auto c_expected = MultiplyNaiveDouble(a, b, rows_a, cols_a, cols_b);
 
@@ -629,11 +582,8 @@ TEST(borisov_s_strassen_seq, Rectangular32x64_Random) {
   const int cols_a = 64;
   const int cols_b = 32;
 
-  int tmp = 7777;
-  std::mt19937 rng(tmp);
-
-  std::vector<double> a = GenerateRandomMatrix(rows_a, cols_a, rng);
-  std::vector<double> b = GenerateRandomMatrix(cols_a, cols_b, rng);
+  std::vector<double> a = GenerateRandomMatrix(rows_a, cols_a, 7777);
+  std::vector<double> b = GenerateRandomMatrix(cols_a, cols_b, 7777);
 
   auto c_expected = MultiplyNaiveDouble(a, b, rows_a, cols_a, cols_b);
 

--- a/tasks/seq/borisov_s_strassen_seq/include/ops_seq.hpp
+++ b/tasks/seq/borisov_s_strassen_seq/include/ops_seq.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace borisov_s_strassen_seq {
+
+class SequentialStrassenSeq : public ppc::core::Task {
+ public:
+  explicit SequentialStrassenSeq(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<double> input_;
+
+  std::vector<double> output_;
+
+  int rowsA_ = 0;
+  int colsA_ = 0;
+  int rowsB_ = 0;
+  int colsB_ = 0;
+};
+
+}  // namespace borisov_s_strassen_seq

--- a/tasks/seq/borisov_s_strassen_seq/perf_tests/main.cpp
+++ b/tasks/seq/borisov_s_strassen_seq/perf_tests/main.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <random>

--- a/tasks/seq/borisov_s_strassen_seq/perf_tests/main.cpp
+++ b/tasks/seq/borisov_s_strassen_seq/perf_tests/main.cpp
@@ -1,0 +1,110 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "seq/borisov_s_strassen_seq/include/ops_seq.hpp"
+
+namespace {
+
+void GenerateRandomMatrix(int rows, int cols, std::vector<double>& matrix) {
+  std::mt19937 rng(7777);
+  std::uniform_real_distribution<double> dist(0.0, 1.0);
+  matrix.resize(rows * cols);
+  for (auto& value : matrix) {
+    value = dist(rng);
+  }
+}
+
+}  // namespace
+
+TEST(borisov_s_seq_strassen_perf, test_pipeline_run) {
+  constexpr int rowsA = 1024;
+  constexpr int colsA = 512;
+  constexpr int rowsB = 512;
+  constexpr int colsB = 1024;
+
+  std::vector<double> A;
+  std::vector<double> B;
+  GenerateRandomMatrix(rowsA, colsA, A);
+  GenerateRandomMatrix(rowsB, colsB, B);
+
+  std::vector<double> in_data = {static_cast<double>(rowsA), static_cast<double>(colsA), static_cast<double>(rowsB),
+                                 static_cast<double>(colsB)};
+  in_data.insert(in_data.end(), A.begin(), A.end());
+  in_data.insert(in_data.end(), B.begin(), B.end());
+
+  size_t output_count = 2 + (rowsA * colsB);
+  std::vector<double> out(output_count, 0.0);
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data_seq->inputs_count.emplace_back(in_data.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  auto test_task_sequential = std::make_shared<borisov_s_strassen_seq::SequentialStrassenSeq>(task_data_seq);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}
+
+TEST(borisov_s_seq_strassen_perf, test_task_run) {
+  constexpr int rowsA = 1024;
+  constexpr int colsA = 512;
+  constexpr int rowsB = 512;
+  constexpr int colsB = 1024;
+
+  std::vector<double> A;
+  std::vector<double> B;
+  GenerateRandomMatrix(rowsA, colsA, A);
+  GenerateRandomMatrix(rowsB, colsB, B);
+
+  std::vector<double> in_data = {static_cast<double>(rowsA), static_cast<double>(colsA), static_cast<double>(rowsB),
+                                 static_cast<double>(colsB)};
+  in_data.insert(in_data.end(), A.begin(), A.end());
+  in_data.insert(in_data.end(), B.begin(), B.end());
+
+  size_t output_count = 2 + (rowsA * colsB);
+  std::vector<double> out(output_count, 0.0);
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data_seq->inputs_count.emplace_back(in_data.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  auto test_task_sequential = std::make_shared<borisov_s_strassen_seq::SequentialStrassenSeq>(task_data_seq);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}

--- a/tasks/seq/borisov_s_strassen_seq/perf_tests/main.cpp
+++ b/tasks/seq/borisov_s_strassen_seq/perf_tests/main.cpp
@@ -25,7 +25,7 @@ void GenerateRandomMatrix(int rows, int cols, std::vector<double>& matrix) {
 
 }  // namespace
 
-TEST(borisov_s_seq_strassen_perf, test_pipeline_run) {
+TEST(borisov_s_strassen_perf_seq, test_pipeline_run) {
   constexpr int kRowsA = 1024;
   constexpr int kColsA = 512;
   constexpr int kRowsB = 512;
@@ -68,7 +68,7 @@ TEST(borisov_s_seq_strassen_perf, test_pipeline_run) {
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 }
 
-TEST(borisov_s_seq_strassen_perf, test_task_run) {
+TEST(borisov_s_strassen_perf_seq, test_task_run) {
   constexpr int kRowsA = 1024;
   constexpr int kColsA = 512;
   constexpr int kRowsB = 512;

--- a/tasks/seq/borisov_s_strassen_seq/perf_tests/main.cpp
+++ b/tasks/seq/borisov_s_strassen_seq/perf_tests/main.cpp
@@ -13,7 +13,8 @@
 namespace {
 
 void GenerateRandomMatrix(int rows, int cols, std::vector<double>& matrix) {
-  std::mt19937 rng(7777);
+  int tmp = 7777;
+  std::mt19937 rng(tmp);
   std::uniform_real_distribution<double> dist(0.0, 1.0);
   matrix.resize(rows * cols);
   for (auto& value : matrix) {
@@ -24,22 +25,22 @@ void GenerateRandomMatrix(int rows, int cols, std::vector<double>& matrix) {
 }  // namespace
 
 TEST(borisov_s_seq_strassen_perf, test_pipeline_run) {
-  constexpr int rowsA = 1024;
-  constexpr int colsA = 512;
-  constexpr int rowsB = 512;
-  constexpr int colsB = 1024;
+  constexpr int kRowsA = 1024;
+  constexpr int kColsA = 512;
+  constexpr int kRowsB = 512;
+  constexpr int kColsB = 1024;
 
-  std::vector<double> A;
-  std::vector<double> B;
-  GenerateRandomMatrix(rowsA, colsA, A);
-  GenerateRandomMatrix(rowsB, colsB, B);
+  std::vector<double> a;
+  std::vector<double> b;
+  GenerateRandomMatrix(kRowsA, kColsA, a);
+  GenerateRandomMatrix(kRowsB, kColsB, b);
 
-  std::vector<double> in_data = {static_cast<double>(rowsA), static_cast<double>(colsA), static_cast<double>(rowsB),
-                                 static_cast<double>(colsB)};
-  in_data.insert(in_data.end(), A.begin(), A.end());
-  in_data.insert(in_data.end(), B.begin(), B.end());
+  std::vector<double> in_data = {static_cast<double>(kRowsA), static_cast<double>(kColsA), static_cast<double>(kRowsB),
+                                 static_cast<double>(kColsB)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
 
-  size_t output_count = 2 + (rowsA * colsB);
+  size_t output_count = 2 + (kRowsA * kColsB);
   std::vector<double> out(output_count, 0.0);
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
@@ -67,22 +68,22 @@ TEST(borisov_s_seq_strassen_perf, test_pipeline_run) {
 }
 
 TEST(borisov_s_seq_strassen_perf, test_task_run) {
-  constexpr int rowsA = 1024;
-  constexpr int colsA = 512;
-  constexpr int rowsB = 512;
-  constexpr int colsB = 1024;
+  constexpr int kRowsA = 1024;
+  constexpr int kColsA = 512;
+  constexpr int kRowsB = 512;
+  constexpr int kColsB = 1024;
 
-  std::vector<double> A;
-  std::vector<double> B;
-  GenerateRandomMatrix(rowsA, colsA, A);
-  GenerateRandomMatrix(rowsB, colsB, B);
+  std::vector<double> a;
+  std::vector<double> b;
+  GenerateRandomMatrix(kRowsA, kColsA, a);
+  GenerateRandomMatrix(kRowsB, kColsB, b);
 
-  std::vector<double> in_data = {static_cast<double>(rowsA), static_cast<double>(colsA), static_cast<double>(rowsB),
-                                 static_cast<double>(colsB)};
-  in_data.insert(in_data.end(), A.begin(), A.end());
-  in_data.insert(in_data.end(), B.begin(), B.end());
+  std::vector<double> in_data = {static_cast<double>(kRowsA), static_cast<double>(kColsA), static_cast<double>(kRowsB),
+                                 static_cast<double>(kColsB)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
 
-  size_t output_count = 2 + (rowsA * colsB);
+  size_t output_count = 2 + (kRowsA * kColsB);
   std::vector<double> out(output_count, 0.0);
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();

--- a/tasks/seq/borisov_s_strassen_seq/perf_tests/main.cpp
+++ b/tasks/seq/borisov_s_strassen_seq/perf_tests/main.cpp
@@ -14,8 +14,8 @@
 namespace {
 
 void GenerateRandomMatrix(int rows, int cols, std::vector<double>& matrix) {
-  int tmp = 7777;
-  std::mt19937 rng(tmp);
+  std::random_device rd;
+  std::mt19937 rng(rd());
   std::uniform_real_distribution<double> dist(0.0, 1.0);
   matrix.resize(rows * cols);
   for (auto& value : matrix) {

--- a/tasks/seq/borisov_s_strassen_seq/src/ops_seq.cpp
+++ b/tasks/seq/borisov_s_strassen_seq/src/ops_seq.cpp
@@ -1,0 +1,199 @@
+#include "seq/borisov_s_strassen_seq/include/ops_seq.hpp"
+
+#include <cmath>
+#include <iostream>
+
+namespace borisov_s_strassen_seq {
+
+namespace {
+
+std::vector<double> MultiplyNaive(const std::vector<double> &a, const std::vector<double> &b, int n) {
+  std::vector<double> c(n * n, 0.0);
+  for (int i = 0; i < n; ++i) {
+    for (int j = 0; j < n; ++j) {
+      double sum = 0.0;
+      for (int k = 0; k < n; ++k) {
+        sum += a[(i * n) + k] * b[(k * n) + j];
+      }
+      c[(i * n) + j] = sum;
+    }
+  }
+  return c;
+}
+
+std::vector<double> AddMatr(const std::vector<double> &a, const std::vector<double> &b, int n) {
+  std::vector<double> c(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    c[i] = a[i] + b[i];
+  }
+  return c;
+}
+
+std::vector<double> SubMatr(const std::vector<double> &a, const std::vector<double> &b, int n) {
+  std::vector<double> c(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    c[i] = a[i] - b[i];
+  }
+  return c;
+}
+
+std::vector<double> SubMatrix(const std::vector<double> &m, int n, int row, int col, int size) {
+  std::vector<double> sub(size * size);
+  for (int i = 0; i < size; ++i) {
+    for (int j = 0; j < size; ++j) {
+      sub[(i * size) + j] = m[((row + i) * n) + (col + j)];
+    }
+  }
+  return sub;
+}
+
+void SetSubMatrix(std::vector<double> &m, const std::vector<double> &sub, int n, int row, int col, int size) {
+  for (int i = 0; i < size; ++i) {
+    for (int j = 0; j < size; ++j) {
+      m[((row + i) * n) + (col + j)] = sub[(i * size) + j];
+    }
+  }
+}
+
+std::vector<double> StrassenRecursive(const std::vector<double> &A, const std::vector<double> &B, int n) {
+  if (n <= 16) {
+    return MultiplyNaive(A, B, n);
+  }
+  int k = n / 2;
+  auto A11 = SubMatrix(A, n, 0, 0, k);
+  auto A12 = SubMatrix(A, n, 0, k, k);
+  auto A21 = SubMatrix(A, n, k, 0, k);
+  auto A22 = SubMatrix(A, n, k, k, k);
+
+  auto B11 = SubMatrix(B, n, 0, 0, k);
+  auto B12 = SubMatrix(B, n, 0, k, k);
+  auto B21 = SubMatrix(B, n, k, 0, k);
+  auto B22 = SubMatrix(B, n, k, k, k);
+
+  auto M1 = StrassenRecursive(AddMatr(A11, A22, k), AddMatr(B11, B22, k), k);
+  auto M2 = StrassenRecursive(AddMatr(A21, A22, k), B11, k);
+  auto M3 = StrassenRecursive(A11, SubMatr(B12, B22, k), k);
+  auto M4 = StrassenRecursive(A22, SubMatr(B21, B11, k), k);
+  auto M5 = StrassenRecursive(AddMatr(A11, A12, k), B22, k);
+  auto M6 = StrassenRecursive(SubMatr(A21, A11, k), AddMatr(B11, B12, k), k);
+  auto M7 = StrassenRecursive(SubMatr(A12, A22, k), AddMatr(B21, B22, k), k);
+
+  std::vector<double> C(n * n, 0.0);
+
+  auto C11 = AddMatr(SubMatr(AddMatr(M1, M4, k), M5, k), M7, k);
+  auto C12 = AddMatr(M3, M5, k);
+  auto C21 = AddMatr(M2, M4, k);
+  auto C22 = AddMatr(AddMatr(SubMatr(M1, M2, k), M3, k), M6, k);
+
+  SetSubMatrix(C, C11, n, 0, 0, k);
+  SetSubMatrix(C, C12, n, 0, k, k);
+  SetSubMatrix(C, C21, n, k, 0, k);
+  SetSubMatrix(C, C22, n, k, k, k);
+
+  return C;
+}
+
+int NextPowerOfTwo(int n) {
+  int r = 1;
+  while (r < n) {
+    r <<= 1;
+  }
+  return r;
+}
+
+}  // namespace
+
+bool SequentialStrassenSeq::PreProcessingImpl() {
+  size_t input_count = task_data->inputs_count[0];
+  auto *double_ptr = reinterpret_cast<double *>(task_data->inputs[0]);
+  input_.assign(double_ptr, double_ptr + input_count);
+
+  //  for (int i = 0; i < input_count; i++) {
+  //    std::cout << input_[i] << " " << input_[2];
+  //  }
+
+  size_t output_count = task_data->outputs_count[0];
+  output_.resize(output_count, 0.0);
+
+  if (input_.size() < 4) {
+    return false;
+  }
+
+  rowsA_ = static_cast<int>(input_[0]);
+  colsA_ = static_cast<int>(input_[1]);
+  rowsB_ = static_cast<int>(input_[2]);
+  colsB_ = static_cast<int>(input_[3]);
+
+  return true;
+}
+
+bool SequentialStrassenSeq::ValidationImpl() {
+  if (colsA_ != rowsB_) {
+    return false;
+  }
+
+  size_t needed = 4 + (static_cast<size_t>(rowsA_) * colsA_) + (static_cast<size_t>(rowsB_) * colsB_);
+
+  if (input_.size() < needed) {
+    return false;
+  }
+  return true;
+}
+
+bool SequentialStrassenSeq::RunImpl() {
+  size_t offset = 4;
+  std::vector<double> A(rowsA_ * colsA_);
+  for (int i = 0; i < rowsA_ * colsA_; ++i) {
+    A[i] = input_[offset + i];
+  }
+  offset += static_cast<size_t>(rowsA_ * colsA_);
+
+  std::vector<double> B(rowsB_ * colsB_);
+  for (int i = 0; i < rowsB_ * colsB_; ++i) {
+    B[i] = input_[offset + i];
+  }
+
+  int maxDim = std::max({rowsA_, colsA_, colsB_});
+  int M = NextPowerOfTwo(maxDim);
+
+  std::vector<double> Aexp(M * M, 0.0);
+  std::vector<double> Bexp(M * M, 0.0);
+
+  for (int i = 0; i < rowsA_; ++i) {
+    for (int j = 0; j < colsA_; ++j) {
+      Aexp[(i * M) + j] = A[(i * colsA_) + j];
+    }
+  }
+  for (int i = 0; i < rowsB_; ++i) {
+    for (int j = 0; j < colsB_; ++j) {
+      Bexp[(i * M) + j] = B[(i * colsB_) + j];
+    }
+  }
+
+  auto Cexp = StrassenRecursive(Aexp, Bexp, M);
+
+  std::vector<double> C(rowsA_ * colsB_, 0.0);
+  for (int i = 0; i < rowsA_; ++i) {
+    for (int j = 0; j < colsB_; ++j) {
+      C[(i * colsB_) + j] = Cexp[(i * M) + j];
+    }
+  }
+
+  output_[0] = static_cast<double>(rowsA_);
+  output_[1] = static_cast<double>(colsB_);
+  for (int i = 0; i < rowsA_ * colsB_; ++i) {
+    output_[2 + i] = C[i];
+  }
+
+  return true;
+}
+
+bool SequentialStrassenSeq::PostProcessingImpl() {
+  auto *out_ptr = reinterpret_cast<double *>(task_data->outputs[0]);
+  for (size_t i = 0; i < output_.size(); ++i) {
+    out_ptr[i] = output_[i];
+  }
+  return true;
+}
+
+}  // namespace borisov_s_strassen_seq

--- a/tasks/seq/borisov_s_strassen_seq/src/ops_seq.cpp
+++ b/tasks/seq/borisov_s_strassen_seq/src/ops_seq.cpp
@@ -109,10 +109,6 @@ bool SequentialStrassenSeq::PreProcessingImpl() {
   auto *double_ptr = reinterpret_cast<double *>(task_data->inputs[0]);
   input_.assign(double_ptr, double_ptr + input_count);
 
-  //  for (int i = 0; i < input_count; i++) {
-  //    std::cout << input_[i] << " " << input_[2];
-  //  }
-
   size_t output_count = task_data->outputs_count[0];
   output_.resize(output_count, 0.0);
 


### PR DESCRIPTION
Реализован алгоритм Штрассена для умножения плотных матриц (элементы типа double). Если матрицы прямоугольные или размерность не является степенью двойки, я дополняю их нулями до ближайшей степени двойки. При малом размере (n <= 16) используется обычное умножение (O(n^3)), а для больших задействуется рекурсивный Штрассена с асимптотикой примерно O(n^(2.8074)), что быстрее, чем классический O(n^3). Такой подход корректно обрабатывает любые размеры (включая прямоугольные) и обеспечивает выигрыш по скорости на крупных матрицах.