### PR TITLE
Коровин Никита. Вариант 14. Технология OMP. Сортировка Хоара с четно-нечетным слиянием Бэтчера.

### DIFF
--- a/tasks/omp/korovin_n_qsort_batcher_omp/func_tests/main.cpp
+++ b/tasks/omp/korovin_n_qsort_batcher_omp/func_tests/main.cpp
@@ -31,14 +31,12 @@ std::vector<int> GenerateRndVector(GenParams param) {
 void RunTest(std::vector<int> &in) {
   std::vector<int> out(in.size());
 
-  // Create task_data
   auto task_data_omp = std::make_shared<ppc::core::TaskData>();
   task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
   task_data_omp->inputs_count.emplace_back(in.size());
   task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_omp->outputs_count.emplace_back(out.size());
 
-  // Create Task
   korovin_n_qsort_batcher_omp::TestTaskOpenMP test_task_omp(task_data_omp);
   ASSERT_TRUE(test_task_omp.Validation());
   ASSERT_TRUE(test_task_omp.PreProcessing());
@@ -49,31 +47,26 @@ void RunTest(std::vector<int> &in) {
 }  // namespace
 
 TEST(korovin_n_qsort_batcher_omp, test_unsort) {
-  // Create data
   std::vector<int> in = {11, 5, 1, 42, 3, 8, 7, 25, 6};
   RunTest(in);
 }
 
 TEST(korovin_n_qsort_batcher_omp, test_empty_sort) {
-  // Create data
   std::vector<int> in = {};
   RunTest(in);
 }
 
 TEST(korovin_n_qsort_batcher_omp, test_one_el_sort) {
-  // Create data
   std::vector<int> in = {42};
   RunTest(in);
 }
 
 TEST(korovin_n_qsort_batcher_omp, test_already_sort) {
-  // Create data
   std::vector<int> in = {1, 2, 3, 4, 5, 6};
   RunTest(in);
 }
 
 TEST(korovin_n_qsort_batcher_omp, test_random_sort) {
-  // Create data
   auto param = GenParams();
   param.size = 20;
 
@@ -82,7 +75,6 @@ TEST(korovin_n_qsort_batcher_omp, test_random_sort) {
 }
 
 TEST(korovin_n_qsort_batcher_omp, test_random_sort_100) {
-  // Create data
   auto param = GenParams();
   param.size = 100;
 
@@ -91,7 +83,6 @@ TEST(korovin_n_qsort_batcher_omp, test_random_sort_100) {
 }
 
 TEST(korovin_n_qsort_batcher_omp, test_random_sort_500) {
-  // Create data
   auto param = GenParams();
   param.size = 500;
 
@@ -100,7 +91,6 @@ TEST(korovin_n_qsort_batcher_omp, test_random_sort_500) {
 }
 
 TEST(korovin_n_qsort_batcher_omp, test_random_sort_1000) {
-  // Create data
   auto param = GenParams();
   param.size = 1000;
 

--- a/tasks/omp/korovin_n_qsort_batcher_omp/func_tests/main.cpp
+++ b/tasks/omp/korovin_n_qsort_batcher_omp/func_tests/main.cpp
@@ -51,6 +51,11 @@ TEST(korovin_n_qsort_batcher_omp, test_unsort) {
   RunTest(in);
 }
 
+TEST(korovin_n_qsort_batcher_omp, test_reverse_sort) {
+  std::vector<int> in = {10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
+  RunTest(in);
+}
+
 TEST(korovin_n_qsort_batcher_omp, test_empty_sort) {
   std::vector<int> in = {};
   RunTest(in);

--- a/tasks/omp/korovin_n_qsort_batcher_omp/func_tests/main.cpp
+++ b/tasks/omp/korovin_n_qsort_batcher_omp/func_tests/main.cpp
@@ -1,0 +1,109 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "omp/korovin_n_qsort_batcher_omp/include/ops_omp.hpp"
+
+namespace {
+struct GenParams {
+  int size;
+  int lower_bound = -500;
+  int upper_bound = 500;
+};
+
+std::vector<int> GenerateRndVector(GenParams param) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> dist(param.lower_bound, param.upper_bound);
+
+  std::vector<int> v1(param.size);
+  for (auto &num : v1) {
+    num = dist(gen);
+  }
+  return v1;
+}
+
+void RunTest(std::vector<int> &in) {
+  std::vector<int> out(in.size());
+
+  // Create task_data
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  korovin_n_qsort_batcher_omp::TestTaskOpenMP test_task_omp(task_data_omp);
+  ASSERT_TRUE(test_task_omp.Validation());
+  ASSERT_TRUE(test_task_omp.PreProcessing());
+  ASSERT_TRUE(test_task_omp.Run());
+  ASSERT_TRUE(test_task_omp.PostProcessing());
+  ASSERT_TRUE(std::ranges::is_sorted(out));
+}
+}  // namespace
+
+TEST(korovin_n_qsort_batcher_omp, test_unsort) {
+  // Create data
+  std::vector<int> in = {11, 5, 1, 42, 3, 8, 7, 25, 6};
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_omp, test_empty_sort) {
+  // Create data
+  std::vector<int> in = {};
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_omp, test_one_el_sort) {
+  // Create data
+  std::vector<int> in = {42};
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_omp, test_already_sort) {
+  // Create data
+  std::vector<int> in = {1, 2, 3, 4, 5, 6};
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_omp, test_random_sort) {
+  // Create data
+  auto param = GenParams();
+  param.size = 20;
+
+  std::vector<int> in = GenerateRndVector(param);
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_omp, test_random_sort_100) {
+  // Create data
+  auto param = GenParams();
+  param.size = 100;
+
+  std::vector<int> in = GenerateRndVector(param);
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_omp, test_random_sort_500) {
+  // Create data
+  auto param = GenParams();
+  param.size = 500;
+
+  std::vector<int> in = GenerateRndVector(param);
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_omp, test_random_sort_1000) {
+  // Create data
+  auto param = GenParams();
+  param.size = 1000;
+
+  std::vector<int> in = GenerateRndVector(param);
+  RunTest(in);
+}

--- a/tasks/omp/korovin_n_qsort_batcher_omp/func_tests/main.cpp
+++ b/tasks/omp/korovin_n_qsort_batcher_omp/func_tests/main.cpp
@@ -56,6 +56,11 @@ TEST(korovin_n_qsort_batcher_omp, test_reverse_sort) {
   RunTest(in);
 }
 
+TEST(korovin_n_qsort_batcher_omp, test_double_reverse_sort) {
+  std::vector<int> in = {5, 4, 3, 2, 1, 5, 4, 3, 2, 1};
+  RunTest(in);
+}
+
 TEST(korovin_n_qsort_batcher_omp, test_empty_sort) {
   std::vector<int> in = {};
   RunTest(in);

--- a/tasks/omp/korovin_n_qsort_batcher_omp/include/ops_omp.hpp
+++ b/tasks/omp/korovin_n_qsort_batcher_omp/include/ops_omp.hpp
@@ -25,7 +25,7 @@ class TestTaskOpenMP : public ppc::core::Task {
   std::vector<int> input_;
   static int GetRandomIndex(int low, int high);
   static void QuickSort(std::vector<int>& arr, int low, int high, int depth = 0);
-  static bool InPlaceMerge(std::vector<int>& arr, const BlockRange& A, const BlockRange& B, std::vector<int>& buffer);
+  static bool InPlaceMerge(std::vector<int>& arr, const BlockRange& a, const BlockRange& b, std::vector<int>& buffer);
   static std::vector<BlockRange> PartitionBlocks(int n, int p);
   void OddEvenMerge(std::vector<BlockRange>& blocks);
 };

--- a/tasks/omp/korovin_n_qsort_batcher_omp/include/ops_omp.hpp
+++ b/tasks/omp/korovin_n_qsort_batcher_omp/include/ops_omp.hpp
@@ -27,7 +27,7 @@ class TestTaskOpenMP : public ppc::core::Task {
   static void QuickSort(std::vector<int>::iterator low, std::vector<int>::iterator high, int depth = 0);
   static bool InPlaceMerge(const BlockRange& a, const BlockRange& b, std::vector<int>& buffer);
   static std::vector<BlockRange> PartitionBlocks(std::vector<int>& arr, int p);
-  void OddEvenMerge(std::vector<BlockRange>& blocks);
+  static void OddEvenMerge(std::vector<BlockRange>& blocks);
 };
 
 }  // namespace korovin_n_qsort_batcher_omp

--- a/tasks/omp/korovin_n_qsort_batcher_omp/include/ops_omp.hpp
+++ b/tasks/omp/korovin_n_qsort_batcher_omp/include/ops_omp.hpp
@@ -8,8 +8,8 @@
 namespace korovin_n_qsort_batcher_omp {
 
 struct BlockRange {
-  int start;
-  int length;
+  std::vector<int>::iterator low;
+  std::vector<int>::iterator high;
 };
 
 class TestTaskOpenMP : public ppc::core::Task {
@@ -24,9 +24,9 @@ class TestTaskOpenMP : public ppc::core::Task {
  private:
   std::vector<int> input_;
   static int GetRandomIndex(int low, int high);
-  static void QuickSort(std::vector<int>& arr, int low, int high, int depth = 0);
-  static bool InPlaceMerge(std::vector<int>& arr, const BlockRange& a, const BlockRange& b, std::vector<int>& buffer);
-  static std::vector<BlockRange> PartitionBlocks(int n, int p);
+  static void QuickSort(std::vector<int>::iterator low, std::vector<int>::iterator high, int depth = 0);
+  static bool InPlaceMerge(const BlockRange& a, const BlockRange& b, std::vector<int>& buffer);
+  static std::vector<BlockRange> PartitionBlocks(std::vector<int>& arr, int p);
   void OddEvenMerge(std::vector<BlockRange>& blocks);
 };
 

--- a/tasks/omp/korovin_n_qsort_batcher_omp/include/ops_omp.hpp
+++ b/tasks/omp/korovin_n_qsort_batcher_omp/include/ops_omp.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace korovin_n_qsort_batcher_omp {
+
+struct BlockRange {
+  int start;
+  int length;
+};
+
+class TestTaskOpenMP : public ppc::core::Task {
+ public:
+  explicit TestTaskOpenMP(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> input_;
+  static int GetRandomIndex(int low, int high);
+  static void QuickSort(std::vector<int>& arr, int low, int high, int depth = 0);
+  static bool InPlaceMerge(std::vector<int>& arr, const BlockRange& A, const BlockRange& B, std::vector<int>& buffer);
+  static std::vector<BlockRange> PartitionBlocks(int n, int p);
+  void OddEvenMerge(std::vector<BlockRange>& blocks);
+};
+
+}  // namespace korovin_n_qsort_batcher_omp

--- a/tasks/omp/korovin_n_qsort_batcher_omp/perf_tests/main.cpp
+++ b/tasks/omp/korovin_n_qsort_batcher_omp/perf_tests/main.cpp
@@ -11,7 +11,7 @@
 #include "omp/korovin_n_qsort_batcher_omp/include/ops_omp.hpp"
 
 TEST(korovin_n_qsort_batcher_omp, test_pipeline_run) {
-  constexpr int kSize = 10000000;
+  constexpr int kSize = 60000;
   std::vector<int> in(kSize);
   std::vector<int> out(in.size());
   std::iota(in.rbegin(), in.rend(), 1);
@@ -41,7 +41,7 @@ TEST(korovin_n_qsort_batcher_omp, test_pipeline_run) {
 }
 
 TEST(korovin_n_qsort_batcher_omp, test_task_run) {
-  constexpr int kSize = 10000000;
+  constexpr int kSize = 60000;
   std::vector<int> in(kSize);
   std::vector<int> out(in.size());
   std::iota(in.rbegin(), in.rend(), 1);

--- a/tasks/omp/korovin_n_qsort_batcher_omp/perf_tests/main.cpp
+++ b/tasks/omp/korovin_n_qsort_batcher_omp/perf_tests/main.cpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
+#include <numeric>
 #include <vector>
 
 #include "core/perf/include/perf.hpp"
@@ -10,26 +11,19 @@
 #include "omp/korovin_n_qsort_batcher_omp/include/ops_omp.hpp"
 
 TEST(korovin_n_qsort_batcher_omp, test_pipeline_run) {
-  // Create data
-  constexpr int kSize = 20000000;
+  constexpr int kSize = 10000000;
   std::vector<int> in(kSize);
   std::vector<int> out(in.size());
+  std::iota(in.rbegin(), in.rend(), 1);
 
-  for (int i = 0; i < kSize; i++) {
-    in[i] = kSize - i;
-  }
-
-  // Create task_data
   auto task_data_omp = std::make_shared<ppc::core::TaskData>();
   task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
   task_data_omp->inputs_count.emplace_back(in.size());
   task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_omp->outputs_count.emplace_back(out.size());
 
-  // Create Task
   auto test_task_omp = std::make_shared<korovin_n_qsort_batcher_omp::TestTaskOpenMP>(task_data_omp);
 
-  // Create Perf attributes
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
@@ -39,36 +33,27 @@ TEST(korovin_n_qsort_batcher_omp, test_pipeline_run) {
     return static_cast<double>(duration) * 1e-9;
   };
 
-  // Create and init perf results
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
 
-  // Create Perf analyzer
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 }
 
 TEST(korovin_n_qsort_batcher_omp, test_task_run) {
-  // Create data
-  constexpr int kSize = 20000000;
+  constexpr int kSize = 10000000;
   std::vector<int> in(kSize);
   std::vector<int> out(in.size());
+  std::iota(in.rbegin(), in.rend(), 1);
 
-  for (int i = 0; i < kSize; i++) {
-    in[i] = kSize - i;
-  }
-
-  // Create task_data
   auto task_data_omp = std::make_shared<ppc::core::TaskData>();
   task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
   task_data_omp->inputs_count.emplace_back(in.size());
   task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_omp->outputs_count.emplace_back(out.size());
 
-  // Create Task
   auto test_task_omp = std::make_shared<korovin_n_qsort_batcher_omp::TestTaskOpenMP>(task_data_omp);
 
-  // Create Perf attributes
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
@@ -78,10 +63,8 @@ TEST(korovin_n_qsort_batcher_omp, test_task_run) {
     return static_cast<double>(duration) * 1e-9;
   };
 
-  // Create and init perf results
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
 
-  // Create Perf analyzer
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);

--- a/tasks/omp/korovin_n_qsort_batcher_omp/perf_tests/main.cpp
+++ b/tasks/omp/korovin_n_qsort_batcher_omp/perf_tests/main.cpp
@@ -11,7 +11,7 @@
 #include "omp/korovin_n_qsort_batcher_omp/include/ops_omp.hpp"
 
 TEST(korovin_n_qsort_batcher_omp, test_pipeline_run) {
-  constexpr int kSize = 60000;
+  constexpr int kSize = 250000;
   std::vector<int> in(kSize);
   std::vector<int> out(in.size());
   std::iota(in.rbegin(), in.rend(), 1);
@@ -25,7 +25,7 @@ TEST(korovin_n_qsort_batcher_omp, test_pipeline_run) {
   auto test_task_omp = std::make_shared<korovin_n_qsort_batcher_omp::TestTaskOpenMP>(task_data_omp);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 10;
+  perf_attr->num_running = 35;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&] {
     auto current_time_point = std::chrono::high_resolution_clock::now();
@@ -41,7 +41,7 @@ TEST(korovin_n_qsort_batcher_omp, test_pipeline_run) {
 }
 
 TEST(korovin_n_qsort_batcher_omp, test_task_run) {
-  constexpr int kSize = 60000;
+  constexpr int kSize = 250000;
   std::vector<int> in(kSize);
   std::vector<int> out(in.size());
   std::iota(in.rbegin(), in.rend(), 1);
@@ -55,7 +55,7 @@ TEST(korovin_n_qsort_batcher_omp, test_task_run) {
   auto test_task_omp = std::make_shared<korovin_n_qsort_batcher_omp::TestTaskOpenMP>(task_data_omp);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 10;
+  perf_attr->num_running = 35;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&] {
     auto current_time_point = std::chrono::high_resolution_clock::now();

--- a/tasks/omp/korovin_n_qsort_batcher_omp/perf_tests/main.cpp
+++ b/tasks/omp/korovin_n_qsort_batcher_omp/perf_tests/main.cpp
@@ -1,0 +1,88 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "omp/korovin_n_qsort_batcher_omp/include/ops_omp.hpp"
+
+TEST(korovin_n_qsort_batcher_omp, test_pipeline_run) {
+  // Create data
+  constexpr int kSize = 20000000;
+  std::vector<int> in(kSize);
+  std::vector<int> out(in.size());
+
+  for (int i = 0; i < kSize; i++) {
+    in[i] = kSize - i;
+  }
+
+  // Create task_data
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_omp = std::make_shared<korovin_n_qsort_batcher_omp::TestTaskOpenMP>(task_data_omp);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}
+
+TEST(korovin_n_qsort_batcher_omp, test_task_run) {
+  // Create data
+  constexpr int kSize = 20000000;
+  std::vector<int> in(kSize);
+  std::vector<int> out(in.size());
+
+  for (int i = 0; i < kSize; i++) {
+    in[i] = kSize - i;
+  }
+
+  // Create task_data
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_omp = std::make_shared<korovin_n_qsort_batcher_omp::TestTaskOpenMP>(task_data_omp);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}

--- a/tasks/omp/korovin_n_qsort_batcher_omp/src/ops_omp.cpp
+++ b/tasks/omp/korovin_n_qsort_batcher_omp/src/ops_omp.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <iterator>
 #include <random>
 #include <span>

--- a/tasks/omp/korovin_n_qsort_batcher_omp/src/ops_omp.cpp
+++ b/tasks/omp/korovin_n_qsort_batcher_omp/src/ops_omp.cpp
@@ -1,0 +1,173 @@
+#include "omp/korovin_n_qsort_batcher_omp/include/ops_omp.hpp"
+
+#include <omp.h>
+
+#include <algorithm>
+#include <cmath>
+#include <iterator>
+#include <random>
+#include <span>
+#include <vector>
+
+int korovin_n_qsort_batcher_omp::TestTaskOpenMP::GetRandomIndex(int low, int high) {
+  static thread_local std::mt19937 gen(std::random_device{}());
+  std::uniform_int_distribution<int> dist(low, high);
+  return dist(gen);
+}
+
+void korovin_n_qsort_batcher_omp::TestTaskOpenMP::QuickSort(std::vector<int>& arr, int low, int high, int depth) {
+  if (low >= high) {
+    return;
+  }
+
+  int partition_index = GetRandomIndex(low, high);
+  int partition_value = arr[partition_index];
+
+  auto partition_iter = std::partition(arr.begin() + low, arr.begin() + high + 1,
+                                       [partition_value](const int& elem) { return elem <= partition_value; });
+  auto mid_iter = std::partition(arr.begin() + low, partition_iter,
+                                 [partition_value](const int& elem) { return elem < partition_value; });
+
+  int i = static_cast<int>(std::distance(arr.begin(), mid_iter));
+  int j = static_cast<int>(std::distance(arr.begin(), partition_iter) - 1);
+
+  int max_depth = static_cast<int>(std::log2(omp_get_num_threads())) + 1;
+
+  if (depth < max_depth) {
+#ifdef _MSC_VER
+#pragma omp parallel sections
+    {
+#pragma omp section
+      { QuickSort(arr, low, i - 1, depth + 1); }
+#pragma omp section
+      { QuickSort(arr, j + 1, high, depth + 1); }
+    }
+#else
+#pragma omp task shared(arr)
+    QuickSort(arr, low, i - 1, depth + 1);
+#pragma omp task shared(arr)
+    QuickSort(arr, j + 1, high, depth + 1);
+#pragma omp taskwait
+#endif
+  } else {
+    QuickSort(arr, low, i - 1, depth + 1);
+    QuickSort(arr, j + 1, high, depth + 1);
+  }
+}
+
+bool korovin_n_qsort_batcher_omp::TestTaskOpenMP::InPlaceMerge(std::vector<int>& arr, const BlockRange& a,
+                                                               const BlockRange& b, std::vector<int>& buffer) {
+  bool changed = false;
+
+  std::span<int> span_a{arr.begin() + a.start, static_cast<size_t>(a.length)};
+  std::span<int> span_b{arr.begin() + b.start, static_cast<size_t>(b.length)};
+
+  size_t i = 0;
+  size_t j = 0;
+  size_t k = 0;
+
+  while (i < span_a.size() && j < span_b.size()) {
+    if (span_a[i] <= span_b[j]) {
+      buffer[k++] = span_a[i++];
+    } else {
+      changed = true;
+      buffer[k++] = span_b[j++];
+    }
+  }
+  while (i < span_a.size()) {
+    buffer[k++] = span_a[i++];
+  }
+  while (j < span_b.size()) {
+    changed = true;
+    buffer[k++] = span_b[j++];
+  }
+  std::ranges::copy(buffer.begin(), buffer.begin() + a.length, span_a.begin());
+  std::ranges::copy(buffer.begin() + a.length, buffer.begin() + a.length + b.length, span_b.begin());
+
+  return changed;
+}
+
+std::vector<korovin_n_qsort_batcher_omp::BlockRange> korovin_n_qsort_batcher_omp::TestTaskOpenMP::PartitionBlocks(
+    int n, int p) {
+  std::vector<BlockRange> blocks;
+  blocks.reserve(p);
+  int chunk_size = n / p;
+  int remainder = n % p;
+  int start = 0;
+  for (int i = 0; i < p; i++) {
+    int size = chunk_size + (i < remainder ? 1 : 0);
+    blocks.push_back({start, size});
+    start += size;
+  }
+  return blocks;
+}
+
+void korovin_n_qsort_batcher_omp::TestTaskOpenMP::OddEvenMerge(std::vector<BlockRange>& blocks) {
+  if (blocks.size() <= 1) {
+    return;
+  }
+  int p = static_cast<int>(blocks.size());
+  int max_iters = p * 2;
+  int max_block_len = 0;
+  for (const auto& b : blocks) {
+    max_block_len = std::max(max_block_len, b.length);
+  }
+  int buffer_size = max_block_len * 2;
+
+#pragma omp parallel
+  {
+    std::vector<int> buffer(buffer_size);
+#pragma omp single
+    {
+      for (int iter = 0; iter < max_iters; iter++) {
+        bool changed_global = false;
+#pragma omp parallel for schedule(static) reduction(|| : changed_global)
+        for (int b = iter % 2; b < p; b += 2) {
+          if (b + 1 < p) {
+            bool changed_local = InPlaceMerge(input_, blocks[b], blocks[b + 1], buffer);
+            changed_global = changed_global || changed_local;
+          }
+        }
+        if (!changed_global) {
+          break;
+        }
+      }
+    }
+  }
+}
+
+bool korovin_n_qsort_batcher_omp::TestTaskOpenMP::PreProcessingImpl() {
+  unsigned int input_size = task_data->inputs_count[0];
+  auto* in_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
+  input_.assign(in_ptr, in_ptr + input_size);
+  return true;
+}
+
+bool korovin_n_qsort_batcher_omp::TestTaskOpenMP::ValidationImpl() {
+  return (!task_data->inputs.empty()) && (!task_data->outputs.empty()) &&
+         (task_data->inputs_count[0] == task_data->outputs_count[0]);
+}
+
+bool korovin_n_qsort_batcher_omp::TestTaskOpenMP::RunImpl() {
+  int n = static_cast<int>(input_.size());
+  if (n <= 1) {
+    return true;
+  }
+  int num_threads = omp_get_max_threads();
+  int p = std::max(num_threads / 2, 1);
+  std::vector<BlockRange> blocks = PartitionBlocks(n, p);
+
+#pragma omp parallel for schedule(static)
+  for (int i = 0; i < p; i++) {
+    int start = blocks[i].start;
+    int end = start + blocks[i].length - 1;
+    QuickSort(input_, start, end, 0);
+  }
+  OddEvenMerge(blocks);
+  return true;
+}
+
+bool korovin_n_qsort_batcher_omp::TestTaskOpenMP::PostProcessingImpl() {
+  std::ranges::copy(input_, reinterpret_cast<int*>(task_data->outputs[0]));
+  return true;
+}


### PR DESCRIPTION
# Постановка задачи

Данный код реализует сортировку Хоара с четно-нечетным слиянием Бэтчера. Основная идея состоит в том, чтобы:
- Разбить исходный массив на независимые блоки
- Локально отсортировать каждый блок с помощью рекурсивной QuickSort с параллелизмом на ранних этапах рекурсии
- Объединить отсортированные блоки в единый массив через итеративное четно-нечетное слияние, выполняемое параллельно

---
# Схема распараллеливания

## 1. Локальная сортировка с параллелизмом (QuickSort)

- **Выбор опорного элемента**  

- **Разбиение массива**  

- **Параллелизация рекурсии:**  
  - Определяется максимальная глубина параллельных вызовов как `max_depth = log2(omp_get_num_threads()) + 1`
  - Если текущая глубина меньше `max_depth`, рекурсивные вызовы для левой и правой частей запускаются параллельно с использованием директивы `#pragma omp parallel sections`
  - При достижении порога глубины рекурсия продолжается последовательно, чтобы не создавать слишком мелкие задачи

---

## 2. Объединение блоков: четно-нечетное слияние (Odd-Even Merge)

- **Разбиение на блоки:**  
  Функция `PartitionBlocks` делит исходный массив на `p` блоков с равномерным количеством элементов

- **Итеративное слияние:**  
  Функция `OddEvenMerge` объединяет соседние блоки, используя вспомогательную функцию `InPlaceMerge`
  - **InPlaceMerge:**  
    Сливает два диапазона (блоки) из массива, копируя элементы во временный буфер и затем возвращая их обратно. Функция возвращает флаг `changed`, который указывает, было ли произведено изменение порядка
  - **Цикл слияния:**  
    Итеративно сливаются пары блоков:
    - На каждом шаге слияния обрабатываются либо четные, либо нечетные пары 
    - Для каждой итерации используется параллельный цикл `#pragma omp parallel for` с редукцией по логическому значению, чтобы определить, произошли ли изменения. Если за итерацию изменений нет - процесс завершается

---

# Основной этап алгоритма

### RunImpl()
  - Если массив содержит более одного элемента, определяется число блоков для сортировки. Число блоков `p` выбирается как максимум между `num_threads / 2` и 1
  - С помощью `PartitionBlocks` массив разбивается на блоки
  - Каждый блок сортируется локально: запускается параллельный цикл `#pragma omp parallel for`, где для каждого блока вызывается QuickSort с начальной глубиной 0
  - После локальной сортировки блоков вызывается функция `OddEvenMerge` для итеративного объединения блоков в один отсортированный массив