### PR TITLE
Гусев Никита. Вариант 17. Технология OMP. Поразрядная сортировка для целых чисел с простым слиянием

### DIFF
--- a/tasks/omp/gusev_n_sorting_int_simple_merging/func_tests/main.cpp
+++ b/tasks/omp/gusev_n_sorting_int_simple_merging/func_tests/main.cpp
@@ -128,3 +128,51 @@ TEST(gusev_n_sorting_int_simple_merging_omp, test_radix_sort_reversed_random) {
 
   EXPECT_EQ(expected, out);
 }
+
+TEST(gusev_n_sorting_int_simple_merging_omp, test_radix_sort_already_sorted) {
+  std::vector<int> in = {1, 2, 3, 4, 5};
+  std::vector<int> out(in.size());
+
+  auto task_data_omp = CreateTaskData(in, out);
+  RunT(task_data_omp);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+  EXPECT_EQ(expected, out);
+}
+
+TEST(gusev_n_sorting_int_simple_merging_omp, test_radix_sort_all_negative) {
+  std::vector<int> in = {-5, -3, -1, -10, -2};
+  std::vector<int> out(in.size());
+
+  auto task_data_omp = CreateTaskData(in, out);
+  RunT(task_data_omp);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+  EXPECT_EQ(expected, out);
+}
+
+TEST(gusev_n_sorting_int_simple_merging_omp, test_radix_sort_all_same) {
+  std::vector<int> in = {5, 5, 5, 5, 5};
+  std::vector<int> out(in.size());
+
+  auto task_data_omp = CreateTaskData(in, out);
+  RunT(task_data_omp);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+  EXPECT_EQ(expected, out);
+}
+
+TEST(gusev_n_sorting_int_simple_merging_omp, test_radix_sort_all_same_negative) {
+  std::vector<int> in = {-3, -3, -3, -3};
+  std::vector<int> out(in.size());
+
+  auto task_data_omp = CreateTaskData(in, out);
+  RunT(task_data_omp);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+  EXPECT_EQ(expected, out);
+}

--- a/tasks/omp/gusev_n_sorting_int_simple_merging/func_tests/main.cpp
+++ b/tasks/omp/gusev_n_sorting_int_simple_merging/func_tests/main.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <random>
 #include <vector>

--- a/tasks/omp/gusev_n_sorting_int_simple_merging/func_tests/main.cpp
+++ b/tasks/omp/gusev_n_sorting_int_simple_merging/func_tests/main.cpp
@@ -107,3 +107,23 @@ TEST(gusev_n_sorting_int_simple_merging_omp, test_radix_sort_duplicates) {
 
   EXPECT_EQ(expected, out);
 }
+
+TEST(gusev_n_sorting_int_simple_merging_omp, test_radix_sort_reversed_random) {
+  size_t size = 1000;
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> dist(-100000, 100000);
+
+  std::vector<int> in(size);
+  std::ranges::generate(in, [&]() { return dist(gen); });
+  std::ranges::sort(in, std::greater{});
+
+  std::vector<int> out(in.size());
+  auto task_data_omp = CreateTaskData(in, out);
+  RunT(task_data_omp);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+
+  EXPECT_EQ(expected, out);
+}

