### PR TITLE
Кудряшова Ирина. Вариант 20. Технология SEQ. Поразрядная сортировка для вещественных чисел (тип double) с четно-нечетным слиянием Бэтчера

### DIFF
--- a/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
@@ -11,7 +11,7 @@
 #include "core/util/include/util.hpp"
 #include "seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp"
 
-std::vector<double> GetRandomDoubleVector(int size) {
+std::vector<double> kudryashova_i_radix_batcher_seq::GetRandomDoubleVector(int size) {
   std::vector<double> vector(size);
   std::mt19937 generator(static_cast<unsigned>(std::time(nullptr)));
   std::uniform_real_distribution<double> distribution(-1000.0, 1000.0);
@@ -97,7 +97,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_empty_test) {
 
 TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_1) {
   int global_vector_size = 10;
-  std::vector<double> global_vector = GetRandomDoubleVector(global_vector_size);
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_seq::GetRandomDoubleVector(global_vector_size);
   std::vector<double> result(global_vector_size);
   std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
   taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
@@ -116,7 +116,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_1) {
 
 TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_2) {
   int global_vector_size = 50;
-  std::vector<double> global_vector = GetRandomDoubleVector(global_vector_size);
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_seq::GetRandomDoubleVector(global_vector_size);
   std::vector<double> result(global_vector_size);
   std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
   taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
@@ -135,7 +135,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_2) {
 
 TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_3) {
   int global_vector_size = 512;
-  std::vector<double> global_vector = GetRandomDoubleVector(global_vector_size);
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_seq::GetRandomDoubleVector(global_vector_size);
   std::vector<double> result(global_vector_size);
   std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
   taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));

--- a/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
@@ -35,7 +35,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_0) {
   testTaskSequential.PreProcessingImpl();
   testTaskSequential.RunImpl();
   testTaskSequential.PostProcessingImpl();
-  for (int i = 1; i < result.size(); i++) {
+  for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
     ASSERT_LE(result[i - 1], result[i]);
   }
 }
@@ -54,7 +54,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_1) {
   testTaskSequential.PreProcessingImpl();
   testTaskSequential.RunImpl();
   testTaskSequential.PostProcessingImpl();
-  for (int i = 1; i < result.size(); i++) {
+  for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
     ASSERT_LE(result[i - 1], result[i]);
   }
 }
@@ -74,7 +74,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_2) {
   testTaskSequential.PreProcessingImpl();
   testTaskSequential.RunImpl();
   testTaskSequential.PostProcessingImpl();
-  for (int i = 1; i < result.size(); i++) {
+  for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
     ASSERT_LE(result[i - 1], result[i]);
   }
 }
@@ -109,7 +109,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_1) {
   testTaskSequential.PreProcessingImpl();
   testTaskSequential.RunImpl();
   testTaskSequential.PostProcessingImpl();
-  for (int i = 1; i < result.size(); i++) {
+  for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
     ASSERT_LE(result[i - 1], result[i]);
   }
 }
@@ -128,7 +128,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_2) {
   testTaskSequential.PreProcessingImpl();
   testTaskSequential.RunImpl();
   testTaskSequential.PostProcessingImpl();
-  for (int i = 1; i < result.size(); i++) {
+  for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
     ASSERT_LE(result[i - 1], result[i]);
   }
 }
@@ -147,7 +147,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_3) {
   testTaskSequential.PreProcessingImpl();
   testTaskSequential.RunImpl();
   testTaskSequential.PostProcessingImpl();
-  for (int i = 1; i < result.size(); i++) {
+  for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
     ASSERT_LE(result[i - 1], result[i]);
   }
 }

--- a/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
@@ -59,7 +59,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_1) {
 
 TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_2) {
   int global_vector_size = 11;
-  std::vector<double> global_vector = {-8.55,   1.85,   -4.0,   2.81828, 8.77,  -5.56562,
+  std::vector<double> global_vector = {-8.55,   1.85,   -4.0,   2.81828, 8.77,   -5.56562,
                                        -15.823, -6.971, 3.1615, 0.0,     10.1415};
   std::vector<double> result(global_vector_size);
   std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();

--- a/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
@@ -1,0 +1,73 @@
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "core/util/include/util.hpp"
+#include "seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp"
+
+TEST(kudryashova_i_radix_batcher_seq, test_matmul_50) {
+  constexpr size_t kCount = 50;
+
+  // Create data
+  std::vector<int> in(kCount * kCount, 0);
+  std::vector<int> out(kCount * kCount, 0);
+
+  for (size_t i = 0; i < kCount; i++) {
+    in[(i * kCount) + i] = 1;
+  }
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  kudryashova_i_radix_batcher_seq::TestTaskSequential test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(in, out);
+}
+
+TEST(kudryashova_i_radix_batcher_seq, test_matmul_100_from_file) {
+  std::string line;
+  std::ifstream test_file(ppc::util::GetAbsolutePath("seq/example/data/test.txt"));
+  if (test_file.is_open()) {
+    getline(test_file, line);
+  }
+  test_file.close();
+
+  const size_t count = std::stoi(line);
+
+  // Create data
+  std::vector<int> in(count * count, 0);
+  std::vector<int> out(count * count, 0);
+
+  for (size_t i = 0; i < count; i++) {
+    in[(i * count) + i] = 1;
+  }
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  kudryashova_i_radix_batcher_seq::TestTaskSequential test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(in, out);
+}

--- a/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
@@ -147,3 +147,23 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_3) {
   std::ranges::sort(sorted_global_vector);
   ASSERT_EQ(result, sorted_global_vector);
 }
+
+TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_reverse_order_test_4) {
+  int global_vector_size = 123;
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_seq::GetRandomDoubleVector(global_vector_size);
+  std::ranges::sort(global_vector, std::greater<double>());
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_seq::TestTaskSequential test_task_sequential(task_data);
+  ASSERT_TRUE(test_task_sequential.ValidationImpl());
+  test_task_sequential.PreProcessingImpl();
+  test_task_sequential.RunImpl();
+  test_task_sequential.PostProcessingImpl();
+  std::vector<double> sorted_global_vector = global_vector;
+  std::ranges::sort(sorted_global_vector);
+  ASSERT_EQ(result, sorted_global_vector);
+}

--- a/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
@@ -3,10 +3,10 @@
 #include <algorithm>
 #include <cstdint>
 #include <ctime>
