### PR TITLE
Аникин Максим. Вариант 16. Технология SEQ. Сортировка Шелла с четно-нечетным слиянием Бэтчера.

### DIFF
--- a/tasks/seq/anikin_m_shall_batcher/func_tests/main.cpp
+++ b/tasks/seq/anikin_m_shall_batcher/func_tests/main.cpp
@@ -1,0 +1,137 @@
+// Copyright Anikin Maksim 2025W
+#include <gtest/gtest.h>
+
+#include <vector>
+#include <random>
+
+#include "core/task/include/task.hpp"
+#include "core/util/include/util.hpp"
+#include "seq/anikin_m_shall_batcher/include/ops_seq.hpp"
+
+namespace {
+void fillVectorWithRandomValues(std::vector<int>& vec, int size, int minVal = 0, int maxVal = 100) {
+  vec.resize(size);
+
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> dist(minVal, maxVal);
+
+  for (int i = 0; i < size; ++i) {
+    vec[i] = dist(gen);
+  }
+}
+}  // namespace
+
+TEST(anikin_m_shall_batcher_seq, test_sort_5) {
+  // Create data
+  int vec_size = 5;
+  std::vector<int> in(vec_size, 0);
+  std::vector<int> out(vec_size, 0);
+
+  in[0] = 5;
+  in[1] = -2;
+  in[2] = 8;
+  in[3] = 6;
+  in[4] = 5;
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  anikin_m_shall_batcher_seq::TestTaskSequential test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(in.size(), out.size());
+  EXPECT_EQ(-2, out[0]);
+  EXPECT_EQ(5, out[1]);
+  EXPECT_EQ(5, out[2]);
+  EXPECT_EQ(6, out[3]);
+  EXPECT_EQ(8, out[4]);
+}
+
+TEST(anikin_m_shall_batcher_seq, test_sort_rand_100) {
+  // Create data
+  int vec_size = 100;
+  std::vector<int> in(vec_size, 0);
+  std::vector<int> out(vec_size, 0);
+
+  fillVectorWithRandomValues(in, vec_size);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  anikin_m_shall_batcher_seq::TestTaskSequential test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(in.size(), out.size());
+  for (int i = 1; i < vec_size; i++) {
+    EXPECT_GE(out[i], out[i - 1]);
+  }
+}
+
+TEST(anikin_m_shall_batcher_seq, test_sort_rand_1000000) {
+  // Create data
+  int vec_size = 1000000;
+  std::vector<int> in(vec_size, 0);
+  std::vector<int> out(vec_size, 0);
+
+  fillVectorWithRandomValues(in, vec_size);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  anikin_m_shall_batcher_seq::TestTaskSequential test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(in.size(), out.size());
+  for (int i = 1; i < vec_size; i++) {
+    EXPECT_GE(out[i], out[i - 1]);
+  }
+}
+
+TEST(anikin_m_shall_batcher_seq, size_0) {
+  // Create data
+  int vec_size = 0;
+  std::vector<int> in(vec_size, 0);
+  std::vector<int> out(vec_size, 0);
+
+  fillVectorWithRandomValues(in, vec_size);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  anikin_m_shall_batcher_seq::TestTaskSequential test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(in.size(), out.size());
+  for (int i = 1; i < vec_size; i++) {
+    EXPECT_GE(out[i], out[i - 1]);
+  }
+}

--- a/tasks/seq/anikin_m_shall_batcher/func_tests/main.cpp
+++ b/tasks/seq/anikin_m_shall_batcher/func_tests/main.cpp
@@ -2,10 +2,10 @@
 #include <gtest/gtest.h>
 
 #include <random>
+#include <memory>
 #include <vector>
 
 #include "core/task/include/task.hpp"
