### PR TITLE
Ковальчук Александр. Вариант 15. Технология SEQ. Сортировка Шелла с простым слиянием

### DIFF
--- a/tasks/seq/kovalchuk_a_shell_sort/func_tests/main.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/func_tests/main.cpp
@@ -208,3 +208,45 @@ TEST(kovalchuk_a_shell_sort, test_double_reverse) {
   std::vector<int> expected = {1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
   ASSERT_EQ(expected, output);
 }
+
+TEST(kovalchuk_a_shell_sort, test_double_reverse_size6) {
+  std::vector<int> input = {3, 2, 1, 3, 2, 1};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort::ShellSortSequential>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  std::vector<int> expected = {1, 1, 2, 2, 3, 3};
+  ASSERT_EQ(expected, output);
+}
+
+TEST(kovalchuk_a_shell_sort, test_double_reverse_size8) {
+  std::vector<int> input = {4, 3, 2, 1, 4, 3, 2, 1};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort::ShellSortSequential>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  std::vector<int> expected = {1, 1, 2, 2, 3, 3, 4, 4};
+  ASSERT_EQ(expected, output);
+}

--- a/tasks/seq/kovalchuk_a_shell_sort/func_tests/main.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/func_tests/main.cpp
@@ -1,13 +1,13 @@
 #include <gtest/gtest.h>
 
-#include <cstdint>
+#include <algorithm>
 #include <memory>
 #include <vector>
 
 #include "core/task/include/task.hpp"
 #include "seq/kovalchuk_a_shell_sort/include/ops_seq.hpp"
 
-
+// Базовый тест: сортировка несортированного массива
 TEST(kovalchuk_a_shell_sort, test_sort_basic) {
   std::vector<int> input = {9, 2, 5, 1, 7};
   std::vector<int> output(input.size());
@@ -29,9 +29,10 @@ TEST(kovalchuk_a_shell_sort, test_sort_basic) {
   ASSERT_EQ(expected, output);
 }
 
+// Тест пустого массива
 TEST(kovalchuk_a_shell_sort, test_empty_array) {
-  std::vector<int> input = {};
-  std::vector<int> output(input.size());
+  std::vector<int> input;
+  std::vector<int> output;
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
@@ -46,11 +47,12 @@ TEST(kovalchuk_a_shell_sort, test_empty_array) {
   task->Run();
   task->PostProcessing();
 
-  EXPECT_TRUE(output.empty());
+  ASSERT_TRUE(output.empty());
 }
 
+// Тест массива из одного элемента
 TEST(kovalchuk_a_shell_sort, test_single_element) {
-  std::vector<int> input = {2};
+  std::vector<int> input = {42};
   std::vector<int> output(input.size());
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
@@ -69,6 +71,29 @@ TEST(kovalchuk_a_shell_sort, test_single_element) {
   ASSERT_EQ(input, output);
 }
 
+// Тест уже отсортированного массива
+TEST(kovalchuk_a_shell_sort, test_already_sorted) {
+  std::vector<int> input = {1, 2, 3, 4, 5};
+  std::vector<int> output(input.size());
+  std::vector<int> expected = input;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort::ShellSortSequential>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  ASSERT_EQ(expected, output);
+}
+
+// Тест обратно отсортированного массива
 TEST(kovalchuk_a_shell_sort, test_reverse_sorted) {
   std::vector<int> input = {9, 7, 5, 3, 1};
   std::vector<int> output(input.size());
@@ -90,6 +115,7 @@ TEST(kovalchuk_a_shell_sort, test_reverse_sorted) {
   ASSERT_EQ(expected, output);
 }
 
+// Тест с дубликатами
 TEST(kovalchuk_a_shell_sort, test_duplicates) {
   std::vector<int> input = {5, 2, 5, 1, 2};
   std::vector<int> output(input.size());
@@ -111,6 +137,7 @@ TEST(kovalchuk_a_shell_sort, test_duplicates) {
   ASSERT_EQ(expected, output);
 }
 
+// Тест с отрицательными числами
 TEST(kovalchuk_a_shell_sort, test_negative_numbers) {
   std::vector<int> input = {-5, 0, -3, 10, -1};
   std::vector<int> output(input.size());
@@ -132,9 +159,10 @@ TEST(kovalchuk_a_shell_sort, test_negative_numbers) {
   ASSERT_EQ(expected, output);
 }
 
+// Тест на валидацию несоответствия размеров
 TEST(kovalchuk_a_shell_sort, test_validation_fail) {
   std::vector<int> input = {1, 2, 3};
-  std::vector<int> output(5);
+  std::vector<int> output(5);  // Намеренно неверный размер
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
@@ -145,4 +173,26 @@ TEST(kovalchuk_a_shell_sort, test_validation_fail) {
   auto task = std::make_shared<kovalchuk_a_shell_sort::ShellSortSequential>(task_data);
 
   ASSERT_FALSE(task->Validation());
+}
+
+// Тест с большими значениями
+TEST(kovalchuk_a_shell_sort, test_large_values) {
+  std::vector<int> input = {INT32_MAX, 0, INT32_MIN};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort::ShellSortSequential>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  std::vector<int> expected = {INT32_MIN, 0, INT32_MAX};
+  ASSERT_EQ(expected, output);
 }

--- a/tasks/seq/kovalchuk_a_shell_sort/func_tests/main.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/func_tests/main.cpp
@@ -187,3 +187,24 @@ TEST(kovalchuk_a_shell_sort, test_large_values) {
   std::vector<int> expected = {INT32_MIN, 0, INT32_MAX};
   ASSERT_EQ(expected, output);
 }
+
+TEST(kovalchuk_a_shell_sort, test_double_reverse) {
+  std::vector<int> input = {5, 4, 3, 2, 1, 5, 4, 3, 2, 1};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort::ShellSortSequential>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  std::vector<int> expected = {1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
+  ASSERT_EQ(expected, output);
+}

--- a/tasks/seq/kovalchuk_a_shell_sort/func_tests/main.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/func_tests/main.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 #include "core/task/include/task.hpp"

--- a/tasks/seq/kovalchuk_a_shell_sort/func_tests/main.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/func_tests/main.cpp
@@ -1,11 +1,12 @@
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <memory>
-#include <random>
 #include <vector>
 
 #include "core/task/include/task.hpp"
 #include "seq/kovalchuk_a_shell_sort/include/ops_seq.hpp"
+
 
 TEST(kovalchuk_a_shell_sort, test_sort_basic) {
   std::vector<int> input = {9, 2, 5, 1, 7};

--- a/tasks/seq/kovalchuk_a_shell_sort/func_tests/main.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/func_tests/main.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <cstdint>
 #include <vector>
 
 #include "core/task/include/task.hpp"

--- a/tasks/seq/kovalchuk_a_shell_sort/func_tests/main.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/func_tests/main.cpp
@@ -1,0 +1,147 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "seq/kovalchuk_a_shell_sort/include/ops_seq.hpp"
+
+TEST(kovalchuk_a_shell_sort, test_sort_basic) {
+  std::vector<int> input = {9, 2, 5, 1, 7};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort::ShellSortSequential>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  std::vector<int> expected = {1, 2, 5, 7, 9};
+  ASSERT_EQ(expected, output);
+}
+
+TEST(kovalchuk_a_shell_sort, test_empty_array) {
+  std::vector<int> input = {};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort::ShellSortSequential>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  EXPECT_TRUE(output.empty());
+}
+
+TEST(kovalchuk_a_shell_sort, test_single_element) {
+  std::vector<int> input = {2};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort::ShellSortSequential>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  ASSERT_EQ(input, output);
+}
+
+TEST(kovalchuk_a_shell_sort, test_reverse_sorted) {
+  std::vector<int> input = {9, 7, 5, 3, 1};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort::ShellSortSequential>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  std::vector<int> expected = {1, 3, 5, 7, 9};
+  ASSERT_EQ(expected, output);
+}
+
+TEST(kovalchuk_a_shell_sort, test_duplicates) {
+  std::vector<int> input = {5, 2, 5, 1, 2};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort::ShellSortSequential>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  std::vector<int> expected = {1, 2, 2, 5, 5};
+  ASSERT_EQ(expected, output);
+}
+
+TEST(kovalchuk_a_shell_sort, test_negative_numbers) {
+  std::vector<int> input = {-5, 0, -3, 10, -1};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort::ShellSortSequential>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  std::vector<int> expected = {-5, -3, -1, 0, 10};
+  ASSERT_EQ(expected, output);
+}
+
+TEST(kovalchuk_a_shell_sort, test_validation_fail) {
+  std::vector<int> input = {1, 2, 3};
+  std::vector<int> output(5);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort::ShellSortSequential>(task_data);
+
+  ASSERT_FALSE(task->Validation());
+}

--- a/tasks/seq/kovalchuk_a_shell_sort/func_tests/main.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/func_tests/main.cpp
@@ -1,14 +1,11 @@
 #include <gtest/gtest.h>
 
-#include <algorithm>
-#include <memory>
 #include <cstdint>
 #include <vector>
 
 #include "core/task/include/task.hpp"
 #include "seq/kovalchuk_a_shell_sort/include/ops_seq.hpp"
 
-// Базовый тест: сортировка несортированного массива
 TEST(kovalchuk_a_shell_sort, test_sort_basic) {
   std::vector<int> input = {9, 2, 5, 1, 7};
   std::vector<int> output(input.size());
@@ -30,7 +27,6 @@ TEST(kovalchuk_a_shell_sort, test_sort_basic) {
   ASSERT_EQ(expected, output);
 }
 
-// Тест пустого массива
 TEST(kovalchuk_a_shell_sort, test_empty_array) {
   std::vector<int> input;
   std::vector<int> output;
@@ -51,7 +47,6 @@ TEST(kovalchuk_a_shell_sort, test_empty_array) {
   ASSERT_TRUE(output.empty());
 }
 
-// Тест массива из одного элемента
 TEST(kovalchuk_a_shell_sort, test_single_element) {
   std::vector<int> input = {42};
   std::vector<int> output(input.size());
@@ -72,7 +67,6 @@ TEST(kovalchuk_a_shell_sort, test_single_element) {
   ASSERT_EQ(input, output);
 }
 
-// Тест уже отсортированного массива
 TEST(kovalchuk_a_shell_sort, test_already_sorted) {
   std::vector<int> input = {1, 2, 3, 4, 5};
   std::vector<int> output(input.size());
@@ -94,7 +88,6 @@ TEST(kovalchuk_a_shell_sort, test_already_sorted) {
   ASSERT_EQ(expected, output);
 }
 
-// Тест обратно отсортированного массива
 TEST(kovalchuk_a_shell_sort, test_reverse_sorted) {
   std::vector<int> input = {9, 7, 5, 3, 1};
   std::vector<int> output(input.size());
@@ -116,7 +109,6 @@ TEST(kovalchuk_a_shell_sort, test_reverse_sorted) {
   ASSERT_EQ(expected, output);
 }
 
-// Тест с дубликатами
 TEST(kovalchuk_a_shell_sort, test_duplicates) {
   std::vector<int> input = {5, 2, 5, 1, 2};
   std::vector<int> output(input.size());
@@ -138,7 +130,6 @@ TEST(kovalchuk_a_shell_sort, test_duplicates) {
   ASSERT_EQ(expected, output);
 }
 
-// Тест с отрицательными числами
 TEST(kovalchuk_a_shell_sort, test_negative_numbers) {
   std::vector<int> input = {-5, 0, -3, 10, -1};
   std::vector<int> output(input.size());
@@ -160,10 +151,9 @@ TEST(kovalchuk_a_shell_sort, test_negative_numbers) {
   ASSERT_EQ(expected, output);
 }
 
-// Тест на валидацию несоответствия размеров
 TEST(kovalchuk_a_shell_sort, test_validation_fail) {
   std::vector<int> input = {1, 2, 3};
-  std::vector<int> output(5);  // Намеренно неверный размер
+  std::vector<int> output(5);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
@@ -176,7 +166,6 @@ TEST(kovalchuk_a_shell_sort, test_validation_fail) {
   ASSERT_FALSE(task->Validation());
 }
 
-// Тест с большими значениями
 TEST(kovalchuk_a_shell_sort, test_large_values) {
   std::vector<int> input = {INT32_MAX, 0, INT32_MIN};
   std::vector<int> output(input.size());

--- a/tasks/seq/kovalchuk_a_shell_sort/include/ops_seq.hpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/include/ops_seq.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kovalchuk_a_shell_sort {
+
+class ShellSortSequential : public ppc::core::Task {
+ public:
+  explicit ShellSortSequential(ppc::core::TaskDataPtr task_data);
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> input_;
+  void shellSort();
+};
+
+}  // namespace kovalchuk_a_shell_sort

--- a/tasks/seq/kovalchuk_a_shell_sort/include/ops_seq.hpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/include/ops_seq.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 
 #include "core/task/include/task.hpp"
@@ -17,7 +16,7 @@ class ShellSortSequential : public ppc::core::Task {
 
  private:
   std::vector<int> input_;
-  void shellSort();
+  void ShellSort();
 };
 
 }  // namespace kovalchuk_a_shell_sort

--- a/tasks/seq/kovalchuk_a_shell_sort/include/ops_seq.hpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/include/ops_seq.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <vector>
 
 #include "core/task/include/task.hpp"

--- a/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <memory>

--- a/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
@@ -14,10 +14,8 @@ TEST(kovalchuk_a_shell_sort_seq, test_pipeline_run) {
   constexpr int kCount = 1000000;
 
   std::vector<int> in(kCount);
-  std::mt19937 gen(42);
-  std::uniform_int_distribution<> dist(-1000000, 1000000);
-  for (auto& num : in) {
-    num = dist(gen);
+  for (int i = 0; i < kCount; ++i) {
+    in[i] = kCount / 2 - i;
   }
   std::vector<int> out(kCount);
 
@@ -48,10 +46,8 @@ TEST(kovalchuk_a_shell_sort_seq, test_task_run) {
   constexpr int kCount = 1000000;
 
   std::vector<int> in(kCount);
-  std::mt19937 gen(42);
-  std::uniform_int_distribution<> dist(-1000000, 1000000);
-  for (auto& num : in) {
-    num = dist(gen);
+  for (int i = 0; i < kCount; ++i) {
+    in[i] = kCount / 2 - i;
   }
   std::vector<int> out(kCount);
 

--- a/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
@@ -3,7 +3,6 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
-#include <random>
 #include <vector>
 
 #include "core/perf/include/perf.hpp"

--- a/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <memory>

--- a/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
@@ -1,0 +1,86 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "seq/kovalchuk_a_shell_sort/include/ops_seq.hpp"
+
+TEST(kovalchuk_a_shell_sort, test_pipeline_run) {
+  constexpr int kCount = 1000000;
+
+  std::vector<int> in(kCount);
+  std::mt19937 gen(42);
+  std::uniform_int_distribution<> dist(-1000000, 1000000);
+  for (auto& num : in) num = dist(gen);
+  std::vector<int> out(kCount);
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  auto test_task = std::make_shared<kovalchuk_a_shell_sort::ShellSortSequential>(task_data_seq);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  std::vector<int> expected = in;
+  std::sort(expected.begin(), expected.end());
+  ASSERT_EQ(expected, out);
+}
+
+TEST(kovalchuk_a_shell_sort, test_task_run) {
+  constexpr int kCount = 1000000;
+
+  std::vector<int> in(kCount);
+  std::mt19937 gen(42);
+  std::uniform_int_distribution<> dist(-1000000, 1000000);
+  for (auto& num : in) num = dist(gen);
+  std::vector<int> out(kCount);
+
+  // init task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create tast
+  auto test_task = std::make_shared<kovalchuk_a_shell_sort::ShellSortSequential>(task_data_seq);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  std::vector<int> expected = in;
+  std::sort(expected.begin(), expected.end());
+  ASSERT_EQ(expected, out);
+}

--- a/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
@@ -45,7 +45,7 @@ TEST(kovalchuk_a_shell_sort, test_pipeline_run) {
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
   std::vector<int> expected = in;
-  std::sort(expected.begin(), expected.end());
+  std::ranges::sort(expected);
   ASSERT_EQ(expected, out);
 }
 
@@ -83,6 +83,6 @@ TEST(kovalchuk_a_shell_sort, test_task_run) {
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
   std::vector<int> expected = in;
-  std::sort(expected.begin(), expected.end());
+  std::ranges::sort(expected);
   ASSERT_EQ(expected, out);
 }

--- a/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
+#include <memory>
 #include <random>
 #include <vector>
 
@@ -44,7 +45,7 @@ TEST(kovalchuk_a_shell_sort, test_pipeline_run) {
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
   std::vector<int> expected = in;
-  std::sort(expected.begin(), expected.end());
+  std::ranges::sort(expected);
   ASSERT_EQ(expected, out);
 }
 
@@ -82,6 +83,6 @@ TEST(kovalchuk_a_shell_sort, test_task_run) {
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
   std::vector<int> expected = in;
-  std::sort(expected.begin(), expected.end());
+  std::ranges::sort(expected);
   ASSERT_EQ(expected, out);
 }

--- a/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
@@ -43,10 +43,6 @@ TEST(kovalchuk_a_shell_sort, test_pipeline_run) {
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task);
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
-
-  std::vector<int> expected = in;
-  std::ranges::sort(expected);
-  ASSERT_EQ(expected, out);
 }
 
 TEST(kovalchuk_a_shell_sort, test_task_run) {
@@ -81,8 +77,4 @@ TEST(kovalchuk_a_shell_sort, test_task_run) {
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task);
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
-
-  std::vector<int> expected = in;
-  std::ranges::sort(expected);
-  ASSERT_EQ(expected, out);
 }

--- a/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
@@ -1,9 +1,8 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
-#include <cstddef>
 #include <cstdint>
-#include <memory>
 #include <random>
 #include <vector>
 
@@ -17,7 +16,9 @@ TEST(kovalchuk_a_shell_sort, test_pipeline_run) {
   std::vector<int> in(kCount);
   std::mt19937 gen(42);
   std::uniform_int_distribution<> dist(-1000000, 1000000);
-  for (auto& num : in) num = dist(gen);
+  for (auto& num : in) {
+    num = dist(gen);
+  }
   std::vector<int> out(kCount);
 
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
@@ -53,17 +54,17 @@ TEST(kovalchuk_a_shell_sort, test_task_run) {
   std::vector<int> in(kCount);
   std::mt19937 gen(42);
   std::uniform_int_distribution<> dist(-1000000, 1000000);
-  for (auto& num : in) num = dist(gen);
+  for (auto& num : in) {
+    num = dist(gen);
+  }
   std::vector<int> out(kCount);
 
-  // init task_data
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
   task_data_seq->inputs_count.emplace_back(in.size());
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
   task_data_seq->outputs_count.emplace_back(out.size());
 
-  // Create tast
   auto test_task = std::make_shared<kovalchuk_a_shell_sort::ShellSortSequential>(task_data_seq);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();

--- a/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
@@ -10,7 +10,7 @@
 #include "core/task/include/task.hpp"
 #include "seq/kovalchuk_a_shell_sort/include/ops_seq.hpp"
 
-TEST(kovalchuk_a_shell_sort, test_pipeline_run) {
+TEST(kovalchuk_a_shell_sort_seq, test_pipeline_run) {
   constexpr int kCount = 1000000;
 
   std::vector<int> in(kCount);
@@ -44,7 +44,7 @@ TEST(kovalchuk_a_shell_sort, test_pipeline_run) {
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 }
 
-TEST(kovalchuk_a_shell_sort, test_task_run) {
+TEST(kovalchuk_a_shell_sort_seq, test_task_run) {
   constexpr int kCount = 1000000;
 
   std::vector<int> in(kCount);

--- a/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <memory>
 #include <random>
 #include <vector>
 

--- a/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
@@ -1,9 +1,7 @@
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <chrono>
 #include <cstdint>
-#include <memory>
 #include <random>
 #include <vector>
 

--- a/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/perf_tests/main.cpp
@@ -44,7 +44,7 @@ TEST(kovalchuk_a_shell_sort, test_pipeline_run) {
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
   std::vector<int> expected = in;
-  std::ranges::sort(expected);
+  std::sort(expected.begin(), expected.end());
   ASSERT_EQ(expected, out);
 }
 
@@ -82,6 +82,6 @@ TEST(kovalchuk_a_shell_sort, test_task_run) {
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
   std::vector<int> expected = in;
-  std::ranges::sort(expected);
+  std::sort(expected.begin(), expected.end());
   ASSERT_EQ(expected, out);
 }

--- a/tasks/seq/kovalchuk_a_shell_sort/src/ops_seq.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/src/ops_seq.cpp
@@ -1,7 +1,10 @@
 #include "seq/kovalchuk_a_shell_sort/include/ops_seq.hpp"
 
 #include <algorithm>
+#include <utility>
 #include <vector>
+
+#include "core/task/include/task.hpp"
 
 namespace kovalchuk_a_shell_sort {
 
@@ -14,26 +17,26 @@ bool ShellSortSequential::PreProcessingImpl() {
 }
 
 bool ShellSortSequential::ValidationImpl() {
-  if (task_data->inputs_count.empty() || task_data->outputs_count.empty()) {
-    return false;
-  }
-  return task_data->inputs_count[0] == task_data->outputs_count[0];
+  return !task_data->inputs_count.empty() && !task_data->outputs_count.empty() &&
+         task_data->inputs_count[0] == task_data->outputs_count[0];
 }
 
 bool ShellSortSequential::RunImpl() {
-  shellSort();
+  ShellSort();
   return true;
 }
 
-void ShellSortSequential::shellSort() {
-  if (input_.empty()) return;
+void ShellSortSequential::ShellSort() {
+  if (input_.empty()) {
+    return;
+  }
 
-  int n = input_.size();
+  int n = static_cast<int>(input_.size());
   for (int gap = n / 2; gap > 0; gap /= 2) {
     for (int i = gap; i < n; ++i) {
       int temp = input_[i];
-      int j;
-      for (j = i; j >= gap && input_[j - gap] > temp; j -= gap) {
+      int j = i;
+      for (; j >= gap && input_[j - gap] > temp; j -= gap) {
         input_[j] = input_[j - gap];
       }
       input_[j] = temp;
@@ -43,7 +46,7 @@ void ShellSortSequential::shellSort() {
 
 bool ShellSortSequential::PostProcessingImpl() {
   auto* output_ptr = reinterpret_cast<int*>(task_data->outputs[0]);
-  std::copy(input_.begin(), input_.end(), output_ptr);
+  std::ranges::copy(input_, output_ptr);
   return true;
 }
 

--- a/tasks/seq/kovalchuk_a_shell_sort/src/ops_seq.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/src/ops_seq.cpp
@@ -9,7 +9,7 @@ ShellSortSequential::ShellSortSequential(ppc::core::TaskDataPtr task_data) : Tas
 
 bool ShellSortSequential::PreProcessingImpl() {
   auto* input_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
-  input_.assign (input_ptr, input_ptr + task_data->inputs_count[0]);
+  input_.assign(input_ptr, input_ptr + task_data->inputs_count[0]);
   return true;
 }
 

--- a/tasks/seq/kovalchuk_a_shell_sort/src/ops_seq.cpp
+++ b/tasks/seq/kovalchuk_a_shell_sort/src/ops_seq.cpp
@@ -1,0 +1,50 @@
+#include "seq/kovalchuk_a_shell_sort/include/ops_seq.hpp"
+
+#include <algorithm>
+#include <vector>
+
+namespace kovalchuk_a_shell_sort {
+
+ShellSortSequential::ShellSortSequential(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+
+bool ShellSortSequential::PreProcessingImpl() {
+  auto* input_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
+  input_.assign (input_ptr, input_ptr + task_data->inputs_count[0]);
+  return true;
+}
+
+bool ShellSortSequential::ValidationImpl() {
+  if (task_data->inputs_count.empty() || task_data->outputs_count.empty()) {
+    return false;
+  }
+  return task_data->inputs_count[0] == task_data->outputs_count[0];
+}
+
+bool ShellSortSequential::RunImpl() {
+  shellSort();
+  return true;
+}
+
+void ShellSortSequential::shellSort() {
+  if (input_.empty()) return;
+
+  int n = input_.size();
+  for (int gap = n / 2; gap > 0; gap /= 2) {
+    for (int i = gap; i < n; ++i) {
+      int temp = input_[i];
+      int j;
+      for (j = i; j >= gap && input_[j - gap] > temp; j -= gap) {
+        input_[j] = input_[j - gap];
+      }
+      input_[j] = temp;
+    }
+  }
+}
+
+bool ShellSortSequential::PostProcessingImpl() {
+  auto* output_ptr = reinterpret_cast<int*>(task_data->outputs[0]);
+  std::copy(input_.begin(), input_.end(), output_ptr);
+  return true;
+}
+
+}  // namespace kovalchuk_a_shell_sort


### PR DESCRIPTION
Последовательная версия Сортировки Шелла: Итеративно уменьшаем gap начиная с n/2  Для каждого gap элементы сравниваются и сдвигаются на gap, на последней итерации gap = 1