+#include <functional>
 #include <memory>
 #include <random>
 #include <vector>
-#include <functional>
 
 #include "core/task/include/task.hpp"
 #include "seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp"

--- a/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
@@ -33,9 +33,9 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_0) {
   test_task_sequential.PreProcessingImpl();
   test_task_sequential.RunImpl();
   test_task_sequential.PostProcessingImpl();
-  for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
-    ASSERT_LE(result[i - 1], result[i]);
-  }
+  std::vector<double> sorted_global_vector = global_vector;
+  std::sort(sorted_global_vector.begin(), sorted_global_vector.end());
+  ASSERT_EQ(result, sorted_global_vector);
 }
 
 TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_1) {
@@ -52,9 +52,9 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_1) {
   test_task_sequential.PreProcessingImpl();
   test_task_sequential.RunImpl();
   test_task_sequential.PostProcessingImpl();
-  for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
-    ASSERT_LE(result[i - 1], result[i]);
-  }
+  std::vector<double> sorted_global_vector = global_vector;
+  std::sort(sorted_global_vector.begin(), sorted_global_vector.end());
+  ASSERT_EQ(result, sorted_global_vector);
 }
 
 TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_2) {
@@ -72,9 +72,9 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_2) {
   test_task_sequential.PreProcessingImpl();
   test_task_sequential.RunImpl();
   test_task_sequential.PostProcessingImpl();
-  for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
-    ASSERT_LE(result[i - 1], result[i]);
-  }
+  std::vector<double> sorted_global_vector = global_vector;
+  std::sort(sorted_global_vector.begin(), sorted_global_vector.end());
+  ASSERT_EQ(result, sorted_global_vector);
 }
 
 TEST(kudryashova_i_radix_batcher_seq, seq_radix_empty_test) {
@@ -104,9 +104,9 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_1) {
   test_task_sequential.PreProcessingImpl();
   test_task_sequential.RunImpl();
   test_task_sequential.PostProcessingImpl();
-  for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
-    ASSERT_LE(result[i - 1], result[i]);
-  }
+  std::vector<double> sorted_global_vector = global_vector;
+  std::sort(sorted_global_vector.begin(), sorted_global_vector.end());
+  ASSERT_EQ(result, sorted_global_vector);
 }
 
 TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_2) {
@@ -123,9 +123,9 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_2) {
   test_task_sequential.PreProcessingImpl();
   test_task_sequential.RunImpl();
   test_task_sequential.PostProcessingImpl();
-  for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
-    ASSERT_LE(result[i - 1], result[i]);
-  }
+  std::vector<double> sorted_global_vector = global_vector;
+  std::sort(sorted_global_vector.begin(), sorted_global_vector.end());
+  ASSERT_EQ(result, sorted_global_vector);
 }
 
 TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_3) {
@@ -142,7 +142,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_3) {
   test_task_sequential.PreProcessingImpl();
   test_task_sequential.RunImpl();
   test_task_sequential.PostProcessingImpl();
-  for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
-    ASSERT_LE(result[i - 1], result[i]);
-  }
+  std::vector<double> sorted_global_vector = global_vector;
+  std::sort(sorted_global_vector.begin(), sorted_global_vector.end());
+  ASSERT_EQ(result, sorted_global_vector);
 }

--- a/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
@@ -60,7 +60,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_1) {
 TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_2) {
   int global_vector_size = 11;
   std::vector<double> global_vector = {-8.55,   1.85,   -4.0,   2.81828, 8.77,  -5.56562,
-                                       -15.823, -6.971, 3.1615, 0.0,     3.1415};
+                                       -15.823, -6.971, 3.1615, 0.0,     10.1415};
   std::vector<double> result(global_vector_size);
   std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));

--- a/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <random>
 #include <vector>
+#include <functional>
 
 #include "core/task/include/task.hpp"
 #include "seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp"
@@ -151,7 +152,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_3) {
 TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_reverse_order_test_4) {
   int global_vector_size = 123;
   std::vector<double> global_vector = kudryashova_i_radix_batcher_seq::GetRandomDoubleVector(global_vector_size);
-  std::ranges::sort(global_vector, std::greater<double>());
+  std::ranges::sort(global_vector, std::greater<>());
   std::vector<double> result(global_vector_size);
   std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));

--- a/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
@@ -2,13 +2,11 @@
 
 #include <cstdint>
 #include <ctime>
-#include <fstream>
 #include <memory>
 #include <random>
 #include <vector>
 
 #include "core/task/include/task.hpp"