-#include "core/util/include/util.hpp"
 #include "seq/anikin_m_shall_batcher/include/ops_seq.hpp"
 
 namespace {
@@ -48,11 +48,9 @@ TEST(anikin_m_shall_batcher_seq, test_sort_5) {
   test_task_sequential.Run();
   test_task_sequential.PostProcessing();
   EXPECT_EQ(in.size(), out.size());
-  EXPECT_EQ(-2, out[0]);
-  EXPECT_EQ(5, out[1]);
-  EXPECT_EQ(5, out[2]);
-  EXPECT_EQ(6, out[3]);
-  EXPECT_EQ(8, out[4]);
+  for (int i = 1; i < vec_size; i++) {
+    EXPECT_GE(out[i], out[i - 1]);
+  }
 }
 
 TEST(anikin_m_shall_batcher_seq, test_sort_rand_100) {

--- a/tasks/seq/anikin_m_shall_batcher/func_tests/main.cpp
+++ b/tasks/seq/anikin_m_shall_batcher/func_tests/main.cpp
@@ -10,7 +10,7 @@
 #include "seq/anikin_m_shall_batcher/include/ops_seq.hpp"
 
 namespace {
-void FillVectorWithRandomValues(std::vector<int>& vec, int size, int min_val = 0, int max_val = 100) {
+void FillVectorWithRandomValues(std::vector<int> &vec, int size, int min_val = 0, int max_val = 100) {
   vec.resize(size);
 
   std::random_device rd;

--- a/tasks/seq/anikin_m_shall_batcher/func_tests/main.cpp
+++ b/tasks/seq/anikin_m_shall_batcher/func_tests/main.cpp
@@ -1,8 +1,9 @@
 // Copyright Anikin Maksim 2025W
 #include <gtest/gtest.h>
 
-#include <random>
+#include <cstdint>
 #include <memory>
+#include <random>
 #include <vector>
 
 #include "core/task/include/task.hpp"

--- a/tasks/seq/anikin_m_shall_batcher/func_tests/main.cpp
+++ b/tasks/seq/anikin_m_shall_batcher/func_tests/main.cpp
@@ -1,20 +1,20 @@
 // Copyright Anikin Maksim 2025W
 #include <gtest/gtest.h>
 
-#include <vector>
 #include <random>
+#include <vector>
 
 #include "core/task/include/task.hpp"
 #include "core/util/include/util.hpp"
 #include "seq/anikin_m_shall_batcher/include/ops_seq.hpp"
 
 namespace {
-void fillVectorWithRandomValues(std::vector<int>& vec, int size, int minVal = 0, int maxVal = 100) {
+void FillVectorWithRandomValues(std::vector<int>& vec, int size, int min_val = 0, int max_val = 100) {
   vec.resize(size);
 
   std::random_device rd;
   std::mt19937 gen(rd());
-  std::uniform_int_distribution<int> dist(minVal, maxVal);
+  std::uniform_int_distribution<int> dist(min_val, max_val);
 
   for (int i = 0; i < size; ++i) {
     vec[i] = dist(gen);
@@ -61,7 +61,7 @@ TEST(anikin_m_shall_batcher_seq, test_sort_rand_100) {
   std::vector<int> in(vec_size, 0);
   std::vector<int> out(vec_size, 0);
 
-  fillVectorWithRandomValues(in, vec_size);
+  FillVectorWithRandomValues(in, vec_size);
 
   // Create task_data
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
@@ -88,7 +88,7 @@ TEST(anikin_m_shall_batcher_seq, test_sort_rand_1000000) {
   std::vector<int> in(vec_size, 0);
   std::vector<int> out(vec_size, 0);
 
-  fillVectorWithRandomValues(in, vec_size);
+  FillVectorWithRandomValues(in, vec_size);
 
   // Create task_data
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
@@ -115,7 +115,7 @@ TEST(anikin_m_shall_batcher_seq, size_0) {
   std::vector<int> in(vec_size, 0);
   std::vector<int> out(vec_size, 0);
 
-  fillVectorWithRandomValues(in, vec_size);
+  FillVectorWithRandomValues(in, vec_size);
 
   // Create task_data
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();

--- a/tasks/seq/anikin_m_shall_batcher/include/ops_seq.hpp
+++ b/tasks/seq/anikin_m_shall_batcher/include/ops_seq.hpp
@@ -1,15 +1,16 @@
 // Copyright Anikin Maksim 2025
 #pragma once
 
+#include <utility>
 #include <vector>
 
 #include "core/task/include/task.hpp"
 
 namespace anikin_m_shall_batcher_seq {
 
-void shellSort(std::vector<int>& arr);
-void batcherOddEvenMerge(std::vector<int>& arr1, std::vector<int>& arr2, std::vector<int>& output);
-void shellSortWithBatcherMerge(const std::vector<int>& input, std::vector<int>& output);
+void ShellSort(std::vector<int>& arr);
+void BatcherOddEvenMerge(std::vector<int>& arr1, std::vector<int>& arr2, std::vector<int>& output);
+void ShellSortWithBatcherMerge(const std::vector<int>& input, std::vector<int>& output);
 
 class TestTaskSequential : public ppc::core::Task {
  public:
@@ -23,4 +24,4 @@ class TestTaskSequential : public ppc::core::Task {
   std::vector<int> input_, output_;
 };
 
-}
+}  // namespace anikin_m_shall_batcher_seq

--- a/tasks/seq/anikin_m_shall_batcher/include/ops_seq.hpp
+++ b/tasks/seq/anikin_m_shall_batcher/include/ops_seq.hpp
@@ -1,0 +1,26 @@
+// Copyright Anikin Maksim 2025
+#pragma once
+
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace anikin_m_shall_batcher_seq {
+
+void shellSort(std::vector<int>& arr);
+void batcherOddEvenMerge(std::vector<int>& arr1, std::vector<int>& arr2, std::vector<int>& output);
+void shellSortWithBatcherMerge(const std::vector<int>& input, std::vector<int>& output);
+
+class TestTaskSequential : public ppc::core::Task {
+ public:
+  explicit TestTaskSequential(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> input_, output_;
+};
+
+}

--- a/tasks/seq/anikin_m_shall_batcher/perf_tests/main.cpp
+++ b/tasks/seq/anikin_m_shall_batcher/perf_tests/main.cpp
@@ -1,0 +1,102 @@
+// Copyright Anikin Maksim 2025
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <vector>
+#include <random>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "seq/anikin_m_shall_batcher/include/ops_seq.hpp"
+
+namespace {
+void fillVectorWithRandomValues(std::vector<int>& vec, int size, int minVal = 0, int maxVal = 100) {
+  vec.resize(size);
+
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> dist(minVal, maxVal);
+
+  for (int i = 0; i < size; ++i) {
+    vec[i] = dist(gen);
+  }
+}
+}  // namespace
+
+TEST(anikin_m_shall_batcher_seq, test_pipeline_run) {
+  constexpr int kCount = 5000000;
+
+  // Create data
+  std::vector<int> in(kCount, 0);
+  std::vector<int> out(kCount, 0);
+
+  fillVectorWithRandomValues(in, kCount);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_sequential = std::make_shared<anikin_m_shall_batcher_seq::TestTaskSequential>(task_data_seq);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(true, true);
+}
+
+TEST(anikin_m_shall_batcher_seq, test_task_run) {
+  constexpr int kCount = 5000000;
+
+  // Create data
+  std::vector<int> in(kCount, 0);
+  std::vector<int> out(kCount, 0);
+
+  fillVectorWithRandomValues(in, kCount);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_sequential = std::make_shared<anikin_m_shall_batcher_seq::TestTaskSequential>(task_data_seq);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(true, true);
+}

--- a/tasks/seq/anikin_m_shall_batcher/perf_tests/main.cpp
+++ b/tasks/seq/anikin_m_shall_batcher/perf_tests/main.cpp
@@ -2,20 +2,22 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
-#include <vector>
 #include <random>
+#include <cstdint>
+#include <memory>
+#include <vector>
 
 #include "core/perf/include/perf.hpp"
 #include "core/task/include/task.hpp"
 #include "seq/anikin_m_shall_batcher/include/ops_seq.hpp"
 
 namespace {
-void fillVectorWithRandomValues(std::vector<int>& vec, int size, int minVal = 0, int maxVal = 100) {
+void FillVectorWithRandomValues(std::vector<int>& vec, int size, int min_val = 0, int max_val = 100) {
   vec.resize(size);
 
   std::random_device rd;
   std::mt19937 gen(rd());
-  std::uniform_int_distribution<int> dist(minVal, maxVal);
+  std::uniform_int_distribution<int> dist(min_val, max_val);
 
   for (int i = 0; i < size; ++i) {
     vec[i] = dist(gen);
@@ -30,7 +32,7 @@ TEST(anikin_m_shall_batcher_seq, test_pipeline_run) {
   std::vector<int> in(kCount, 0);
   std::vector<int> out(kCount, 0);
 
-  fillVectorWithRandomValues(in, kCount);
+  FillVectorWithRandomValues(in, kCount);
 
   // Create task_data
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
@@ -69,7 +71,7 @@ TEST(anikin_m_shall_batcher_seq, test_task_run) {
   std::vector<int> in(kCount, 0);
   std::vector<int> out(kCount, 0);
 
-  fillVectorWithRandomValues(in, kCount);
+  FillVectorWithRandomValues(in, kCount);
 
   // Create task_data
   auto task_data_seq = std::make_shared<ppc::core::TaskData>();

--- a/tasks/seq/anikin_m_shall_batcher/perf_tests/main.cpp
+++ b/tasks/seq/anikin_m_shall_batcher/perf_tests/main.cpp
@@ -2,9 +2,9 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
-#include <random>
 #include <cstdint>
 #include <memory>
+#include <random>
 #include <vector>
 
 #include "core/perf/include/perf.hpp"

--- a/tasks/seq/anikin_m_shall_batcher/perf_tests/main.cpp
+++ b/tasks/seq/anikin_m_shall_batcher/perf_tests/main.cpp
@@ -12,7 +12,7 @@
 #include "seq/anikin_m_shall_batcher/include/ops_seq.hpp"
 
 namespace {
-void FillVectorWithRandomValues(std::vector<int>& vec, int size, int min_val = 0, int max_val = 100) {
+void FillVectorWithRandomValues(std::vector<int> &vec, int size, int min_val = 0, int max_val = 100) {
   vec.resize(size);
 
   std::random_device rd;

--- a/tasks/seq/anikin_m_shall_batcher/src/ops_seq.cpp
+++ b/tasks/seq/anikin_m_shall_batcher/src/ops_seq.cpp
@@ -1,0 +1,84 @@
+// Copyright Anikin Maksim 2025
+#include "seq/anikin_m_shall_batcher/include/ops_seq.hpp"
+
+#include <vector>
+#include <algorithm>
+
+void anikin_m_shall_batcher_seq::shellSort(std::vector<int>& arr) {
+  int n = arr.size();
+  for (int gap = n / 2; gap > 0; gap /= 2) {
+    for (int i = gap; i < n; i++) {
+      int temp = arr[i];
+      int j;
+      for (j = i; j >= gap && arr[j - gap] > temp; j -= gap) {
+        arr[j] = arr[j - gap];
+      }
+      arr[j] = temp;
+    }
+  }
+}
+
+void anikin_m_shall_batcher_seq::batcherOddEvenMerge(std::vector<int>& arr1, std::vector<int>& arr2,
+                                                     std::vector<int>& output) {
+  int i = 0, j = 0, k = 0;
+  int n1 = arr1.size(), n2 = arr2.size();
+
+  while (i < n1 && j < n2) {
+    if (arr1[i] < arr2[j]) {
+      output[k++] = arr1[i++];
+    } else {
+      output[k++] = arr2[j++];
+    }
+  }
+
+  while (i < n1) {
+    output[k++] = arr1[i++];
+  }
+
+  while (j < n2) {
+    output[k++] = arr2[j++];
+  }
+}
+
+void anikin_m_shall_batcher_seq::shellSortWithBatcherMerge(const std::vector<int>& input, std::vector<int>& output) {
+  if (input.empty()) {
+    output.clear();
+    return;
+  }
+
+  std::vector<int> arr1(input.begin(), input.begin() + input.size() / 2);
+  std::vector<int> arr2(input.begin() + input.size() / 2, input.end());
+
+  shellSort(arr1);
+  shellSort(arr2);
+
+  output.resize(input.size());
+  batcherOddEvenMerge(arr1, arr2, output);
+}
+
+bool anikin_m_shall_batcher_seq::TestTaskSequential::PreProcessingImpl() {
+  unsigned int input_size = task_data->inputs_count[0];
+  auto *in_ptr = reinterpret_cast<int *>(task_data->inputs[0]);
+  input_ = std::vector<int>(in_ptr, in_ptr + input_size);
+
+  unsigned int output_size = task_data->outputs_count[0];
+  output_ = std::vector<int>(output_size, 0);
+
+  return true;
+}
+
+bool anikin_m_shall_batcher_seq::TestTaskSequential::ValidationImpl() {
+  return task_data->inputs_count[0] == task_data->outputs_count[0];
+}
+
+bool anikin_m_shall_batcher_seq::TestTaskSequential::RunImpl() {
+  shellSortWithBatcherMerge(input_, output_);
+  return true;
+}
+
+bool anikin_m_shall_batcher_seq::TestTaskSequential::PostProcessingImpl() {
+  for (size_t i = 0; i < output_.size(); i++) {
+    reinterpret_cast<int *>(task_data->outputs[0])[i] = output_[i];
+  }
+  return true;
+}

--- a/tasks/seq/anikin_m_shall_batcher/src/ops_seq.cpp
+++ b/tasks/seq/anikin_m_shall_batcher/src/ops_seq.cpp
@@ -61,7 +61,7 @@ void anikin_m_shall_batcher_seq::ShellSortWithBatcherMerge(const std::vector<int
 
 bool anikin_m_shall_batcher_seq::TestTaskSequential::PreProcessingImpl() {
   unsigned int input_size = task_data->inputs_count[0];
-  auto *in_ptr = reinterpret_cast<int *>(task_data->inputs[0]);
+  auto *in_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
   input_ = std::vector<int>(in_ptr, in_ptr + input_size);
 
   unsigned int output_size = task_data->outputs_count[0];
@@ -81,7 +81,7 @@ bool anikin_m_shall_batcher_seq::TestTaskSequential::RunImpl() {
 
 bool anikin_m_shall_batcher_seq::TestTaskSequential::PostProcessingImpl() {
   for (size_t i = 0; i < output_.size(); i++) {
-    reinterpret_cast<int *>(task_data->outputs[0])[i] = output_[i];
+    reinterpret_cast<int*>(task_data->outputs[0])[i] = output_[i];
   }
   return true;
 }

--- a/tasks/seq/anikin_m_shall_batcher/src/ops_seq.cpp
+++ b/tasks/seq/anikin_m_shall_batcher/src/ops_seq.cpp
@@ -61,7 +61,7 @@ void anikin_m_shall_batcher_seq::ShellSortWithBatcherMerge(const std::vector<int
 
 bool anikin_m_shall_batcher_seq::TestTaskSequential::PreProcessingImpl() {
   unsigned int input_size = task_data->inputs_count[0];
-  auto *in_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
+  auto* in_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
   input_ = std::vector<int>(in_ptr, in_ptr + input_size);
 
   unsigned int output_size = task_data->outputs_count[0];

--- a/tasks/seq/anikin_m_shall_batcher/src/ops_seq.cpp
+++ b/tasks/seq/anikin_m_shall_batcher/src/ops_seq.cpp
@@ -1,15 +1,15 @@
 // Copyright Anikin Maksim 2025
 #include "seq/anikin_m_shall_batcher/include/ops_seq.hpp"
 
+#include <cstddef>
 #include <vector>
-#include <algorithm>
 
-void anikin_m_shall_batcher_seq::shellSort(std::vector<int>& arr) {
-  int n = arr.size();
+void anikin_m_shall_batcher_seq::ShellSort(std::vector<int>& arr) {
+  int n = static_cast<int>(arr.size());
   for (int gap = n / 2; gap > 0; gap /= 2) {
     for (int i = gap; i < n; i++) {
       int temp = arr[i];
-      int j;
+      int j = 0;
       for (j = i; j >= gap && arr[j - gap] > temp; j -= gap) {
         arr[j] = arr[j - gap];
       }
@@ -18,10 +18,13 @@ void anikin_m_shall_batcher_seq::shellSort(std::vector<int>& arr) {
   }
 }
 
-void anikin_m_shall_batcher_seq::batcherOddEvenMerge(std::vector<int>& arr1, std::vector<int>& arr2,
+void anikin_m_shall_batcher_seq::BatcherOddEvenMerge(std::vector<int>& arr1, std::vector<int>& arr2,
                                                      std::vector<int>& output) {
-  int i = 0, j = 0, k = 0;
-  int n1 = arr1.size(), n2 = arr2.size();
+  int i = 0;
+  int j = 0;
+  int k = 0;
+  int n1 = static_cast<int>(arr1.size());
+  int n2 = static_cast<int>(arr2.size());
 
   while (i < n1 && j < n2) {
     if (arr1[i] < arr2[j]) {
@@ -40,20 +43,20 @@ void anikin_m_shall_batcher_seq::batcherOddEvenMerge(std::vector<int>& arr1, std
   }
 }
 
-void anikin_m_shall_batcher_seq::shellSortWithBatcherMerge(const std::vector<int>& input, std::vector<int>& output) {
+void anikin_m_shall_batcher_seq::ShellSortWithBatcherMerge(const std::vector<int>& input, std::vector<int>& output) {
   if (input.empty()) {
     output.clear();
     return;
   }
 
-  std::vector<int> arr1(input.begin(), input.begin() + input.size() / 2);
-  std::vector<int> arr2(input.begin() + input.size() / 2, input.end());
+  std::vector<int> arr1(input.begin(), input.begin() + static_cast<std::ptrdiff_t>(input.size() / 2));
+  std::vector<int> arr2(input.begin() + static_cast<std::ptrdiff_t>(input.size() / 2), input.end());
 
-  shellSort(arr1);
-  shellSort(arr2);
+  ShellSort(arr1);
+  ShellSort(arr2);
 
   output.resize(input.size());
-  batcherOddEvenMerge(arr1, arr2, output);
+  BatcherOddEvenMerge(arr1, arr2, output);
 }
 
 bool anikin_m_shall_batcher_seq::TestTaskSequential::PreProcessingImpl() {
@@ -72,7 +75,7 @@ bool anikin_m_shall_batcher_seq::TestTaskSequential::ValidationImpl() {
 }
 
 bool anikin_m_shall_batcher_seq::TestTaskSequential::RunImpl() {
-  shellSortWithBatcherMerge(input_, output_);
+  ShellSortWithBatcherMerge(input_, output_);
   return true;
 }
 


### PR DESCRIPTION
Реализован seq алгоритм сортировки Шелла с четно-нечетным слиянием Бэтчера.
Сортировка Шелла (Shell Sort) и четно-нечетное слияние Бэтчера (Batcher's Odd-Even Merge) — это два разных алгоритма, которые используются для сортировки данных. Давайте кратко рассмотрим каждый из них, а затем обсудим, как их можно комбинировать.
Четно-нечетное слияние Бэтчера — это алгоритм, используемый для слияния двух отсортированных последовательностей в одну. Он основан на разделении элементов на четные и нечетные позиции и последующем их слиянии.
Комбинирование сортировки Шелла и четно-нечетного слияния Бэтчера
Идея комбинирования этих двух алгоритмов заключается в том, чтобы использовать сортировку Шелла для предварительной сортировки подмассивов, а затем применить четно-нечетное слияние Бэтчера для слияния этих подмассивов в окончательный отсортированный массив.