### PR TITLE
Козлова Екатерина. Вариант 28. SEQ. Повышение контраста полутонового изображения посредством линейной растяжки гистограммы.

### DIFF
--- a/tasks/seq/kozlova_e_contrast_enhancement/func_tests/main.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/func_tests/main.cpp
@@ -1,11 +1,6 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
-#include <cstddef>
-#include <cstdint>
-#include <fstream>
-#include <memory>
-#include <string>
 #include <vector>
 
 #include "core/task/include/task.hpp"

--- a/tasks/seq/kozlova_e_contrast_enhancement/func_tests/main.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/func_tests/main.cpp
@@ -1,0 +1,131 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "core/util/include/util.hpp"
+#include "seq/kozlova_e_contrast_enhancement/include/ops_seq.hpp"
+
+std::vector<int> generate_vector(int length) {
+  std::vector<int> vec;
+  for (int i = 0; i < length; ++i) {
+    vec.push_back(rand() % 256);
+  }
+  return vec;
+}
+
+TEST(kozlova_e_contrast_enhancement_seq, test_1st_image) {
+  std::vector<int> in{10, 0, 50, 100, 200};
+  std::vector<int> out(5, 0);
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  kozlova_e_contrast_enhancement_seq::TestTaskSequential test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+
+  EXPECT_EQ(out[0], 12);
+  EXPECT_EQ(out[1], 0);
+  EXPECT_EQ(out[2], 63);
+  EXPECT_EQ(out[3], 127);
+  EXPECT_EQ(out[4], 255);
+}
+
+TEST(kozlova_e_contrast_enhancement_seq, test_image2) {
+  int size = 400;
+  std::vector<int> in = generate_vector(size);
+  std::vector<int> out(size, 0);
+  std::vector<int> expect(size, 0);
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  kozlova_e_contrast_enhancement_seq::TestTaskSequential test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+
+  int min_value = *std::min_element(in.begin(), in.end());
+  int max_value = *std::max_element(in.begin(), in.end());
+
+  for (size_t i = 0; i < in.size(); ++i) {
+    int expected = static_cast<int>(((in[i] - min_value) / (double)(max_value - min_value)) * 255);
+    expected = std::clamp(expected, 0, 255);
+    EXPECT_EQ(out[i], expected);
+  }
+}
+
+TEST(kozlova_e_contrast_enhancement_seq, test_empty_input) {
+  std::vector<int> in = {};
+  std::vector<int> out(0, 0);
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  kozlova_e_contrast_enhancement_seq::TestTaskSequential test_task_sequential(task_data_seq);
+  ASSERT_FALSE(test_task_sequential.Validation());
+}
+
+TEST(kozlova_e_contrast_enhancement_seq, test_same_values_input) {
+  std::vector<int> in(5, 100);
+  std::vector<int> out(5, 0);
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  kozlova_e_contrast_enhancement_seq::TestTaskSequential test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+
+  EXPECT_EQ(in, out);
+}
+
+TEST(kozlova_e_contrast_enhancement_seq, test_difference_input) {
+  std::vector<int> in{10, 20, 30, 100, 200, 250};
+  std::vector<int> out(6, 0);
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  kozlova_e_contrast_enhancement_seq::TestTaskSequential test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+
+  int min_value = *std::min_element(in.begin(), in.end());
+  int max_value = *std::max_element(in.begin(), in.end());
+
+  for (size_t i = 0; i < in.size(); ++i) {
+    int expected = static_cast<int>(((in[i] - min_value) / (double)(max_value - min_value)) * 255);
+    expected = std::clamp(expected, 0, 255);
+    EXPECT_EQ(out[i], expected);
+  }
+}

--- a/tasks/seq/kozlova_e_contrast_enhancement/func_tests/main.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/func_tests/main.cpp
@@ -132,3 +132,19 @@ TEST(kozlova_e_contrast_enhancement_seq, test_difference_input) {
     EXPECT_EQ(out[i], expected);
   }
 }
+
+TEST(kozlova_e_contrast_enhancement_seq, test_negative_values) {
+  std::vector<int> in{-10, -20, -30, -100, -200, -250};
+  std::vector<int> out(6, 0);
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  kozlova_e_contrast_enhancement_seq::TestTaskSequential test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  ASSERT_ANY_THROW(test_task_sequential.Run());
+}