-#include "core/util/include/util.hpp"
 #include "seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp"
 
 std::vector<double> kudryashova_i_radix_batcher_seq::GetRandomDoubleVector(int size) {
@@ -25,16 +23,16 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_0) {
   int global_vector_size = 3;
   std::vector<double> global_vector = {5.69, -2.11, 0.52};
   std::vector<double> result(global_vector_size);
-  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
-  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
-  taskData->inputs_count.emplace_back(global_vector.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
-  taskData->outputs_count.emplace_back(result.size());
-  kudryashova_i_radix_batcher_seq::TestTaskSequential testTaskSequential(taskData);
-  testTaskSequential.ValidationImpl();
-  testTaskSequential.PreProcessingImpl();
-  testTaskSequential.RunImpl();
-  testTaskSequential.PostProcessingImpl();
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_seq::TestTaskSequential test_task_sequential(task_data);
+  test_task_sequential.ValidationImpl();
+  test_task_sequential.PreProcessingImpl();
+  test_task_sequential.RunImpl();
+  test_task_sequential.PostProcessingImpl();
   for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
     ASSERT_LE(result[i - 1], result[i]);
   }
@@ -44,16 +42,16 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_1) {
   int global_vector_size = 9;
   std::vector<double> global_vector = {8, -2, 5, 10, 1, -7, 3, 12, -6};
   std::vector<double> result(global_vector_size);
-  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
-  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
-  taskData->inputs_count.emplace_back(global_vector.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
-  taskData->outputs_count.emplace_back(result.size());
-  kudryashova_i_radix_batcher_seq::TestTaskSequential testTaskSequential(taskData);
-  testTaskSequential.ValidationImpl();
-  testTaskSequential.PreProcessingImpl();
-  testTaskSequential.RunImpl();
-  testTaskSequential.PostProcessingImpl();
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_seq::TestTaskSequential test_task_sequential(task_data);
+  test_task_sequential.ValidationImpl();
+  test_task_sequential.PreProcessingImpl();
+  test_task_sequential.RunImpl();
+  test_task_sequential.PostProcessingImpl();
   for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
     ASSERT_LE(result[i - 1], result[i]);
   }
@@ -61,19 +59,19 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_1) {
 
 TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_2) {
   int global_vector_size = 11;
-  std::vector<double> global_vector = {-8.55,   1.85,   -4.0,   2.71828, 8.77,  -5.56562,
-                                       -15.823, -6.971, 3.1415, 0.0,     3.1415};
+  std::vector<double> global_vector = {-8.55,   1.85,   -4.0,   2.81828, 8.77,  -5.56562,
+                                       -15.823, -6.971, 3.1615, 0.0,     3.1415};
   std::vector<double> result(global_vector_size);
-  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
-  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
-  taskData->inputs_count.emplace_back(global_vector.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
-  taskData->outputs_count.emplace_back(result.size());
-  kudryashova_i_radix_batcher_seq::TestTaskSequential testTaskSequential(taskData);
-  testTaskSequential.ValidationImpl();
-  testTaskSequential.PreProcessingImpl();
-  testTaskSequential.RunImpl();
-  testTaskSequential.PostProcessingImpl();
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_seq::TestTaskSequential test_task_sequential(task_data);
+  test_task_sequential.ValidationImpl();
+  test_task_sequential.PreProcessingImpl();
+  test_task_sequential.RunImpl();
+  test_task_sequential.PostProcessingImpl();
   for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
     ASSERT_LE(result[i - 1], result[i]);
   }
@@ -83,32 +81,32 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_empty_test) {
   int global_vector_size = 0;
   std::vector<double> global_vector;
   std::vector<double> result(global_vector_size);
-  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
-  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
-  taskData->inputs_count.emplace_back(global_vector.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
-  taskData->outputs_count.emplace_back(result.size());
-  kudryashova_i_radix_batcher_seq::TestTaskSequential testTaskSequential(taskData);
-  testTaskSequential.ValidationImpl();
-  testTaskSequential.PreProcessingImpl();
-  testTaskSequential.RunImpl();
-  testTaskSequential.PostProcessingImpl();
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_seq::TestTaskSequential test_task_sequential(task_data);
+  test_task_sequential.ValidationImpl();
+  test_task_sequential.PreProcessingImpl();
+  test_task_sequential.RunImpl();
+  test_task_sequential.PostProcessingImpl();
 }
 
 TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_1) {
   int global_vector_size = 10;
   std::vector<double> global_vector = kudryashova_i_radix_batcher_seq::GetRandomDoubleVector(global_vector_size);
   std::vector<double> result(global_vector_size);
-  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
-  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
-  taskData->inputs_count.emplace_back(global_vector.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
-  taskData->outputs_count.emplace_back(result.size());
-  kudryashova_i_radix_batcher_seq::TestTaskSequential testTaskSequential(taskData);
-  testTaskSequential.ValidationImpl();
-  testTaskSequential.PreProcessingImpl();
-  testTaskSequential.RunImpl();
-  testTaskSequential.PostProcessingImpl();
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_seq::TestTaskSequential test_task_sequential(task_data);
+  test_task_sequential.ValidationImpl();
+  test_task_sequential.PreProcessingImpl();
+  test_task_sequential.RunImpl();
+  test_task_sequential.PostProcessingImpl();
   for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
     ASSERT_LE(result[i - 1], result[i]);
   }
@@ -118,16 +116,16 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_2) {
   int global_vector_size = 50;
   std::vector<double> global_vector = kudryashova_i_radix_batcher_seq::GetRandomDoubleVector(global_vector_size);
   std::vector<double> result(global_vector_size);
-  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
-  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
-  taskData->inputs_count.emplace_back(global_vector.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
-  taskData->outputs_count.emplace_back(result.size());
-  kudryashova_i_radix_batcher_seq::TestTaskSequential testTaskSequential(taskData);
-  testTaskSequential.ValidationImpl();
-  testTaskSequential.PreProcessingImpl();
-  testTaskSequential.RunImpl();
-  testTaskSequential.PostProcessingImpl();
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_seq::TestTaskSequential test_task_sequential(task_data);
+  test_task_sequential.ValidationImpl();
+  test_task_sequential.PreProcessingImpl();
+  test_task_sequential.RunImpl();
+  test_task_sequential.PostProcessingImpl();
   for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
     ASSERT_LE(result[i - 1], result[i]);
   }
@@ -137,16 +135,16 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_3) {
   int global_vector_size = 512;
   std::vector<double> global_vector = kudryashova_i_radix_batcher_seq::GetRandomDoubleVector(global_vector_size);
   std::vector<double> result(global_vector_size);
-  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
-  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
-  taskData->inputs_count.emplace_back(global_vector.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
-  taskData->outputs_count.emplace_back(result.size());
-  kudryashova_i_radix_batcher_seq::TestTaskSequential testTaskSequential(taskData);
-  testTaskSequential.ValidationImpl();
-  testTaskSequential.PreProcessingImpl();
-  testTaskSequential.RunImpl();
-  testTaskSequential.PostProcessingImpl();
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_seq::TestTaskSequential test_task_sequential(task_data);
+  test_task_sequential.ValidationImpl();
+  test_task_sequential.PreProcessingImpl();
+  test_task_sequential.RunImpl();
+  test_task_sequential.PostProcessingImpl();
   for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
     ASSERT_LE(result[i - 1], result[i]);
   }

--- a/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
@@ -60,7 +60,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_1) {
 }
 
 TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_2) {
-  int global_vector_size = 10;
+  int global_vector_size = 11;
   std::vector<double> global_vector = {-8.55,   1.85,   -4.0,   2.71828, 8.77,  -5.56562,
                                        -15.823, -6.971, 3.1415, 0.0,     3.1415};
   std::vector<double> result(global_vector_size);

--- a/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <ctime>
 #include <memory>
@@ -34,7 +35,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_0) {
   test_task_sequential.RunImpl();
   test_task_sequential.PostProcessingImpl();
   std::vector<double> sorted_global_vector = global_vector;
-  std::sort(sorted_global_vector.begin(), sorted_global_vector.end());
+  std::ranges::sort(sorted_global_vector);
   ASSERT_EQ(result, sorted_global_vector);
 }
 
