### PR TITLE
fix: Крылов Михаил. Вариант 12. Вычисление многомерных интегралов методом Монте-Карло.

### DIFF
--- a/tasks/all/krylov_m_monte_carlo/func_tests/main.cpp
+++ b/tasks/all/krylov_m_monte_carlo/func_tests/main.cpp
@@ -37,7 +37,7 @@ class krylov_m_monte_carlo_all_test  // NOLINT(readability-identifier-naming)
     if (world.rank() == 0) {
       const double eps = std::abs(ref - out) / out;
       if (ref == 0 || std::isnan(eps)) {
-        EXPECT_NEAR(out, ref, 0.3);
+        EXPECT_NEAR(out, ref, 0.42);
       } else {
         EXPECT_LE(eps, 0.1) << "actual: " << out << ", ref: " << ref;
       }
@@ -117,7 +117,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_all_test, krylov_m_monte_carlo_all
             .bounds = {
                 {-5, 5}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         0.
     },
@@ -129,7 +129,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_all_test, krylov_m_monte_carlo_all
             .bounds = {
                 {-5, 5}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         50.
     },
@@ -141,7 +141,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_all_test, krylov_m_monte_carlo_all
             .bounds = {
                 {42, 42}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         0.
     },
@@ -153,7 +153,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_all_test, krylov_m_monte_carlo_all
             .bounds = {
                 {-std::numbers::pi, std::numbers::pi}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         0.
     },
@@ -165,7 +165,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_all_test, krylov_m_monte_carlo_all
             .bounds = {
                 {-std::numbers::pi, std::numbers::pi}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         0.
     },
@@ -177,7 +177,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_all_test, krylov_m_monte_carlo_all
             .bounds = {
                 {-std::numbers::pi, std::numbers::pi}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         -4 * std::numbers::pi
     },
@@ -190,7 +190,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_all_test, krylov_m_monte_carlo_all
                 {11, 14},
                 {7, 10}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         []{
             constexpr auto kAntiderivative = [](const double x) { return std::pow(x, 3) + (102 * x); };
@@ -206,7 +206,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_all_test, krylov_m_monte_carlo_all
                 {1, 3},
                 {2, 4}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         []{
             constexpr auto kAntiderivative = [](const double x) { return 42 * std::pow(x, 4); };

--- a/tasks/all/krylov_m_monte_carlo/perf_tests/main.cpp
+++ b/tasks/all/krylov_m_monte_carlo/perf_tests/main.cpp
@@ -48,6 +48,10 @@ class krylov_m_monte_carlo_test_all : public ::testing::Test {  // NOLINT(readab
     runner(perf_analyzer, perf_attr, perf_results);
     if (world.rank() == 0) {
       ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+      const double ref = 2.634;
+      const double eps = std::abs(ref - out) / out;
+      EXPECT_LE(eps, 0.1);
     }
   }
 

--- a/tasks/omp/krylov_m_monte_carlo/func_tests/main.cpp
+++ b/tasks/omp/krylov_m_monte_carlo/func_tests/main.cpp
@@ -34,7 +34,7 @@ class krylov_m_monte_carlo_test_omp  // NOLINT(readability-identifier-naming)
 
     const double eps = std::abs(ref - out) / out;
     if (ref == 0 || std::isnan(eps)) {
-      EXPECT_NEAR(out, ref, 0.3);
+      EXPECT_NEAR(out, ref, 0.42);
     } else {
       EXPECT_LE(eps, 0.1) << "actual: " << out << ", ref: " << ref;
     }
@@ -101,7 +101,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_omp, krylov_m_monte_carlo_tes
             .bounds = {
                 {-5, 5}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         0.
     },
@@ -113,7 +113,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_omp, krylov_m_monte_carlo_tes
             .bounds = {
                 {-5, 5}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         50.
     },
@@ -125,7 +125,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_omp, krylov_m_monte_carlo_tes
             .bounds = {
                 {42, 42}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         0.
     },
@@ -137,7 +137,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_omp, krylov_m_monte_carlo_tes
             .bounds = {
                 {-std::numbers::pi, std::numbers::pi}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         0.
     },
@@ -149,7 +149,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_omp, krylov_m_monte_carlo_tes
             .bounds = {
                 {-std::numbers::pi, std::numbers::pi}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         0.
     },
@@ -161,7 +161,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_omp, krylov_m_monte_carlo_tes
             .bounds = {
                 {-std::numbers::pi, std::numbers::pi}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         -4 * std::numbers::pi
     },
@@ -174,7 +174,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_omp, krylov_m_monte_carlo_tes
                 {11, 14},
                 {7, 10}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         []{
             constexpr auto kAntiderivative = [](const double x) { return std::pow(x, 3) + (102 * x); };
@@ -190,7 +190,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_omp, krylov_m_monte_carlo_tes
                 {1, 3},
                 {2, 4}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         []{
             constexpr auto kAntiderivative = [](const double x) { return 42 * std::pow(x, 4); };

--- a/tasks/omp/krylov_m_monte_carlo/perf_tests/main.cpp
+++ b/tasks/omp/krylov_m_monte_carlo/perf_tests/main.cpp
@@ -42,6 +42,10 @@ class krylov_m_monte_carlo_test_omp : public ::testing::Test {  // NOLINT(readab
     ppc::core::Perf perf_analyzer(task);
     runner(perf_analyzer, perf_attr, perf_results);
     ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+    const double ref = 2.634;
+    const double eps = std::abs(ref - out) / out;
+    EXPECT_LE(eps, 0.1);
   }
 };
 

--- a/tasks/seq/krylov_m_monte_carlo/func_tests/main.cpp
+++ b/tasks/seq/krylov_m_monte_carlo/func_tests/main.cpp
@@ -25,7 +25,7 @@ class krylov_m_monte_carlo_test_seq  // NOLINT(readability-identifier-naming)
 
     const double eps = std::abs(ref - out) / out;
     if (ref == 0 || std::isnan(eps)) {
-      EXPECT_NEAR(out, ref, 0.3);
+      EXPECT_NEAR(out, ref, 0.42);
     } else {
       EXPECT_LE(eps, 0.1) << "actual: " << out << ", ref: " << ref;
     }
@@ -55,7 +55,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_seq, krylov_m_monte_carlo_tes
             .bounds = {
                 {-5, 5}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         0.
     },
@@ -67,7 +67,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_seq, krylov_m_monte_carlo_tes
             .bounds = {
                 {-5, 5}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         50.
     },
@@ -79,7 +79,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_seq, krylov_m_monte_carlo_tes
             .bounds = {
                 {42, 42}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         0.
     },
@@ -91,7 +91,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_seq, krylov_m_monte_carlo_tes
             .bounds = {
                 {-std::numbers::pi, std::numbers::pi}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         0.
     },
@@ -103,7 +103,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_seq, krylov_m_monte_carlo_tes
             .bounds = {
                 {-std::numbers::pi, std::numbers::pi}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         0.
     },
@@ -115,7 +115,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_seq, krylov_m_monte_carlo_tes
             .bounds = {
                 {-std::numbers::pi, std::numbers::pi}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         -4 * std::numbers::pi
     },
@@ -128,7 +128,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_seq, krylov_m_monte_carlo_tes
                 {11, 14},
                 {7, 10}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         []{
             constexpr auto kAntiderivative = [](const double x) { return std::pow(x, 3) + (102 * x); };
@@ -144,7 +144,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_seq, krylov_m_monte_carlo_tes
                 {1, 3},
                 {2, 4}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         []{
             constexpr auto kAntiderivative = [](const double x) { return 42 * std::pow(x, 4); };

--- a/tasks/seq/krylov_m_monte_carlo/perf_tests/main.cpp
+++ b/tasks/seq/krylov_m_monte_carlo/perf_tests/main.cpp
@@ -42,6 +42,10 @@ class krylov_m_monte_carlo_test_seq : public ::testing::Test {  // NOLINT(readab
     ppc::core::Perf perf_analyzer(task);
     runner(perf_analyzer, perf_attr, perf_results);
     ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+    const double ref = 2.634;
+    const double eps = std::abs(ref - out) / out;
+    EXPECT_LE(eps, 0.1);
   }
 };
 

--- a/tasks/stl/krylov_m_monte_carlo/func_tests/main.cpp
+++ b/tasks/stl/krylov_m_monte_carlo/func_tests/main.cpp
@@ -34,7 +34,7 @@ class krylov_m_monte_carlo_test_stl  // NOLINT(readability-identifier-naming)
 
     const double eps = std::abs(ref - out) / out;
     if (ref == 0 || std::isnan(eps)) {
-      EXPECT_NEAR(out, ref, 0.3);
+      EXPECT_NEAR(out, ref, 0.42);
     } else {
       EXPECT_LE(eps, 0.1) << "actual: " << out << ", ref: " << ref;
     }
@@ -101,7 +101,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_stl, krylov_m_monte_carlo_tes
             .bounds = {
                 {-5, 5}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         0.
     },
@@ -113,7 +113,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_stl, krylov_m_monte_carlo_tes
             .bounds = {
                 {-5, 5}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         50.
     },
@@ -125,7 +125,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_stl, krylov_m_monte_carlo_tes
             .bounds = {
                 {42, 42}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         0.
     },
@@ -137,7 +137,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_stl, krylov_m_monte_carlo_tes
             .bounds = {
                 {-std::numbers::pi, std::numbers::pi}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         0.
     },
@@ -149,7 +149,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_stl, krylov_m_monte_carlo_tes
             .bounds = {
                 {-std::numbers::pi, std::numbers::pi}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         0.
     },
@@ -161,7 +161,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_stl, krylov_m_monte_carlo_tes
             .bounds = {
                 {-std::numbers::pi, std::numbers::pi}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         -4 * std::numbers::pi
     },
@@ -174,7 +174,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_stl, krylov_m_monte_carlo_tes
                 {11, 14},
                 {7, 10}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         []{
             constexpr auto kAntiderivative = [](const double x) { return std::pow(x, 3) + (102 * x); };
@@ -190,7 +190,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_stl, krylov_m_monte_carlo_tes
                 {1, 3},
                 {2, 4}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         []{
             constexpr auto kAntiderivative = [](const double x) { return 42 * std::pow(x, 4); };

--- a/tasks/stl/krylov_m_monte_carlo/perf_tests/main.cpp
+++ b/tasks/stl/krylov_m_monte_carlo/perf_tests/main.cpp
@@ -42,6 +42,10 @@ class krylov_m_monte_carlo_test_stl : public ::testing::Test {  // NOLINT(readab
     ppc::core::Perf perf_analyzer(task);
     runner(perf_analyzer, perf_attr, perf_results);
     ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+    const double ref = 2.634;
+    const double eps = std::abs(ref - out) / out;
+    EXPECT_LE(eps, 0.1);
   }
 };
 

--- a/tasks/tbb/krylov_m_monte_carlo/func_tests/main.cpp
+++ b/tasks/tbb/krylov_m_monte_carlo/func_tests/main.cpp
@@ -34,7 +34,7 @@ class krylov_m_monte_carlo_test_tbb  // NOLINT(readability-identifier-naming)
 
     const double eps = std::abs(ref - out) / out;
     if (ref == 0 || std::isnan(eps)) {
-      EXPECT_NEAR(out, ref, 0.3);
+      EXPECT_NEAR(out, ref, 0.42);
     } else {
       EXPECT_LE(eps, 0.1) << "actual: " << out << ", ref: " << ref;
     }
@@ -101,7 +101,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_tbb, krylov_m_monte_carlo_tes
             .bounds = {
                 {-5, 5}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         0.
     },
@@ -113,7 +113,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_tbb, krylov_m_monte_carlo_tes
             .bounds = {
                 {-5, 5}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         50.
     },
@@ -125,7 +125,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_tbb, krylov_m_monte_carlo_tes
             .bounds = {
                 {42, 42}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         0.
     },
@@ -137,7 +137,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_tbb, krylov_m_monte_carlo_tes
             .bounds = {
                 {-std::numbers::pi, std::numbers::pi}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         0.
     },
@@ -149,7 +149,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_tbb, krylov_m_monte_carlo_tes
             .bounds = {
                 {-std::numbers::pi, std::numbers::pi}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         0.
     },
@@ -161,7 +161,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_tbb, krylov_m_monte_carlo_tes
             .bounds = {
                 {-std::numbers::pi, std::numbers::pi}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         -4 * std::numbers::pi
     },
@@ -174,7 +174,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_tbb, krylov_m_monte_carlo_tes
                 {11, 14},
                 {7, 10}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         []{
             constexpr auto kAntiderivative = [](const double x) { return std::pow(x, 3) + (102 * x); };
@@ -190,7 +190,7 @@ INSTANTIATE_TEST_SUITE_P(krylov_m_monte_carlo_test_tbb, krylov_m_monte_carlo_tes
                 {1, 3},
                 {2, 4}
             },
-            .iterations = 75'000
+            .iterations = 82'000
         },
         []{
             constexpr auto kAntiderivative = [](const double x) { return 42 * std::pow(x, 4); };

--- a/tasks/tbb/krylov_m_monte_carlo/perf_tests/main.cpp
+++ b/tasks/tbb/krylov_m_monte_carlo/perf_tests/main.cpp
@@ -42,6 +42,10 @@ class krylov_m_monte_carlo_test_tbb : public ::testing::Test {  // NOLINT(readab
     ppc::core::Perf perf_analyzer(task);
     runner(perf_analyzer, perf_attr, perf_results);
     ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+    const double ref = 2.634;
+    const double eps = std::abs(ref - out) / out;
+    EXPECT_LE(eps, 0.1);
   }
 };
 


### PR DESCRIPTION
Падения происходят практически независимо от числа потоков из-за случайной природы метода Монте-Карло.

Сходимость некоторых подобранных функций - в частности, двух, у которых интеграл с заданными пределами приблизительно равен нулю - оказалась не совсем хорошей. Для других случаев рассматривалась и рассматривается относительная погрешность, а для этих допустимая абсолютная погрешность была увеличена, как и число итераций для повышения точности.

В тесты на производительность добавлена верификация результата.

Относится ко всем пяти задачам.