--- a/tasks/seq/kozlova_e_contrast_enhancement/func_tests/main.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/func_tests/main.cpp
@@ -1,9 +1,9 @@
 #include <gtest/gtest.h>
-#include <stdlib.h>
 
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <memory>
 #include <vector>
 

--- a/tasks/seq/kozlova_e_contrast_enhancement/func_tests/main.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/func_tests/main.cpp
@@ -25,12 +25,16 @@ std::vector<int> GenerateVector(int length) {
 
 TEST(kozlova_e_contrast_enhancement_seq, test_1st_image) {
   std::vector<int> in{10, 0, 50, 100, 200, 34};
+  size_t width = 2;
+  size_t height = 3;
   std::vector<int> out(6, 0);
   std::vector<int> expected{12, 0, 63, 127, 255, 43};
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
   task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->inputs_count.emplace_back(width);
+  task_data_seq->inputs_count.emplace_back(height);
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_seq->outputs_count.emplace_back(out.size());
 
@@ -48,12 +52,16 @@ TEST(kozlova_e_contrast_enhancement_seq, test_1st_image) {
 TEST(kozlova_e_contrast_enhancement_seq, test_image2) {
   int size = 400;
   std::vector<int> in = GenerateVector(size);
+  size_t width = 10;
+  size_t height = 40;
   std::vector<int> out(size, 0);
   std::vector<int> expect(size, 0);
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
   task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->inputs_count.emplace_back(width);
+  task_data_seq->inputs_count.emplace_back(height);
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_seq->outputs_count.emplace_back(out.size());
 
@@ -75,11 +83,15 @@ TEST(kozlova_e_contrast_enhancement_seq, test_image2) {
 
 TEST(kozlova_e_contrast_enhancement_seq, test_empty_input) {
   std::vector<int> in = {};
+  size_t width = 0;
+  size_t height = 0;
   std::vector<int> out(0, 0);
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
   task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->inputs_count.emplace_back(width);
+  task_data_seq->inputs_count.emplace_back(height);
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_seq->outputs_count.emplace_back(out.size());
 
@@ -89,11 +101,15 @@ TEST(kozlova_e_contrast_enhancement_seq, test_empty_input) {
 
 TEST(kozlova_e_contrast_enhancement_seq, test_same_values_input) {
   std::vector<int> in(6, 100);
+  size_t width = 2;
+  size_t height = 3;
   std::vector<int> out(6, 0);
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
   task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->inputs_count.emplace_back(width);
+  task_data_seq->inputs_count.emplace_back(height);
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_seq->outputs_count.emplace_back(out.size());
 
@@ -108,11 +124,15 @@ TEST(kozlova_e_contrast_enhancement_seq, test_same_values_input) {
 
 TEST(kozlova_e_contrast_enhancement_seq, test_difference_input) {
   std::vector<int> in{10, 20, 30, 100, 200, 250};
+  size_t width = 2;
+  size_t height = 3;
   std::vector<int> out(6, 0);
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
   task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->inputs_count.emplace_back(width);
+  task_data_seq->inputs_count.emplace_back(height);
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_seq->outputs_count.emplace_back(out.size());
 
@@ -134,11 +154,15 @@ TEST(kozlova_e_contrast_enhancement_seq, test_difference_input) {
 
 TEST(kozlova_e_contrast_enhancement_seq, test_negative_values) {
   std::vector<int> in{-10, -20, -30, -100, -200, -250};
+  size_t width = 3;
+  size_t height = 2;
   std::vector<int> out(6, 0);
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
   task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->inputs_count.emplace_back(width);
+  task_data_seq->inputs_count.emplace_back(height);
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_seq->outputs_count.emplace_back(out.size());
 
@@ -150,11 +174,33 @@ TEST(kozlova_e_contrast_enhancement_seq, test_negative_values) {
 
 TEST(kozlova_e_contrast_enhancement_seq, test_incorrect_input_size) {
   std::vector<int> in = {3, 3, 3};
+  size_t width = 3;
+  size_t height = 1;
   std::vector<int> out(0, 0);
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
   task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->inputs_count.emplace_back(width);
+  task_data_seq->inputs_count.emplace_back(height);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  kozlova_e_contrast_enhancement_seq::TestTaskSequential test_task_sequential(task_data_seq);
+  ASSERT_FALSE(test_task_sequential.Validation());
+}
+
+TEST(kozlova_e_contrast_enhancement_seq, test_incorrect_input_width) {
+  std::vector<int> in = {3, 3, 3, 3};
+  size_t width = 3;
+  size_t height = 1;
+  std::vector<int> out(4, 0);
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->inputs_count.emplace_back(width);
+  task_data_seq->inputs_count.emplace_back(height);
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_seq->outputs_count.emplace_back(out.size());
 

--- a/tasks/seq/kozlova_e_contrast_enhancement/func_tests/main.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/func_tests/main.cpp
@@ -1,16 +1,17 @@
 #include <gtest/gtest.h>
+#include <stdlib.h>
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
-#include <random>
-#include <ranges>
 #include <vector>
 
 #include "core/task/include/task.hpp"
 #include "seq/kozlova_e_contrast_enhancement/include/ops_seq.hpp"
 
-static std::vector<int> GenerateVector(int length);
+namespace {
+std::vector<int> GenerateVector(int length);
 
 std::vector<int> GenerateVector(int length) {
   std::vector<int> vec;
@@ -20,6 +21,7 @@ std::vector<int> GenerateVector(int length) {
   }
   return vec;
 }
+}  // namespace
 
 TEST(kozlova_e_contrast_enhancement_seq, test_1st_image) {
   std::vector<int> in{10, 0, 50, 100, 200};

--- a/tasks/seq/kozlova_e_contrast_enhancement/func_tests/main.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/func_tests/main.cpp
@@ -24,8 +24,8 @@ std::vector<int> GenerateVector(int length) {
 }  // namespace
 
 TEST(kozlova_e_contrast_enhancement_seq, test_1st_image) {
-  std::vector<int> in{10, 0, 50, 100, 200};
-  std::vector<int> out(5, 0);
+  std::vector<int> in{10, 0, 50, 100, 200, 34};
+  std::vector<int> out(6, 0);
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
@@ -44,6 +44,7 @@ TEST(kozlova_e_contrast_enhancement_seq, test_1st_image) {
   EXPECT_EQ(out[2], 63);
   EXPECT_EQ(out[3], 127);
   EXPECT_EQ(out[4], 255);
+  EXPECT_EQ(out[5], 43);
 }
 
 TEST(kozlova_e_contrast_enhancement_seq, test_image2) {
@@ -89,8 +90,8 @@ TEST(kozlova_e_contrast_enhancement_seq, test_empty_input) {
 }
 
 TEST(kozlova_e_contrast_enhancement_seq, test_same_values_input) {
-  std::vector<int> in(5, 100);
-  std::vector<int> out(5, 0);
+  std::vector<int> in(6, 100);
+  std::vector<int> out(6, 0);
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
@@ -147,4 +148,18 @@ TEST(kozlova_e_contrast_enhancement_seq, test_negative_values) {
   ASSERT_EQ(test_task_sequential.Validation(), true);
   test_task_sequential.PreProcessing();
   ASSERT_ANY_THROW(test_task_sequential.Run());
+}
+
+TEST(kozlova_e_contrast_enhancement_seq, test_incorrect_input_size) {
+  std::vector<int> in = {3, 3, 3};
+  std::vector<int> out(0, 0);
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  kozlova_e_contrast_enhancement_seq::TestTaskSequential test_task_sequential(task_data_seq);
+  ASSERT_FALSE(test_task_sequential.Validation());
 }

--- a/tasks/seq/kozlova_e_contrast_enhancement/func_tests/main.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/func_tests/main.cpp
@@ -1,16 +1,20 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <random>
+#include <ranges>
 #include <vector>
 
 #include "core/task/include/task.hpp"
-#include "core/util/include/util.hpp"
 #include "seq/kozlova_e_contrast_enhancement/include/ops_seq.hpp"
 
-std::vector<int> generate_vector(int length);
+static std::vector<int> GenerateVector(int length);
 
-std::vector<int> generate_vector(int length) {
+std::vector<int> GenerateVector(int length) {
   std::vector<int> vec;
+  vec.reserve(length);
   for (int i = 0; i < length; ++i) {
     vec.push_back(rand() % 256);
   }
@@ -42,7 +46,7 @@ TEST(kozlova_e_contrast_enhancement_seq, test_1st_image) {
 
 TEST(kozlova_e_contrast_enhancement_seq, test_image2) {
   int size = 400;
-  std::vector<int> in = generate_vector(size);
+  std::vector<int> in = GenerateVector(size);
   std::vector<int> out(size, 0);
   std::vector<int> expect(size, 0);
 
@@ -58,8 +62,8 @@ TEST(kozlova_e_contrast_enhancement_seq, test_image2) {
   test_task_sequential.Run();
   test_task_sequential.PostProcessing();
 
-  int min_value = *std::min_element(in.begin(), in.end());
-  int max_value = *std::max_element(in.begin(), in.end());
+  int min_value = *std::ranges::min_element(in);
+  int max_value = *std::ranges::max_element(in);
 
   for (size_t i = 0; i < in.size(); ++i) {
     int expected = static_cast<int>(((in[i] - min_value) / (double)(max_value - min_value)) * 255);
@@ -117,8 +121,8 @@ TEST(kozlova_e_contrast_enhancement_seq, test_difference_input) {
   test_task_sequential.Run();
   test_task_sequential.PostProcessing();
 
-  int min_value = *std::min_element(in.begin(), in.end());
-  int max_value = *std::max_element(in.begin(), in.end());
+  int min_value = *std::ranges::min_element(in);
+  int max_value = *std::ranges::max_element(in);
 
   for (size_t i = 0; i < in.size(); ++i) {
     int expected = static_cast<int>(((in[i] - min_value) / (double)(max_value - min_value)) * 255);

--- a/tasks/seq/kozlova_e_contrast_enhancement/func_tests/main.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/func_tests/main.cpp
@@ -7,6 +7,8 @@
 #include "core/util/include/util.hpp"
 #include "seq/kozlova_e_contrast_enhancement/include/ops_seq.hpp"
 
+std::vector<int> generate_vector(int length);
+
 std::vector<int> generate_vector(int length) {
   std::vector<int> vec;
   for (int i = 0; i < length; ++i) {

--- a/tasks/seq/kozlova_e_contrast_enhancement/func_tests/main.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/func_tests/main.cpp
@@ -26,6 +26,7 @@ std::vector<int> GenerateVector(int length) {
 TEST(kozlova_e_contrast_enhancement_seq, test_1st_image) {
   std::vector<int> in{10, 0, 50, 100, 200, 34};
   std::vector<int> out(6, 0);
+  std::vector<int> expected{12, 0, 63, 127, 255, 43};
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
@@ -39,12 +40,9 @@ TEST(kozlova_e_contrast_enhancement_seq, test_1st_image) {
   test_task_sequential.Run();
   test_task_sequential.PostProcessing();
 
-  EXPECT_EQ(out[0], 12);
-  EXPECT_EQ(out[1], 0);
-  EXPECT_EQ(out[2], 63);
-  EXPECT_EQ(out[3], 127);
-  EXPECT_EQ(out[4], 255);
-  EXPECT_EQ(out[5], 43);
+  for (size_t i = 0; i < out.size(); ++i) {
+    EXPECT_EQ(out[i], expected[i]);
+  }
 }
 
 TEST(kozlova_e_contrast_enhancement_seq, test_image2) {

--- a/tasks/seq/kozlova_e_contrast_enhancement/include/ops_seq.hpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/include/ops_seq.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <utility>
 #include <vector>
 

--- a/tasks/seq/kozlova_e_contrast_enhancement/include/ops_seq.hpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/include/ops_seq.hpp
@@ -17,8 +17,8 @@ class TestTaskSequential : public ppc::core::Task {
 
  private:
   std::vector<int> input_;
-  size_t width = 0;
-  size_t height = 0;
+  size_t width_ = 0;
+  size_t height_ = 0;
   std::vector<int> output_;
 };
 

--- a/tasks/seq/kozlova_e_contrast_enhancement/include/ops_seq.hpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/include/ops_seq.hpp
@@ -17,6 +17,8 @@ class TestTaskSequential : public ppc::core::Task {
 
  private:
   std::vector<int> input_;
+  size_t width = 0;
+  size_t height = 0;
   std::vector<int> output_;
 };
 

--- a/tasks/seq/kozlova_e_contrast_enhancement/include/ops_seq.hpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/include/ops_seq.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kozlova_e_contrast_enhancement_seq {
+
+class TestTaskSequential : public ppc::core::Task {
+ public:
+  explicit TestTaskSequential(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> input_;
+  std::vector<int> output_;
+};
+
+}  // namespace kozlova_e_contrast_enhancement_seq

--- a/tasks/seq/kozlova_e_contrast_enhancement/perf_tests/main.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/perf_tests/main.cpp
@@ -2,16 +2,21 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstddef>
+#include <memory>
+#include <random>
+#include <ranges>
 #include <vector>
 
 #include "core/perf/include/perf.hpp"
 #include "core/task/include/task.hpp"
 #include "seq/kozlova_e_contrast_enhancement/include/ops_seq.hpp"
 
-std::vector<int> generate_vector(int length);
+static std::vector<int> GenerateVector(int length);
 
-std::vector<int> generate_vector(int length) {
+std::vector<int> GenerateVector(int length) {
   std::vector<int> vec;
+  vec.reserve(length);
   for (int i = 0; i < length; ++i) {
     vec.push_back(rand() % 256);
   }
@@ -19,11 +24,11 @@ std::vector<int> generate_vector(int length) {
 }
 
 TEST(kozlova_e_contrast_enhancement_seq, test_pipeline_run) {
-  constexpr int size = 20000000;
+  constexpr int kSize = 20000000;
 
   // Create data
-  std::vector<int> in = generate_vector(size);
-  std::vector<int> out(size, 0);
+  std::vector<int> in = GenerateVector(kSize);
+  std::vector<int> out(kSize, 0);
 
   // Create task_data
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
@@ -53,8 +58,8 @@ TEST(kozlova_e_contrast_enhancement_seq, test_pipeline_run) {
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
-  int min_value = *std::min_element(in.begin(), in.end());
-  int max_value = *std::max_element(in.begin(), in.end());
+  int min_value = *std::ranges::min_element(in);
+  int max_value = *std::ranges::max_element(in);
 
   for (size_t i = 0; i < in.size(); ++i) {
     int expected = static_cast<int>(((in[i] - min_value) / (double)(max_value - min_value)) * 255);
@@ -64,11 +69,11 @@ TEST(kozlova_e_contrast_enhancement_seq, test_pipeline_run) {
 }
 
 TEST(kozlova_e_contrast_enhancement_seq, test_task_run) {
-  constexpr int size = 20000000;
+  constexpr int kSize = 20000000;
 
   // Create data
-  std::vector<int> in = generate_vector(size);
-  std::vector<int> out(size, 0);
+  std::vector<int> in = GenerateVector(kSize);
+  std::vector<int> out(kSize, 0);
 
   // Create task_data
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
@@ -98,8 +103,8 @@ TEST(kozlova_e_contrast_enhancement_seq, test_task_run) {
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
-  int min_value = *std::min_element(in.begin(), in.end());
-  int max_value = *std::max_element(in.begin(), in.end());
+  int min_value = *std::ranges::min_element(in);
+  int max_value = *std::ranges::max_element(in);
 
   for (size_t i = 0; i < in.size(); ++i) {
     int expected = static_cast<int>(((in[i] - min_value) / (double)(max_value - min_value)) * 255);

--- a/tasks/seq/kozlova_e_contrast_enhancement/perf_tests/main.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/perf_tests/main.cpp
@@ -2,9 +2,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <cstddef>
-#include <cstdint>
-#include <memory>
 #include <vector>
 
 #include "core/perf/include/perf.hpp"

--- a/tasks/seq/kozlova_e_contrast_enhancement/perf_tests/main.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/perf_tests/main.cpp
@@ -1,0 +1,110 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "seq/kozlova_e_contrast_enhancement/include/ops_seq.hpp"
+
+std::vector<int> generate_vector(int length) {
+  std::vector<int> vec;
+  for (int i = 0; i < length; ++i) {
+    vec.push_back(rand() % 256);
+  }
+  return vec;
+}
+
+TEST(kozlova_e_contrast_enhancement_seq, test_pipeline_run) {
+  constexpr int size = 20000000;
+
+  // Create data
+  std::vector<int> in = generate_vector(size);
+  std::vector<int> out(size, 0);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_sequential = std::make_shared<kozlova_e_contrast_enhancement_seq::TestTaskSequential>(task_data_seq);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  int min_value = *std::min_element(in.begin(), in.end());
+  int max_value = *std::max_element(in.begin(), in.end());
+
+  for (size_t i = 0; i < in.size(); ++i) {
+    int expected = static_cast<int>(((in[i] - min_value) / (double)(max_value - min_value)) * 255);
+    expected = std::clamp(expected, 0, 255);
+    EXPECT_EQ(out[i], expected);
+  }
+}
+
+TEST(kozlova_e_contrast_enhancement_seq, test_task_run) {
+  constexpr int size = 20000000;
+
+  // Create data
+  std::vector<int> in = generate_vector(size);
+  std::vector<int> out(size, 0);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_sequential = std::make_shared<kozlova_e_contrast_enhancement_seq::TestTaskSequential>(task_data_seq);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  int min_value = *std::min_element(in.begin(), in.end());
+  int max_value = *std::max_element(in.begin(), in.end());
+
+  for (size_t i = 0; i < in.size(); ++i) {
+    int expected = static_cast<int>(((in[i] - min_value) / (double)(max_value - min_value)) * 255);
+    expected = std::clamp(expected, 0, 255);
+    EXPECT_EQ(out[i], expected);
+  }
+}

--- a/tasks/seq/kozlova_e_contrast_enhancement/perf_tests/main.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/perf_tests/main.cpp
@@ -8,6 +8,8 @@
 #include "core/task/include/task.hpp"
 #include "seq/kozlova_e_contrast_enhancement/include/ops_seq.hpp"
 
+std::vector<int> generate_vector(int length);
+
 std::vector<int> generate_vector(int length) {
   std::vector<int> vec;
   for (int i = 0; i < length; ++i) {

--- a/tasks/seq/kozlova_e_contrast_enhancement/perf_tests/main.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/perf_tests/main.cpp
@@ -1,10 +1,10 @@
 #include <gtest/gtest.h>
-#include <stdlib.h>
 
 #include <algorithm>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <memory>
 #include <vector>
 

--- a/tasks/seq/kozlova_e_contrast_enhancement/perf_tests/main.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/perf_tests/main.cpp
@@ -26,8 +26,9 @@ std::vector<int> GenerateVector(int length) {
 }  // namespace
 
 TEST(kozlova_e_contrast_enhancement_seq, test_pipeline_run) {
-  constexpr int kSize = 20000000;
-
+  constexpr int kSize = 19875000;
+  size_t width = 7500;
+  size_t height = 2650;
   // Create data
   std::vector<int> in = GenerateVector(kSize);
   std::vector<int> out(kSize, 0);
@@ -36,6 +37,8 @@ TEST(kozlova_e_contrast_enhancement_seq, test_pipeline_run) {
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
   task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->inputs_count.emplace_back(width);
+  task_data_seq->inputs_count.emplace_back(height);
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_seq->outputs_count.emplace_back(out.size());
 
@@ -71,8 +74,9 @@ TEST(kozlova_e_contrast_enhancement_seq, test_pipeline_run) {
 }
 
 TEST(kozlova_e_contrast_enhancement_seq, test_task_run) {
-  constexpr int kSize = 20000000;
-
+  constexpr int kSize = 19875000;
+  size_t width = 7500;
+  size_t height = 2650;
   // Create data
   std::vector<int> in = GenerateVector(kSize);
   std::vector<int> out(kSize, 0);
@@ -81,6 +85,8 @@ TEST(kozlova_e_contrast_enhancement_seq, test_task_run) {
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
   task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->inputs_count.emplace_back(width);
+  task_data_seq->inputs_count.emplace_back(height);
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_seq->outputs_count.emplace_back(out.size());
 

--- a/tasks/seq/kozlova_e_contrast_enhancement/perf_tests/main.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/perf_tests/main.cpp
@@ -1,18 +1,19 @@
 #include <gtest/gtest.h>
+#include <stdlib.h>
 
 #include <algorithm>
 #include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
-#include <random>
-#include <ranges>
 #include <vector>
 
 #include "core/perf/include/perf.hpp"
 #include "core/task/include/task.hpp"
 #include "seq/kozlova_e_contrast_enhancement/include/ops_seq.hpp"
 
-static std::vector<int> GenerateVector(int length);
+namespace {
+std::vector<int> GenerateVector(int length);
 
 std::vector<int> GenerateVector(int length) {
   std::vector<int> vec;
@@ -22,6 +23,7 @@ std::vector<int> GenerateVector(int length) {
   }
   return vec;
 }
+}  // namespace
 
 TEST(kozlova_e_contrast_enhancement_seq, test_pipeline_run) {
   constexpr int kSize = 20000000;

--- a/tasks/seq/kozlova_e_contrast_enhancement/src/ops_seq.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/src/ops_seq.cpp
@@ -15,7 +15,7 @@ bool kozlova_e_contrast_enhancement_seq::TestTaskSequential::PreProcessingImpl()
 }
 
 bool kozlova_e_contrast_enhancement_seq::TestTaskSequential::ValidationImpl() {
-  return task_data->inputs_count[0] == task_data->outputs_count[0] && task_data->inputs_count[0] > 0;
+  return task_data->inputs_count[0] == task_data->outputs_count[0] && task_data->inputs_count[0] > 0 && (task_data->inputs_count[0] % 2 == 0);
 }
 
 bool kozlova_e_contrast_enhancement_seq::TestTaskSequential::RunImpl() {

--- a/tasks/seq/kozlova_e_contrast_enhancement/src/ops_seq.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/src/ops_seq.cpp
@@ -1,0 +1,45 @@
+#include "seq/kozlova_e_contrast_enhancement/include/ops_seq.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+bool kozlova_e_contrast_enhancement_seq::TestTaskSequential::PreProcessingImpl() {
+  auto* input_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
+  size_t size = task_data->inputs_count[0];
+  output_.resize(size, 0);
+  input_.resize(size);
+  std::copy(input_ptr, input_ptr + size, input_.begin());
+
+  return true;
+}
+
+bool kozlova_e_contrast_enhancement_seq::TestTaskSequential::ValidationImpl() {
+  return task_data->inputs_count[0] == task_data->outputs_count[0] && task_data->inputs_count[0] > 0;
+}
+
+bool kozlova_e_contrast_enhancement_seq::TestTaskSequential::RunImpl() {
+  int min_value = *std::min_element(input_.begin(), input_.end());
+  int max_value = *std::max_element(input_.begin(), input_.end());
+
+  if (min_value == max_value) {
+    std::copy(input_.begin(), input_.end(), output_.begin());
+    return true;
+  }
+
+  for (size_t i = 0; i < input_.size(); ++i) {
+    output_[i] = static_cast<int>(((input_[i] - min_value) / (double)(max_value - min_value)) * 255);
+    output_[i] = std::clamp(output_[i], 0, 255);
+  }
+
+  return true;
+}
+
+bool kozlova_e_contrast_enhancement_seq::TestTaskSequential::PostProcessingImpl() {
+  for (size_t i = 0; i < output_.size(); ++i) {
+    reinterpret_cast<int*>(task_data->outputs[0])[i] = output_[i];
+  }
+  return true;
+}

--- a/tasks/seq/kozlova_e_contrast_enhancement/src/ops_seq.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/src/ops_seq.cpp
@@ -20,6 +20,9 @@ bool kozlova_e_contrast_enhancement_seq::TestTaskSequential::ValidationImpl() {
 
 bool kozlova_e_contrast_enhancement_seq::TestTaskSequential::RunImpl() {
   int min_value = *std::ranges::min_element(input_);
+  if (min_value < 0) {
+    throw "incorrect value";
+  }
   int max_value = *std::ranges::max_element(input_);
 
   if (min_value == max_value) {

--- a/tasks/seq/kozlova_e_contrast_enhancement/src/ops_seq.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/src/ops_seq.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cstddef>
-#include <ranges>
 #include <vector>
 
 bool kozlova_e_contrast_enhancement_seq::TestTaskSequential::PreProcessingImpl() {

--- a/tasks/seq/kozlova_e_contrast_enhancement/src/ops_seq.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/src/ops_seq.cpp
@@ -7,8 +7,8 @@
 bool kozlova_e_contrast_enhancement_seq::TestTaskSequential::PreProcessingImpl() {
   auto* input_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
   size_t size = task_data->inputs_count[0];
-  width = task_data->inputs_count[1];
-  height = task_data->inputs_count[2];
+  width_ = task_data->inputs_count[1];
+  height_ = task_data->inputs_count[2];
   output_.resize(size, 0);
   input_.resize(size);
   std::copy(input_ptr, input_ptr + size, input_.begin());

--- a/tasks/seq/kozlova_e_contrast_enhancement/src/ops_seq.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/src/ops_seq.cpp
@@ -1,7 +1,6 @@
 #include "seq/kozlova_e_contrast_enhancement/include/ops_seq.hpp"
 
 #include <algorithm>
-#include <cmath>
 #include <cstddef>
 #include <memory>
 #include <vector>

--- a/tasks/seq/kozlova_e_contrast_enhancement/src/ops_seq.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/src/ops_seq.cpp
@@ -2,7 +2,7 @@
 
 #include <algorithm>
 #include <cstddef>
-#include <memory>
+#include <ranges>
 #include <vector>
 
 bool kozlova_e_contrast_enhancement_seq::TestTaskSequential::PreProcessingImpl() {
@@ -20,11 +20,11 @@ bool kozlova_e_contrast_enhancement_seq::TestTaskSequential::ValidationImpl() {
 }
 
 bool kozlova_e_contrast_enhancement_seq::TestTaskSequential::RunImpl() {
-  int min_value = *std::min_element(input_.begin(), input_.end());
-  int max_value = *std::max_element(input_.begin(), input_.end());
+  int min_value = *std::ranges::min_element(input_);
+  int max_value = *std::ranges::max_element(input_);
 
   if (min_value == max_value) {
-    std::copy(input_.begin(), input_.end(), output_.begin());
+    std::ranges::copy(input_, output_.begin());
     return true;
   }
 

--- a/tasks/seq/kozlova_e_contrast_enhancement/src/ops_seq.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/src/ops_seq.cpp
@@ -7,6 +7,8 @@
 bool kozlova_e_contrast_enhancement_seq::TestTaskSequential::PreProcessingImpl() {
   auto* input_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
   size_t size = task_data->inputs_count[0];
+  width = task_data->inputs_count[1];
+  height = task_data->inputs_count[2];
   output_.resize(size, 0);
   input_.resize(size);
   std::copy(input_ptr, input_ptr + size, input_.begin());
@@ -15,8 +17,11 @@ bool kozlova_e_contrast_enhancement_seq::TestTaskSequential::PreProcessingImpl()
 }
 
 bool kozlova_e_contrast_enhancement_seq::TestTaskSequential::ValidationImpl() {
-  return task_data->inputs_count[0] == task_data->outputs_count[0] && task_data->inputs_count[0] > 0 &&
-         (task_data->inputs_count[0] % 2 == 0);
+  size_t size = task_data->inputs_count[0];
+  size_t check_width = task_data->inputs_count[1];
+  size_t check_height = task_data->inputs_count[2];
+  return size == task_data->outputs_count[0] && size > 0 && (size % 2 == 0) && check_width >= 1 && check_height >= 1 &&
+         (size == check_height * check_width);
 }
 
 bool kozlova_e_contrast_enhancement_seq::TestTaskSequential::RunImpl() {

--- a/tasks/seq/kozlova_e_contrast_enhancement/src/ops_seq.cpp
+++ b/tasks/seq/kozlova_e_contrast_enhancement/src/ops_seq.cpp
@@ -15,7 +15,8 @@ bool kozlova_e_contrast_enhancement_seq::TestTaskSequential::PreProcessingImpl()
 }
 
 bool kozlova_e_contrast_enhancement_seq::TestTaskSequential::ValidationImpl() {
-  return task_data->inputs_count[0] == task_data->outputs_count[0] && task_data->inputs_count[0] > 0 && (task_data->inputs_count[0] % 2 == 0);
+  return task_data->inputs_count[0] == task_data->outputs_count[0] && task_data->inputs_count[0] > 0 &&
+         (task_data->inputs_count[0] % 2 == 0);
 }
 
 bool kozlova_e_contrast_enhancement_seq::TestTaskSequential::RunImpl() {


### PR DESCRIPTION
Полутоновое изображение представлено вектором целых чисел. Значения пикселей изображения масштабируются на весь диапазон от 0 до 255. Для этого находятся минимальное и максимальное значения пикселей, которые используются как конечные точки для растяжки, распределяя все пиксели между этими границами.