--- a/tasks/omp/gusev_n_sorting_int_simple_merging/func_tests/main.cpp
+++ b/tasks/omp/gusev_n_sorting_int_simple_merging/func_tests/main.cpp
@@ -1,0 +1,110 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "core/util/include/util.hpp"
+#include "omp/gusev_n_sorting_int_simple_merging/include/ops_omp.hpp"
+
+namespace {
+ppc::core::TaskDataPtr CreateTaskData(std::vector<int> &input, std::vector<int> &output) {
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(input.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(output.data()));
+  task_data_omp->outputs_count.emplace_back(output.size());
+
+  return task_data_omp;
+}
+
+void RunT(ppc::core::TaskDataPtr &task_data) {
+  gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP task(task_data);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+}
+}  // namespace
+TEST(gusev_n_sorting_int_simple_merging_omp, test_radix_sort_basic) {
+  std::vector<int> in = {170, 45, 75, 90, 802, 24, 2, 66};
+  std::vector<int> out(in.size());
+
+  auto task_data_omp = CreateTaskData(in, out);
+
+  RunT(task_data_omp);
+  std::vector<int> expected = in;
+  std::ranges::sort(expected.begin(), expected.end());
+  EXPECT_EQ(expected, out);
+}
+
+TEST(gusev_n_sorting_int_simple_merging_omp, test_radix_sort_empty) {
+  std::vector<int> in = {};
+  std::vector<int> out(in.size());
+
+  auto task_data_omp = CreateTaskData(in, out);
+
+  RunT(task_data_omp);
+
+  EXPECT_EQ(out.size(), 0U);
+}
+
+TEST(gusev_n_sorting_int_simple_merging_omp, test_radix_sort_single_element) {
+  std::vector<int> in = {42};
+  std::vector<int> out(in.size());
+
+  auto task_data_omp = CreateTaskData(in, out);
+
+  RunT(task_data_omp);
+
+  EXPECT_EQ(in, out);
+}
+
+TEST(gusev_n_sorting_int_simple_merging_omp, test_radix_sort_negative_numbers) {
+  std::vector<int> in = {3, -1, 0, -5, 2, -3};
+  std::vector<int> out(in.size());
+
+  auto task_data_omp = CreateTaskData(in, out);
+
+  RunT(task_data_omp);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected.begin(), expected.end());
+  EXPECT_EQ(expected, out);
+}
+
+TEST(gusev_n_sorting_int_simple_merging_omp, test_radix_sort_random) {
+  size_t size = 1000;
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> dist(-10000, 10000);
+
+  std::vector<int> in(size);
+  std::ranges::generate(in, [&]() { return dist(gen); });
+  std::vector<int> out(in.size());
+
+  auto task_data_omp = CreateTaskData(in, out);
+  RunT(task_data_omp);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+  EXPECT_EQ(expected, out);
+}
+
+TEST(gusev_n_sorting_int_simple_merging_omp, test_radix_sort_duplicates) {
+  std::vector<int> in = {5, 3, 5, -2, 3, -2, -2, 5, 0, 0, -0, 7, 7, -7};
+  std::vector<int> out(in.size());
+
+  auto task_data_omp = CreateTaskData(in, out);
+  RunT(task_data_omp);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+
+  EXPECT_EQ(expected, out);
+}

--- a/tasks/omp/gusev_n_sorting_int_simple_merging/func_tests/main.cpp
+++ b/tasks/omp/gusev_n_sorting_int_simple_merging/func_tests/main.cpp
@@ -8,7 +8,6 @@
 #include <vector>
 
 #include "core/task/include/task.hpp"