@@ -53,7 +54,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_1) {
   test_task_sequential.RunImpl();
   test_task_sequential.PostProcessingImpl();
   std::vector<double> sorted_global_vector = global_vector;
-  std::sort(sorted_global_vector.begin(), sorted_global_vector.end());
+  std::ranges::sort(sorted_global_vector);
   ASSERT_EQ(result, sorted_global_vector);
 }
 
@@ -73,7 +74,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_2) {
   test_task_sequential.RunImpl();
   test_task_sequential.PostProcessingImpl();
   std::vector<double> sorted_global_vector = global_vector;
-  std::sort(sorted_global_vector.begin(), sorted_global_vector.end());
+  std::ranges::sort(sorted_global_vector);
   ASSERT_EQ(result, sorted_global_vector);
 }
 
@@ -105,7 +106,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_1) {
   test_task_sequential.RunImpl();
   test_task_sequential.PostProcessingImpl();
   std::vector<double> sorted_global_vector = global_vector;
-  std::sort(sorted_global_vector.begin(), sorted_global_vector.end());
+  std::ranges::sort(sorted_global_vector);
   ASSERT_EQ(result, sorted_global_vector);
 }
 
@@ -124,7 +125,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_2) {
   test_task_sequential.RunImpl();
   test_task_sequential.PostProcessingImpl();
   std::vector<double> sorted_global_vector = global_vector;
-  std::sort(sorted_global_vector.begin(), sorted_global_vector.end());
+  std::ranges::sort(sorted_global_vector);
   ASSERT_EQ(result, sorted_global_vector);
 }
 
@@ -143,6 +144,6 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_3) {
   test_task_sequential.RunImpl();
   test_task_sequential.PostProcessingImpl();
   std::vector<double> sorted_global_vector = global_vector;
-  std::sort(sorted_global_vector.begin(), sorted_global_vector.end());
+  std::ranges::sort(sorted_global_vector);
   ASSERT_EQ(result, sorted_global_vector);
 }