-#include "core/util/include/util.hpp"
 #include "omp/gusev_n_sorting_int_simple_merging/include/ops_omp.hpp"
 
 namespace {

--- a/tasks/omp/gusev_n_sorting_int_simple_merging/include/ops_omp.hpp
+++ b/tasks/omp/gusev_n_sorting_int_simple_merging/include/ops_omp.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace gusev_n_sorting_int_simple_merging_omp {
+
+class TestTaskOpenMP : public ppc::core::Task {
+ public:
+  explicit TestTaskOpenMP(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+  static void CountingSort(std::vector<int>& arr, int exp);
+  static void RadixSort(std::vector<int>& arr);
+  static void RadixSortForNonNegative(std::vector<int>& arr);
+
+ private:
+  std::vector<int> input_, output_;
+};
+
+}  // namespace gusev_n_sorting_int_simple_merging_omp

--- a/tasks/omp/gusev_n_sorting_int_simple_merging/perf_tests/main.cpp
+++ b/tasks/omp/gusev_n_sorting_int_simple_merging/perf_tests/main.cpp
@@ -1,0 +1,76 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "omp/gusev_n_sorting_int_simple_merging/include/ops_omp.hpp"
+
+TEST(gusev_n_sorting_int_simple_merging_omp, test_pipeline_run) {
+  constexpr int kCount = 5000000;
+
+  std::vector<int> in(kCount);
+  std::vector<int> out(kCount);
+
+  std::ranges::generate(in.begin(), in.end(), []() { return std::rand() % 1000; });
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  auto test_task_omp = std::make_shared<gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP>(task_data_omp);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}
+
+TEST(gusev_n_sorting_int_simple_merging_omp, test_task_run) {
+  constexpr int kCount = 5000000;
+
+  std::vector<int> in(kCount);
+  std::vector<int> out(kCount);
+
+  std::ranges::generate(in.begin(), in.end(), []() { return std::rand() % 1000; });
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  auto test_task_omp = std::make_shared<gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP>(task_data_omp);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}

--- a/tasks/omp/gusev_n_sorting_int_simple_merging/perf_tests/main.cpp
+++ b/tasks/omp/gusev_n_sorting_int_simple_merging/perf_tests/main.cpp
@@ -41,6 +41,11 @@ TEST(gusev_n_sorting_int_simple_merging_omp, test_pipeline_run) {
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+
+  ASSERT_EQ(expected, out);
 }
 
 TEST(gusev_n_sorting_int_simple_merging_omp, test_task_run) {
@@ -73,4 +78,9 @@ TEST(gusev_n_sorting_int_simple_merging_omp, test_task_run) {
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+
+  ASSERT_EQ(expected, out);
 }

--- a/tasks/omp/gusev_n_sorting_int_simple_merging/src/ops_omp.cpp
+++ b/tasks/omp/gusev_n_sorting_int_simple_merging/src/ops_omp.cpp
@@ -71,16 +71,10 @@ void gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP::RadixSortForNonNega
     int local_max = max_val;
 #pragma omp for nowait
     for (int i = 0; i < static_cast<int>(arr.size()); ++i) {
-      if (arr[static_cast<size_t>(i)] > local_max) {
-        local_max = arr[static_cast<size_t>(i)];
-      }
+      local_max = std::max(arr[static_cast<size_t>(i)], local_max);
     }
 #pragma omp critical
-    {
-      if (local_max > max_val) {
-        max_val = local_max;
-      }
-    }
+    { max_val = std::max(local_max, max_val); }
   }
 
   for (int exp = 1; max_val / exp > 0; exp *= 10) {

--- a/tasks/omp/gusev_n_sorting_int_simple_merging/src/ops_omp.cpp
+++ b/tasks/omp/gusev_n_sorting_int_simple_merging/src/ops_omp.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstddef>
 #include <numeric>
 #include <vector>
 

--- a/tasks/omp/gusev_n_sorting_int_simple_merging/src/ops_omp.cpp
+++ b/tasks/omp/gusev_n_sorting_int_simple_merging/src/ops_omp.cpp
@@ -20,7 +20,7 @@ void gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP::RadixSort(std::vect
     std::vector<int> local_pos;
 #pragma omp for nowait
     for (int i = 0; i < static_cast<int>(arr.size()); ++i) {
-      int num = arr[static_cast<size_t>(i)];
+      int num = arr[i];
       if (num < 0) {
         local_neg.push_back(-num);
       } else {
@@ -71,7 +71,7 @@ void gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP::RadixSortForNonNega
     int local_max = max_val;
 #pragma omp for nowait
     for (int i = 0; i < static_cast<int>(arr.size()); ++i) {
-      local_max = std::max(arr[static_cast<size_t>(i)], local_max);
+      local_max = std::max(arr[i], local_max);
     }
 #pragma omp critical
     { max_val = std::max(local_max, max_val); }
@@ -91,15 +91,15 @@ void gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP::CountingSort(std::v
     std::vector<int> local_count(10, 0);
 #pragma omp for
     for (int i = 0; i < static_cast<int>(arr.size()); ++i) {
-      int num = arr[static_cast<size_t>(i)];
+      int num = arr[i];
       int digit = (num / exp) % 10;
-      local_count[static_cast<size_t>(digit)]++;
+      local_count[digit]++;
     }
 
 #pragma omp critical
     {
       for (int j = 0; j < 10; ++j) {
-        count[static_cast<size_t>(j)] += local_count[static_cast<size_t>(j)];
+        count[j] += local_count[j];
       }
     }
   }
@@ -107,12 +107,12 @@ void gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP::CountingSort(std::v
   std::partial_sum(count.begin(), count.end(), count.begin());
 
   for (int i = static_cast<int>(arr.size()); i > 0; --i) {
-    int digit = (arr[static_cast<size_t>(i - 1)] / exp) % 10;
-    output[static_cast<size_t>(count[static_cast<size_t>(digit)] - 1)] = arr[static_cast<size_t>(i - 1)];
-    count[static_cast<size_t>(digit)]--;
+    int digit = (arr[i - 1] / exp) % 10;
+    output[count[digit] - 1] = arr[i - 1];
+    count[digit]--;
   }
 
-  arr = output;
+  arr.swap(output);
 }
 
 bool gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP::PreProcessingImpl() {

--- a/tasks/omp/gusev_n_sorting_int_simple_merging/src/ops_omp.cpp
+++ b/tasks/omp/gusev_n_sorting_int_simple_merging/src/ops_omp.cpp
@@ -2,6 +2,7 @@
 #include <cmath>
 #include <numeric>
 #include <vector>
+#include <cstddef>
 
 #include "omp/gusev_n_sorting_int_simple_merging/include/ops_omp.hpp"
 
@@ -15,9 +16,10 @@ void gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP::RadixSort(std::vect
 
 #pragma omp parallel
   {
-    std::vector<int> local_neg, local_pos;
+    std::vector<int> local_neg;
+    std::vector<int> local_pos;
 #pragma omp for nowait
-    for (int i = 0; i < arr.size(); ++i) {
+    for (std::vector<int>::size_type i = 0; i < arr.size(); ++i) {
       int num = arr[i];
       if (num < 0) {
         local_neg.push_back(-num);
@@ -40,7 +42,9 @@ void gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP::RadixSort(std::vect
       if (!negatives.empty()) {
         RadixSortForNonNegative(negatives);
         std::reverse(negatives.begin(), negatives.end());
-        for (auto& num : negatives) num = -num;
+        for (auto& num : negatives) {
+          num = -num;
+        }
       }
     }
 #pragma omp section
@@ -63,8 +67,8 @@ void gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP::RadixSortForNonNega
 
   int max_val = arr[0];
 #pragma omp parallel for reduction(max : max_val)
-  for (int i = 0; i < arr.size(); ++i) {
-    if (arr[i] > max_val) max_val = arr[i];
+  for (std::vector<int>::size_type i = 0; i < arr.size(); ++i) {
+    max_val = std::max(arr[i], max_val);
   }
   int max = max_val;
 
@@ -81,7 +85,7 @@ void gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP::CountingSort(std::v
   {
     std::vector<int> local_count(10, 0);
 #pragma omp for
-    for (int i = 0; i < arr.size(); ++i) {
+    for (std::vector<int>::size_type i = 0; i < arr.size(); ++i) {
       int num = arr[i];
       int digit = (num / exp) % 10;
       local_count[digit]++;
@@ -89,7 +93,9 @@ void gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP::CountingSort(std::v
 
 #pragma omp critical
     {
-      for (int j = 0; j < 10; ++j) count[j] += local_count[j];
+      for (int j = 0; j < 10; ++j) {
+        count[j] += local_count[j];
+      }
     }
   }
 

--- a/tasks/omp/gusev_n_sorting_int_simple_merging/src/ops_omp.cpp
+++ b/tasks/omp/gusev_n_sorting_int_simple_merging/src/ops_omp.cpp
@@ -1,10 +1,10 @@
+#include "omp/gusev_n_sorting_int_simple_merging/include/ops_omp.hpp"
+
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <numeric>
 #include <vector>
-#include <cstddef>
-
-#include "omp/gusev_n_sorting_int_simple_merging/include/ops_omp.hpp"
 
 void gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP::RadixSort(std::vector<int>& arr) {
   if (arr.empty()) {
@@ -41,7 +41,7 @@ void gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP::RadixSort(std::vect
     {
       if (!negatives.empty()) {
         RadixSortForNonNegative(negatives);
-        std::reverse(negatives.begin(), negatives.end());
+        std::ranges::reverse(negatives);
         for (auto& num : negatives) {
           num = -num;
         }

--- a/tasks/omp/gusev_n_sorting_int_simple_merging/src/ops_seq.cpp
+++ b/tasks/omp/gusev_n_sorting_int_simple_merging/src/ops_seq.cpp
@@ -1,0 +1,126 @@
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <vector>
+
+#include "omp/gusev_n_sorting_int_simple_merging/include/ops_omp.hpp"
+
+void gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP::RadixSort(std::vector<int>& arr) {
+  if (arr.empty()) {
+    return;
+  }
+
+  std::vector<int> negatives;
+  std::vector<int> positives;
+
+#pragma omp parallel
+  {
+    std::vector<int> local_neg, local_pos;
+#pragma omp for nowait
+    for (int i = 0; i < arr.size(); ++i) {
+      int num = arr[i];
+      if (num < 0) {
+        local_neg.push_back(-num);
+      } else {
+        local_pos.push_back(num);
+      }
+    }
+
+#pragma omp critical
+    {
+      negatives.insert(negatives.end(), local_neg.begin(), local_neg.end());
+      positives.insert(positives.end(), local_pos.begin(), local_pos.end());
+    }
+  }
+
+#pragma omp parallel sections
+  {
+#pragma omp section
+    {
+      if (!negatives.empty()) {
+        RadixSortForNonNegative(negatives);
+        std::reverse(negatives.begin(), negatives.end());
+        for (auto& num : negatives) num = -num;
+      }
+    }
+#pragma omp section
+    {
+      if (!positives.empty()) {
+        RadixSortForNonNegative(positives);
+      }
+    }
+  }
+
+  arr.clear();
+  arr.insert(arr.end(), negatives.begin(), negatives.end());
+  arr.insert(arr.end(), positives.begin(), positives.end());
+}
+
+void gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP::RadixSortForNonNegative(std::vector<int>& arr) {
+  if (arr.empty()) {
+    return;
+  }
+
+  int max_val = arr[0];
+#pragma omp parallel for reduction(max : max_val)
+  for (int i = 0; i < arr.size(); ++i) {
+    if (arr[i] > max_val) max_val = arr[i];
+  }
+  int max = max_val;
+
+  for (int exp = 1; max / exp > 0; exp *= 10) {
+    CountingSort(arr, exp);
+  }
+}
+
+void gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP::CountingSort(std::vector<int>& arr, int exp) {
+  std::vector<int> output(arr.size());
+  std::vector<int> count(10, 0);
+
+#pragma omp parallel
+  {
+    std::vector<int> local_count(10, 0);
+#pragma omp for
+    for (int i = 0; i < arr.size(); ++i) {
+      int num = arr[i];
+      int digit = (num / exp) % 10;
+      local_count[digit]++;
+    }
+
+#pragma omp critical
+    {
+      for (int j = 0; j < 10; ++j) count[j] += local_count[j];
+    }
+  }
+
+  std::partial_sum(count.begin(), count.end(), count.begin());
+
+  for (size_t i = arr.size(); i > 0; --i) {
+    int digit = (arr[i - 1] / exp) % 10;
+    output[count[digit] - 1] = arr[i - 1];
+    count[digit]--;
+  }
+
+  arr = output;
+}
+
+bool gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP::PreProcessingImpl() {
+  auto* in_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
+  input_ = std::vector<int>(in_ptr, in_ptr + task_data->inputs_count[0]);
+  output_.resize(input_.size());
+  return true;
+}
+
+bool gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP::ValidationImpl() {
+  return task_data->inputs_count[0] == task_data->outputs_count[0];
+}
+
+bool gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP::RunImpl() {
+  gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP::RadixSort(input_);
+  return true;
+}
+
+bool gusev_n_sorting_int_simple_merging_omp::TestTaskOpenMP::PostProcessingImpl() {
+  std::ranges::copy(input_, reinterpret_cast<int*>(task_data->outputs[0]));
+  return true;
+}


### PR DESCRIPTION
Входной массив разделяется на два: для отрицательных и положительных чисел.
Используется #pragma omp parallel для параллельного выполнения этого шага. Каждый поток создает локальные векторы (local_neg, local_pos), которые затем объединяются в общие векторы (negatives, positives) с помощью #pragma omp critical

Для каждого разряда (единицы, десятки, сотни и т.д.) выполняется сортировка подсчетом (в CountingSort).
CountingSort: используется #pragma omp parallel для параллельного подсчета цифр в каждом разряде. Локальные счетчики (local_count) объединяются в общий массив count с помощью #pragma omp critical

Используется #pragma omp parallel sections для параллельной сортировки отрицательных и положительных чисел. После сортировки результаты объединяются в исходный массив