--- a/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
@@ -29,7 +29,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_0) {
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   task_data->outputs_count.emplace_back(result.size());
   kudryashova_i_radix_batcher_seq::TestTaskSequential test_task_sequential(task_data);
-  test_task_sequential.ValidationImpl();
+  ASSERT_TRUE(test_task_sequential.ValidationImpl());
   test_task_sequential.PreProcessingImpl();
   test_task_sequential.RunImpl();
   test_task_sequential.PostProcessingImpl();
@@ -48,7 +48,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_1) {
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   task_data->outputs_count.emplace_back(result.size());
   kudryashova_i_radix_batcher_seq::TestTaskSequential test_task_sequential(task_data);
-  test_task_sequential.ValidationImpl();
+  ASSERT_TRUE(test_task_sequential.ValidationImpl());
   test_task_sequential.PreProcessingImpl();
   test_task_sequential.RunImpl();
   test_task_sequential.PostProcessingImpl();
@@ -68,7 +68,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_2) {
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   task_data->outputs_count.emplace_back(result.size());
   kudryashova_i_radix_batcher_seq::TestTaskSequential test_task_sequential(task_data);
-  test_task_sequential.ValidationImpl();
+  ASSERT_TRUE(test_task_sequential.ValidationImpl());
   test_task_sequential.PreProcessingImpl();
   test_task_sequential.RunImpl();
   test_task_sequential.PostProcessingImpl();
@@ -87,10 +87,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_empty_test) {
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   task_data->outputs_count.emplace_back(result.size());
   kudryashova_i_radix_batcher_seq::TestTaskSequential test_task_sequential(task_data);
-  test_task_sequential.ValidationImpl();
-  test_task_sequential.PreProcessingImpl();
-  test_task_sequential.RunImpl();
-  test_task_sequential.PostProcessingImpl();
+  ASSERT_FALSE(test_task_sequential.ValidationImpl());
 }
 
 TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_1) {
@@ -103,7 +100,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_1) {
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   task_data->outputs_count.emplace_back(result.size());
   kudryashova_i_radix_batcher_seq::TestTaskSequential test_task_sequential(task_data);
-  test_task_sequential.ValidationImpl();
+  ASSERT_TRUE(test_task_sequential.ValidationImpl());
   test_task_sequential.PreProcessingImpl();
   test_task_sequential.RunImpl();
   test_task_sequential.PostProcessingImpl();
@@ -122,7 +119,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_2) {
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   task_data->outputs_count.emplace_back(result.size());
   kudryashova_i_radix_batcher_seq::TestTaskSequential test_task_sequential(task_data);
-  test_task_sequential.ValidationImpl();
+  ASSERT_TRUE(test_task_sequential.ValidationImpl());
   test_task_sequential.PreProcessingImpl();
   test_task_sequential.RunImpl();
   test_task_sequential.PostProcessingImpl();
@@ -141,7 +138,7 @@ TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_3) {
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   task_data->outputs_count.emplace_back(result.size());
   kudryashova_i_radix_batcher_seq::TestTaskSequential test_task_sequential(task_data);
-  test_task_sequential.ValidationImpl();
+  ASSERT_TRUE(test_task_sequential.ValidationImpl());
   test_task_sequential.PreProcessingImpl();
   test_task_sequential.RunImpl();
   test_task_sequential.PostProcessingImpl();

--- a/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSeq.cpp
@@ -1,73 +1,153 @@
 #include <gtest/gtest.h>
 
-#include <cstddef>
 #include <cstdint>
+#include <ctime>
 #include <fstream>
 #include <memory>
-#include <string>
+#include <random>
 #include <vector>
 
 #include "core/task/include/task.hpp"
 #include "core/util/include/util.hpp"
 #include "seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp"
 
-TEST(kudryashova_i_radix_batcher_seq, test_matmul_50) {
-  constexpr size_t kCount = 50;
-
-  // Create data
-  std::vector<int> in(kCount * kCount, 0);
-  std::vector<int> out(kCount * kCount, 0);
-
-  for (size_t i = 0; i < kCount; i++) {
-    in[(i * kCount) + i] = 1;
+std::vector<double> GetRandomDoubleVector(int size) {
+  std::vector<double> vector(size);
+  std::mt19937 generator(static_cast<unsigned>(std::time(nullptr)));
+  std::uniform_real_distribution<double> distribution(-1000.0, 1000.0);
+  for (int i = 0; i < size; ++i) {
+    vector[i] = distribution(generator);
   }
-
-  // Create task_data
-  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
-  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  task_data_seq->inputs_count.emplace_back(in.size());
-  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data_seq->outputs_count.emplace_back(out.size());
-
-  // Create Task
-  kudryashova_i_radix_batcher_seq::TestTaskSequential test_task_sequential(task_data_seq);
-  ASSERT_EQ(test_task_sequential.Validation(), true);
-  test_task_sequential.PreProcessing();
-  test_task_sequential.Run();
-  test_task_sequential.PostProcessing();
-  EXPECT_EQ(in, out);
+  return vector;
 }
 
-TEST(kudryashova_i_radix_batcher_seq, test_matmul_100_from_file) {
-  std::string line;
-  std::ifstream test_file(ppc::util::GetAbsolutePath("seq/example/data/test.txt"));
-  if (test_file.is_open()) {
-    getline(test_file, line);
+TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_0) {
+  int global_vector_size = 3;
+  std::vector<double> global_vector = {5.69, -2.11, 0.52};
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
+  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  taskData->inputs_count.emplace_back(global_vector.size());
+  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  taskData->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_seq::TestTaskSequential testTaskSequential(taskData);
+  testTaskSequential.ValidationImpl();
+  testTaskSequential.PreProcessingImpl();
+  testTaskSequential.RunImpl();
+  testTaskSequential.PostProcessingImpl();
+  for (int i = 1; i < result.size(); i++) {
+    ASSERT_LE(result[i - 1], result[i]);
   }
-  test_file.close();
+}
 
-  const size_t count = std::stoi(line);
-
-  // Create data
-  std::vector<int> in(count * count, 0);
-  std::vector<int> out(count * count, 0);
-
-  for (size_t i = 0; i < count; i++) {
-    in[(i * count) + i] = 1;
+TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_1) {
+  int global_vector_size = 9;
+  std::vector<double> global_vector = {8, -2, 5, 10, 1, -7, 3, 12, -6};
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
+  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  taskData->inputs_count.emplace_back(global_vector.size());
+  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  taskData->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_seq::TestTaskSequential testTaskSequential(taskData);
+  testTaskSequential.ValidationImpl();
+  testTaskSequential.PreProcessingImpl();
+  testTaskSequential.RunImpl();
+  testTaskSequential.PostProcessingImpl();
+  for (int i = 1; i < result.size(); i++) {
+    ASSERT_LE(result[i - 1], result[i]);
   }
+}
 
-  // Create task_data
-  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
-  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
-  task_data_seq->inputs_count.emplace_back(in.size());
-  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data_seq->outputs_count.emplace_back(out.size());
+TEST(kudryashova_i_radix_batcher_seq, seq_radix_test_2) {
+  int global_vector_size = 10;
+  std::vector<double> global_vector = {-8.55,   1.85,   -4.0,   2.71828, 8.77,  -5.56562,
+                                       -15.823, -6.971, 3.1415, 0.0,     3.1415};
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
+  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  taskData->inputs_count.emplace_back(global_vector.size());
+  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  taskData->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_seq::TestTaskSequential testTaskSequential(taskData);
+  testTaskSequential.ValidationImpl();
+  testTaskSequential.PreProcessingImpl();
+  testTaskSequential.RunImpl();
+  testTaskSequential.PostProcessingImpl();
+  for (int i = 1; i < result.size(); i++) {
+    ASSERT_LE(result[i - 1], result[i]);
+  }
+}
 
-  // Create Task
-  kudryashova_i_radix_batcher_seq::TestTaskSequential test_task_sequential(task_data_seq);
-  ASSERT_EQ(test_task_sequential.Validation(), true);
-  test_task_sequential.PreProcessing();
-  test_task_sequential.Run();
-  test_task_sequential.PostProcessing();
-  EXPECT_EQ(in, out);
+TEST(kudryashova_i_radix_batcher_seq, seq_radix_empty_test) {
+  int global_vector_size = 0;
+  std::vector<double> global_vector;
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
+  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  taskData->inputs_count.emplace_back(global_vector.size());
+  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  taskData->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_seq::TestTaskSequential testTaskSequential(taskData);
+  testTaskSequential.ValidationImpl();
+  testTaskSequential.PreProcessingImpl();
+  testTaskSequential.RunImpl();
+  testTaskSequential.PostProcessingImpl();
+}
+
+TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_1) {
+  int global_vector_size = 10;
+  std::vector<double> global_vector = GetRandomDoubleVector(global_vector_size);
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
+  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  taskData->inputs_count.emplace_back(global_vector.size());
+  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  taskData->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_seq::TestTaskSequential testTaskSequential(taskData);
+  testTaskSequential.ValidationImpl();
+  testTaskSequential.PreProcessingImpl();
+  testTaskSequential.RunImpl();
+  testTaskSequential.PostProcessingImpl();
+  for (int i = 1; i < result.size(); i++) {
+    ASSERT_LE(result[i - 1], result[i]);
+  }
+}
+
+TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_2) {
+  int global_vector_size = 50;
+  std::vector<double> global_vector = GetRandomDoubleVector(global_vector_size);
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
+  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  taskData->inputs_count.emplace_back(global_vector.size());
+  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  taskData->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_seq::TestTaskSequential testTaskSequential(taskData);
+  testTaskSequential.ValidationImpl();
+  testTaskSequential.PreProcessingImpl();
+  testTaskSequential.RunImpl();
+  testTaskSequential.PostProcessingImpl();
+  for (int i = 1; i < result.size(); i++) {
+    ASSERT_LE(result[i - 1], result[i]);
+  }
+}
+
+TEST(kudryashova_i_radix_batcher_seq, seq_radix_random_test_3) {
+  int global_vector_size = 512;
+  std::vector<double> global_vector = GetRandomDoubleVector(global_vector_size);
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
+  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  taskData->inputs_count.emplace_back(global_vector.size());
+  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  taskData->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_seq::TestTaskSequential testTaskSequential(taskData);
+  testTaskSequential.ValidationImpl();
+  testTaskSequential.PreProcessingImpl();
+  testTaskSequential.RunImpl();
+  testTaskSequential.PostProcessingImpl();
+  for (int i = 1; i < result.size(); i++) {
+    ASSERT_LE(result[i - 1], result[i]);
+  }
 }

--- a/tasks/seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp
@@ -1,17 +1,14 @@
 #pragma once
 
-#include <algorithm>
 #include <cmath>
-#include <cstdint>
-#include <iostream>
-#include <numeric>
 #include <vector>
+#include <utility>
 
 #include "core/task/include/task.hpp"
 
 namespace kudryashova_i_radix_batcher_seq {
 std::vector<double> GetRandomDoubleVector(int size);
-void radix_double_sort(std::vector<double> &data, int first, int last);
+void RadixDoubleSort(std::vector<double> &data, int first, int last);
 class TestTaskSequential : public ppc::core::Task {
  public:
   explicit TestTaskSequential(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
@@ -21,7 +18,7 @@ class TestTaskSequential : public ppc::core::Task {
   bool PostProcessingImpl() override;
 
  private:
-  std::vector<double> input_data;
+  std::vector<double> input_data_;
 };
 
 }  // namespace kudryashova_i_radix_batcher_seq

--- a/tasks/seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp
@@ -19,7 +19,6 @@ class TestTaskSequential : public ppc::core::Task {
 
  private:
   std::vector<double> input_data_;
-  std::vector<double> output_data_;
 };
 
 }  // namespace kudryashova_i_radix_batcher_seq

--- a/tasks/seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp
@@ -10,6 +10,7 @@
 #include "core/task/include/task.hpp"
 
 namespace kudryashova_i_radix_batcher_seq {
+std::vector<double> GetRandomDoubleVector(int size);
 void radix_double_sort(std::vector<double> &data, int first, int last);
 class TestTaskSequential : public ppc::core::Task {
  public:

--- a/tasks/seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp
@@ -21,7 +21,6 @@ class TestTaskSequential : public ppc::core::Task {
 
  private:
   std::vector<double> input_data;
-  int rc_size_{};
 };
 
 }  // namespace kudryashova_i_radix_batcher_seq

--- a/tasks/seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kudryashova_i_radix_batcher_seq {
+
+class TestTaskSequential : public ppc::core::Task {
+ public:
+  explicit TestTaskSequential(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> input_, output_;
+  int rc_size_{};
+};
+
+}  // namespace kudryashova_i_radix_batcher_seq

--- a/tasks/seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp
@@ -1,12 +1,16 @@
 #pragma once
 
-#include <utility>
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <numeric>
 #include <vector>
 
 #include "core/task/include/task.hpp"
 
 namespace kudryashova_i_radix_batcher_seq {
-
+void radix_double_sort(std::vector<double> &data, int first, int last);
 class TestTaskSequential : public ppc::core::Task {
  public:
   explicit TestTaskSequential(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
@@ -16,7 +20,7 @@ class TestTaskSequential : public ppc::core::Task {
   bool PostProcessingImpl() override;
 
  private:
-  std::vector<int> input_, output_;
+  std::vector<double> input_data;
   int rc_size_{};
 };
 

--- a/tasks/seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp
@@ -19,6 +19,7 @@ class TestTaskSequential : public ppc::core::Task {
 
  private:
   std::vector<double> input_data_;
+  std::vector<double> output_data_;
 };
 
 }  // namespace kudryashova_i_radix_batcher_seq

--- a/tasks/seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <cmath>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "core/task/include/task.hpp"
 

--- a/tasks/seq/kudryashova_i_radix_batcher/perf_tests/kudryashovaRadixBatcherPerfSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/perf_tests/kudryashovaRadixBatcherPerfSeq.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
-#include <cstddef>
 #include <cstdint>
 #include <ctime>
 #include <memory>

--- a/tasks/seq/kudryashova_i_radix_batcher/perf_tests/kudryashovaRadixBatcherPerfSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/perf_tests/kudryashovaRadixBatcherPerfSeq.cpp
@@ -12,7 +12,7 @@
 #include "core/task/include/task.hpp"
 #include "seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp"
 
-std::vector<double> GetRandomDoubleVector(int size) {
+std::vector<double> kudryashova_i_radix_batcher_seq::GetRandomDoubleVector(int size) {
   std::vector<double> vector(size);
   std::mt19937 generator(static_cast<unsigned>(std::time(nullptr)));
   std::uniform_real_distribution<double> distribution(-1000.0, 1000.0);
@@ -24,7 +24,7 @@ std::vector<double> GetRandomDoubleVector(int size) {
 
 TEST(kudryashova_i_radix_batcher_seq, test_pipeline_run) {
   int global_vector_size = 3000000;
-  std::vector<double> global_vector = GetRandomDoubleVector(global_vector_size);
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_seq::GetRandomDoubleVector(global_vector_size);
   std::vector<double> result(global_vector_size);
   std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
   taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
@@ -52,7 +52,7 @@ TEST(kudryashova_i_radix_batcher_seq, test_pipeline_run) {
 
 TEST(kudryashova_i_radix_batcher_seq, test_task_run) {
   int global_vector_size = 3000000;
-  std::vector<double> global_vector = GetRandomDoubleVector(global_vector_size);
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_seq::GetRandomDoubleVector(global_vector_size);
   std::vector<double> result(global_vector_size);
   std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
   taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));

--- a/tasks/seq/kudryashova_i_radix_batcher/perf_tests/kudryashovaRadixBatcherPerfSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/perf_tests/kudryashovaRadixBatcherPerfSeq.cpp
@@ -1,0 +1,93 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp"
+
+TEST(kudryashova_i_radix_batcher_seq, test_pipeline_run) {
+  constexpr int kCount = 500;
+
+  // Create data
+  std::vector<int> in(kCount * kCount, 0);
+  std::vector<int> out(kCount * kCount, 0);
+
+  for (size_t i = 0; i < kCount; i++) {
+    in[(i * kCount) + i] = 1;
+  }
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_sequential = std::make_shared<kudryashova_i_radix_batcher_seq::TestTaskSequential>(task_data_seq);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(in, out);
+}
+
+TEST(kudryashova_i_radix_batcher_seq, test_task_run) {
+  constexpr int kCount = 500;
+
+  // Create data
+  std::vector<int> in(kCount * kCount, 0);
+  std::vector<int> out(kCount * kCount, 0);
+
+  for (size_t i = 0; i < kCount; i++) {
+    in[(i * kCount) + i] = 1;
+  }
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_sequential = std::make_shared<kudryashova_i_radix_batcher_seq::TestTaskSequential>(task_data_seq);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(in, out);
+}

--- a/tasks/seq/kudryashova_i_radix_batcher/perf_tests/kudryashovaRadixBatcherPerfSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/perf_tests/kudryashovaRadixBatcherPerfSeq.cpp
@@ -45,7 +45,7 @@ TEST(kudryashova_i_radix_batcher_seq, test_pipeline_run) {
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
-  for (int i = 1; i < result.size(); i++) {
+  for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
     ASSERT_LE(result[i - 1], result[i]);
   }
 }
@@ -72,7 +72,7 @@ TEST(kudryashova_i_radix_batcher_seq, test_task_run) {
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
-  for (int i = 1; i < result.size(); i++) {
+  for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
     ASSERT_LE(result[i - 1], result[i]);
   }
 }

--- a/tasks/seq/kudryashova_i_radix_batcher/perf_tests/kudryashovaRadixBatcherPerfSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/perf_tests/kudryashovaRadixBatcherPerfSeq.cpp
@@ -26,12 +26,12 @@ TEST(kudryashova_i_radix_batcher_seq, test_pipeline_run) {
   int global_vector_size = 3000000;
   std::vector<double> global_vector = kudryashova_i_radix_batcher_seq::GetRandomDoubleVector(global_vector_size);
   std::vector<double> result(global_vector_size);
-  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
-  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
-  taskData->inputs_count.emplace_back(global_vector.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
-  taskData->outputs_count.emplace_back(result.size());
-  auto testTaskSequential = std::make_shared<kudryashova_i_radix_batcher_seq::TestTaskSequential>(taskData);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  auto test_task_sequential = std::make_shared<kudryashova_i_radix_batcher_seq::TestTaskSequential>(task_data);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;
@@ -42,7 +42,7 @@ TEST(kudryashova_i_radix_batcher_seq, test_pipeline_run) {
     return static_cast<double>(duration) * 1e-9;
   };
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
-  auto perf_analyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
   for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
@@ -54,12 +54,12 @@ TEST(kudryashova_i_radix_batcher_seq, test_task_run) {
   int global_vector_size = 3000000;
   std::vector<double> global_vector = kudryashova_i_radix_batcher_seq::GetRandomDoubleVector(global_vector_size);
   std::vector<double> result(global_vector_size);
-  std::shared_ptr<ppc::core::TaskData> taskData = std::make_shared<ppc::core::TaskData>();
-  taskData->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
-  taskData->inputs_count.emplace_back(global_vector.size());
-  taskData->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
-  taskData->outputs_count.emplace_back(result.size());
-  auto testTaskSequential = std::make_shared<kudryashova_i_radix_batcher_seq::TestTaskSequential>(taskData);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  auto test_task_sequential = std::make_shared<kudryashova_i_radix_batcher_seq::TestTaskSequential>(task_data);
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
@@ -69,7 +69,7 @@ TEST(kudryashova_i_radix_batcher_seq, test_task_run) {
     return static_cast<double>(duration) * 1e-9;
   };
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
-  auto perf_analyzer = std::make_shared<ppc::core::Perf>(testTaskSequential);
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
   for (std::vector<double>::size_type i = 1; i < result.size(); i++) {

--- a/tasks/seq/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherSeq.cpp
@@ -73,7 +73,6 @@ bool kudryashova_i_radix_batcher_seq::TestTaskSequential::RunImpl() {
 }
 
 bool kudryashova_i_radix_batcher_seq::TestTaskSequential::PostProcessingImpl() {
-  output_data_.resize(task_data->outputs_count[0]);
-  std::ranges::copy(input_data_, output_data_.begin());
+  std::ranges::copy(input_data_, reinterpret_cast<double *>(task_data->outputs[0]));
   return true;
 }

--- a/tasks/seq/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherSeq.cpp
@@ -23,7 +23,7 @@ void kudryashova_i_radix_batcher_seq::radix_double_sort(std::vector<double> &dat
 
   for (int shift = 0; shift < total_passes; ++shift) {
     size_t count[256] = {0};                      // Array to count occurrences of each byte
-    const int shift_loc = shift * bits_int_byte;  // Determine how much to shift for the current pass
+    const int shift_loc = shift * bits_int_byte;  // Determine shift for the current pass
 
     // Count occurrences of each byte in the current shift position
     for (const auto &num : converted) {

--- a/tasks/seq/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherSeq.cpp
@@ -73,7 +73,7 @@ bool kudryashova_i_radix_batcher_seq::TestTaskSequential::RunImpl() {
 }
 
 bool kudryashova_i_radix_batcher_seq::TestTaskSequential::PostProcessingImpl() {
-  std::vector<double> output(input_data_.size());
-  std::ranges::copy(input_data_, output.begin());
+  output_data_.resize(task_data->outputs_count[0]);
+  std::ranges::copy(input_data_, output_data_.begin());
   return true;
 }

--- a/tasks/seq/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherSeq.cpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <cstring>
 #include <vector>
+#include <ranges>
 
 void kudryashova_i_radix_batcher_seq::RadixDoubleSort(std::vector<double> &data, int first, int last) {
   const int sort_size = last - first;
@@ -13,9 +14,9 @@ void kudryashova_i_radix_batcher_seq::RadixDoubleSort(std::vector<double> &data,
   // Convert each double to uint64_t representation
   for (int i = 0; i < sort_size; ++i) {
     double value = data[first + i];
-    uint64_t bits;
+    uint64_t bits = 0;
     std::memcpy(&bits, &value, sizeof(value));
-    converted[i] = (bits & (1ULL << 63)) ? ~bits : bits ^ (1ULL << 63);  // sign of the number
+    converted[i] = ((bits & (1ULL << 63)) != 0) ? ~bits : bits ^ (1ULL << 63);  // sign of the number
   }
   std::vector<uint64_t> buffer(sort_size);
   int bits_int_byte = 8;
@@ -68,12 +69,12 @@ bool kudryashova_i_radix_batcher_seq::TestTaskSequential::ValidationImpl() {
 }
 
 bool kudryashova_i_radix_batcher_seq::TestTaskSequential::RunImpl() {
-  RadixDoubleSort(input_data_, 0, input_data_.size());
+  RadixDoubleSort(input_data_, 0, static_cast<int>(input_data_.size()));
   return true;
 }
 
 bool kudryashova_i_radix_batcher_seq::TestTaskSequential::PostProcessingImpl() {
-  auto *output = reinterpret_cast<double *>(task_data->outputs[0]);
-  std::copy(input_data_.begin(), input_data_.end(), output);
+  std::vector<double> output(input_data_.size());
+  std::ranges::copy(input_data_, output.begin());
   return true;
 }

--- a/tasks/seq/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherSeq.cpp
@@ -1,0 +1,42 @@
+#include "seq/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSeq.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+bool kudryashova_i_radix_batcher_seq::TestTaskSequential::PreProcessingImpl() {
+  // Init value for input and output
+  unsigned int input_size = task_data->inputs_count[0];
+  auto *in_ptr = reinterpret_cast<int *>(task_data->inputs[0]);
+  input_ = std::vector<int>(in_ptr, in_ptr + input_size);
+
+  unsigned int output_size = task_data->outputs_count[0];
+  output_ = std::vector<int>(output_size, 0);
+
+  rc_size_ = static_cast<int>(std::sqrt(input_size));
+  return true;
+}
+
+bool kudryashova_i_radix_batcher_seq::TestTaskSequential::ValidationImpl() {
+  // Check equality of counts elements
+  return task_data->inputs_count[0] == task_data->outputs_count[0];
+}
+
+bool kudryashova_i_radix_batcher_seq::TestTaskSequential::RunImpl() {
+  // Multiply matrices
+  for (int i = 0; i < rc_size_; ++i) {
+    for (int j = 0; j < rc_size_; ++j) {
+      for (int k = 0; k < rc_size_; ++k) {
+        output_[(i * rc_size_) + j] += input_[(i * rc_size_) + k] * input_[(k * rc_size_) + j];
+      }
+    }
+  }
+  return true;
+}
+
+bool kudryashova_i_radix_batcher_seq::TestTaskSequential::PostProcessingImpl() {
+  for (size_t i = 0; i < output_.size(); i++) {
+    reinterpret_cast<int *>(task_data->outputs[0])[i] = output_[i];
+  }
+  return true;
+}

--- a/tasks/seq/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherSeq.cpp
@@ -5,8 +5,8 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
-#include <vector>
 #include <ranges>
+#include <vector>
 
 void kudryashova_i_radix_batcher_seq::RadixDoubleSort(std::vector<double> &data, int first, int last) {
   const int sort_size = last - first;

--- a/tasks/seq/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherSeq.cpp
@@ -5,7 +5,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
-#include <ranges>
 #include <vector>
 
 void kudryashova_i_radix_batcher_seq::RadixDoubleSort(std::vector<double> &data, int first, int last) {
@@ -49,7 +48,7 @@ void kudryashova_i_radix_batcher_seq::RadixDoubleSort(std::vector<double> &data,
   // Convert the sorted uint64_t representations back to double
   for (int i = 0; i < sort_size; ++i) {
     uint64_t bits = converted[i];
-    bits = (bits & (1ULL << 63)) ? (bits ^ (1ULL << 63)) : ~bits;
+    bits = ((bits & (1ULL << 63)) != 0) ? (bits ^ (1ULL << 63)) : ~bits;
     std::memcpy(&data[first + i], &bits, sizeof(double));
   }
 }

--- a/tasks/seq/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherSeq.cpp
+++ b/tasks/seq/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherSeq.cpp
@@ -3,10 +3,11 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <vector>
 
-void kudryashova_i_radix_batcher_seq::radix_double_sort(std::vector<double> &data, int first, int last) {
+void kudryashova_i_radix_batcher_seq::RadixDoubleSort(std::vector<double> &data, int first, int last) {
   const int sort_size = last - first;
   std::vector<uint64_t> converted(sort_size);
   // Convert each double to uint64_t representation
@@ -53,12 +54,12 @@ void kudryashova_i_radix_batcher_seq::radix_double_sort(std::vector<double> &dat
 }
 
 bool kudryashova_i_radix_batcher_seq::TestTaskSequential::PreProcessingImpl() {
-  input_data.resize(task_data->inputs_count[0]);
+  input_data_.resize(task_data->inputs_count[0]);
   if (task_data->inputs[0] == nullptr || task_data->inputs_count[0] == 0) {
     return false;
   }
   auto *tmp_ptr = reinterpret_cast<double *>(task_data->inputs[0]);
-  std::copy(tmp_ptr, tmp_ptr + task_data->inputs_count[0], input_data.begin());
+  std::copy(tmp_ptr, tmp_ptr + task_data->inputs_count[0], input_data_.begin());
   return true;
 }
 
@@ -67,12 +68,12 @@ bool kudryashova_i_radix_batcher_seq::TestTaskSequential::ValidationImpl() {
 }
 
 bool kudryashova_i_radix_batcher_seq::TestTaskSequential::RunImpl() {
-  radix_double_sort(input_data, 0, input_data.size());
+  RadixDoubleSort(input_data_, 0, input_data_.size());
   return true;
 }
 
 bool kudryashova_i_radix_batcher_seq::TestTaskSequential::PostProcessingImpl() {
   auto *output = reinterpret_cast<double *>(task_data->outputs[0]);
-  std::copy(input_data.begin(), input_data.end(), output);
+  std::copy(input_data_.begin(), input_data_.end(), output);
   return true;
 }


### PR DESCRIPTION
Так как слияние Бэтчера используется в основном в параллельных вычислениях, то в seq версии мною был реализован лишь алгоритм поразрядной сортировки. 
Функция radix_double_sort сортирует массив чисел типа double, используя алгоритм поразрядной сортировки. Сначала создаём вектор converted для хранения представлений double в формате uint64_t. Каждое число преобразуется в uint64_t, при этом обрабатывается знак: если старший бит равен 1, число инвертируется, иначе инвертируется только старший бит. После этого функция выполняет сортировку поразрядно, проходя через каждый байт числа от младшего к старшему. В каждом проходе создаём массив подсчета, который фиксирует количество вхождений каждого байта. 
Далее получим массив префиксных сумм, который позволяет определить, куда именно нужно разместить каждый элемент в отсортированном массиве. Здесь происходит перераспределение элементов из converted в buffer на основе подсчитанных префиксных сумм. Каждый элемент помещается в соответствующую позицию в buffer на основе значения младшего байта. После завершения прохода содержимое buffer копируется в converted, и процесс повторяется для следующего байта. В конце выводится отсортированный массив, показывающий результат работы функции.