### PR TITLE
Кудряшова Ирина. Вариант 20. Технология OMP. Поразрядная сортировка для вещественных чисел (тип double) с четно-нечетным слиянием Бэтчера

### DIFF
--- a/tasks/omp/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncOMP.cpp
+++ b/tasks/omp/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncOMP.cpp
@@ -173,3 +173,24 @@ TEST(kudryashova_i_radix_batcher_omp, omp_radix_test_reverse_order) {
   std::ranges::sort(sorted_global_vector);
   ASSERT_EQ(result, sorted_global_vector);
 }
+
+TEST(kudryashova_i_radix_batcher_omp, omp_radix_test_double_reverse_order) {
+  int global_vector_size = 88;
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_omp::GetRandomDoubleVector(global_vector_size);
+  std::ranges::sort(global_vector, std::greater<>());
+  std::ranges::reverse(global_vector.begin(), global_vector.end());
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_omp::TestTaskOpenMP task_open_mp(task_data);
+  ASSERT_TRUE(task_open_mp.ValidationImpl());
+  task_open_mp.PreProcessingImpl();
+  task_open_mp.RunImpl();
+  task_open_mp.PostProcessingImpl();
+  std::vector<double> sorted_global_vector = global_vector;
+  std::ranges::sort(sorted_global_vector);
+  ASSERT_EQ(result, sorted_global_vector);
+}

--- a/tasks/omp/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncOMP.cpp
+++ b/tasks/omp/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncOMP.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 #include "core/task/include/task.hpp"
-#include "omp/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherOmp.hpp"
+#include "omp/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherOMP.hpp"
 
 std::vector<double> kudryashova_i_radix_batcher_omp::GetRandomDoubleVector(int size) {
   std::vector<double> vector(size);

--- a/tasks/omp/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncOMP.cpp
+++ b/tasks/omp/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncOMP.cpp
@@ -134,3 +134,41 @@ TEST(kudryashova_i_radix_batcher_omp, omp_radix_random_test_3) {
   std::ranges::sort(sorted_global_vector);
   ASSERT_EQ(result, sorted_global_vector);
 }
+
+TEST(kudryashova_i_radix_batcher_omp, omp_radix_test_regular_order) {
+  int global_vector_size = 100;
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_omp::GetRandomDoubleVector(global_vector_size);
+  std::ranges::sort(global_vector);
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_omp::TestTaskOpenMP task_open_mp(task_data);
+  ASSERT_TRUE(task_open_mp.ValidationImpl());
+  task_open_mp.PreProcessingImpl();
+  task_open_mp.RunImpl();
+  task_open_mp.PostProcessingImpl();
+  ASSERT_EQ(result, global_vector);
+}
+
+TEST(kudryashova_i_radix_batcher_omp, omp_radix_test_reverse_order) {
+  int global_vector_size = 100;
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_omp::GetRandomDoubleVector(global_vector_size);
+  std::ranges::sort(global_vector, std::greater<>());
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_omp::TestTaskOpenMP task_open_mp(task_data);
+  ASSERT_TRUE(task_open_mp.ValidationImpl());
+  task_open_mp.PreProcessingImpl();
+  task_open_mp.RunImpl();
+  task_open_mp.PostProcessingImpl();
+  std::vector<double> sorted_global_vector = global_vector;
+  std::ranges::sort(sorted_global_vector);
+  ASSERT_EQ(result, sorted_global_vector);
+}

--- a/tasks/omp/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncOMP.cpp
+++ b/tasks/omp/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncOMP.cpp
@@ -34,9 +34,9 @@ TEST(kudryashova_i_radix_batcher_omp, omp_radix_test_0) {
   task_open_mp.PreProcessingImpl();
   task_open_mp.RunImpl();
   task_open_mp.PostProcessingImpl();
-  std::vector<double> sorted_global_vector = global_vector;
-  std::ranges::sort(sorted_global_vector);
-  ASSERT_EQ(result, sorted_global_vector);
+  std::vector<double> sort_global_vector = global_vector;
+  std::ranges::sort(sort_global_vector);
+  ASSERT_EQ(result, sort_global_vector);
 }
 
 TEST(kudryashova_i_radix_batcher_omp, omp_radix_test_1) {

--- a/tasks/omp/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncOMP.cpp
+++ b/tasks/omp/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncOMP.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <ctime>
 #include <memory>

--- a/tasks/omp/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncOMP.cpp
+++ b/tasks/omp/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncOMP.cpp
@@ -1,0 +1,135 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <ctime>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "omp/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherOmp.hpp"
+
+std::vector<double> kudryashova_i_radix_batcher_omp::GetRandomDoubleVector(int size) {
+  std::vector<double> vector(size);
+  std::mt19937 generator(static_cast<unsigned>(std::time(nullptr)));
+  std::uniform_real_distribution<double> distribution(-1000.0, 1000.0);
+  for (int i = 0; i < size; ++i) {
+    vector[i] = distribution(generator);
+  }
+  return vector;
+}
+
+TEST(kudryashova_i_radix_batcher_omp, omp_radix_test_0) {
+  int global_vector_size = 3;
+  std::vector<double> global_vector = {5.69, -2.11, 0.52};
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_omp::TestTaskOpenMP task_open_mp(task_data);
+  ASSERT_TRUE(task_open_mp.ValidationImpl());
+  task_open_mp.PreProcessingImpl();
+  task_open_mp.RunImpl();
+  task_open_mp.PostProcessingImpl();
+  std::vector<double> sorted_global_vector = global_vector;
+  std::ranges::sort(sorted_global_vector);
+  ASSERT_EQ(result, sorted_global_vector);
+}
+
+TEST(kudryashova_i_radix_batcher_omp, omp_radix_test_1) {
+  int global_vector_size = 9;
+  std::vector<double> global_vector = {8, -2, 5, 10, 1, -7, 3, 12, -6};
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_omp::TestTaskOpenMP task_open_mp(task_data);
+  ASSERT_TRUE(task_open_mp.ValidationImpl());
+  task_open_mp.PreProcessingImpl();
+  task_open_mp.RunImpl();
+  task_open_mp.PostProcessingImpl();
+  std::vector<double> sorted_global_vector = global_vector;
+  std::ranges::sort(sorted_global_vector);
+  ASSERT_EQ(result, sorted_global_vector);
+}
+
+TEST(kudryashova_i_radix_batcher_omp, omp_radix_test_2) {
+  int global_vector_size = 11;
+  std::vector<double> global_vector = {-8.55,   1.85,   -4.0,   2.81828, 8.77,   -5.56562,
+                                       -15.823, -6.971, 3.1615, 0.0,     10.1415};
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_omp::TestTaskOpenMP task_open_mp(task_data);
+  ASSERT_TRUE(task_open_mp.ValidationImpl());
+  task_open_mp.PreProcessingImpl();
+  task_open_mp.RunImpl();
+  task_open_mp.PostProcessingImpl();
+  std::vector<double> sorted_global_vector = global_vector;
+  std::ranges::sort(sorted_global_vector);
+  ASSERT_EQ(result, sorted_global_vector);
+}
+
+TEST(kudryashova_i_radix_batcher_omp, omp_radix_random_test_1) {
+  int global_vector_size = 10;
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_omp::GetRandomDoubleVector(global_vector_size);
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_omp::TestTaskOpenMP task_open_mp(task_data);
+  ASSERT_TRUE(task_open_mp.ValidationImpl());
+  task_open_mp.PreProcessingImpl();
+  task_open_mp.RunImpl();
+  task_open_mp.PostProcessingImpl();
+  std::vector<double> sorted_global_vector = global_vector;
+  std::ranges::sort(sorted_global_vector);
+  ASSERT_EQ(result, sorted_global_vector);
+}
+
+TEST(kudryashova_i_radix_batcher_omp, omp_radix_random_test_2) {
+  int global_vector_size = 50;
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_omp::GetRandomDoubleVector(global_vector_size);
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_omp::TestTaskOpenMP task_open_mp(task_data);
+  ASSERT_TRUE(task_open_mp.ValidationImpl());
+  task_open_mp.PreProcessingImpl();
+  task_open_mp.RunImpl();
+  task_open_mp.PostProcessingImpl();
+  std::vector<double> sorted_global_vector = global_vector;
+  std::ranges::sort(sorted_global_vector);
+  ASSERT_EQ(result, sorted_global_vector);
+}
+
+TEST(kudryashova_i_radix_batcher_omp, omp_radix_random_test_3) {
+  int global_vector_size = 512;
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_omp::GetRandomDoubleVector(global_vector_size);
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_omp::TestTaskOpenMP task_open_mp(task_data);
+  ASSERT_TRUE(task_open_mp.ValidationImpl());
+  task_open_mp.PreProcessingImpl();
+  task_open_mp.RunImpl();
+  task_open_mp.PostProcessingImpl();
+  std::vector<double> sorted_global_vector = global_vector;
+  std::ranges::sort(sorted_global_vector);
+  ASSERT_EQ(result, sorted_global_vector);
+}

--- a/tasks/omp/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncOMP.cpp
+++ b/tasks/omp/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncOMP.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <ctime>
+#include <functional>
 #include <memory>
 #include <random>
 #include <vector>

--- a/tasks/omp/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherOMP.hpp
+++ b/tasks/omp/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherOMP.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cmath>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kudryashova_i_radix_batcher_omp {
+std::vector<double> GetRandomDoubleVector(int size);
+void RadixDoubleSort(std::vector<double>& data, int first, int last);
+void BatcherMerge(std::vector<double>& arr, size_t start, size_t mid, size_t end);
+
+class TestTaskOpenMP : public ppc::core::Task {
+ public:
+  explicit TestTaskOpenMP(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<double> input_data_;
+};
+
+}  // namespace kudryashova_i_radix_batcher_omp

--- a/tasks/omp/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherOMP.hpp
+++ b/tasks/omp/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherOMP.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cmath>
+#include <cstddef>
 #include <utility>
 #include <vector>
 
@@ -8,8 +9,8 @@
 
 namespace kudryashova_i_radix_batcher_omp {
 std::vector<double> GetRandomDoubleVector(int size);
-void RadixDoubleSort(std::vector<double>& data, int first, int last);
-void BatcherMerge(std::vector<double>& arr, size_t start, size_t mid, size_t end);
+void RadixDoubleSort(std::vector<double>& data, size_t first, size_t last);
+void BatcherMerge(std::vector<double>& target_array, size_t merge_start, size_t mid_point, size_t merge_end);
 
 class TestTaskOpenMP : public ppc::core::Task {
  public:

--- a/tasks/omp/kudryashova_i_radix_batcher/perf_tests/kudryashovaRadixBatcherPerfOMP.cpp
+++ b/tasks/omp/kudryashova_i_radix_batcher/perf_tests/kudryashovaRadixBatcherPerfOMP.cpp
@@ -1,0 +1,77 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "omp/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherOmp.hpp"
+
+std::vector<double> kudryashova_i_radix_batcher_omp::GetRandomDoubleVector(int size) {
+  std::vector<double> vector(size);
+  std::mt19937 generator(static_cast<unsigned>(std::time(nullptr)));
+  std::uniform_real_distribution<double> distribution(-1000.0, 1000.0);
+  for (int i = 0; i < size; ++i) {
+    vector[i] = distribution(generator);
+  }
+  return vector;
+}
+
+TEST(kudryashova_i_radix_batcher_omp, test_pipeline_run) {
+  int global_vector_size = 3000000;
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_omp::GetRandomDoubleVector(global_vector_size);
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  auto test_task_open_mp = std::make_shared<kudryashova_i_radix_batcher_omp::TestTaskOpenMP>(task_data);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_open_mp);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
+    ASSERT_LE(result[i - 1], result[i]);
+  }
+}
+
+TEST(kudryashova_i_radix_batcher_omp, test_task_run) {
+  int global_vector_size = 3000000;
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_omp::GetRandomDoubleVector(global_vector_size);
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  auto test_task_open_mp = std::make_shared<kudryashova_i_radix_batcher_omp::TestTaskOpenMP>(task_data);
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_open_mp);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
+    ASSERT_LE(result[i - 1], result[i]);
+  }
+}

--- a/tasks/omp/kudryashova_i_radix_batcher/perf_tests/kudryashovaRadixBatcherPerfOMP.cpp
+++ b/tasks/omp/kudryashova_i_radix_batcher/perf_tests/kudryashovaRadixBatcherPerfOMP.cpp
@@ -9,7 +9,7 @@
 
 #include "core/perf/include/perf.hpp"
 #include "core/task/include/task.hpp"
-#include "omp/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherOmp.hpp"
+#include "omp/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherOMP.hpp"
 
 std::vector<double> kudryashova_i_radix_batcher_omp::GetRandomDoubleVector(int size) {
   std::vector<double> vector(size);

--- a/tasks/omp/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherOMP.cpp
+++ b/tasks/omp/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherOMP.cpp
@@ -1,0 +1,160 @@
+﻿
+#include "omp/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherOmp.hpp"
+
+#include <omp.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+using namespace kudryashova_i_radix_batcher_omp;
+void kudryashova_i_radix_batcher_omp::RadixDoubleSort(std::vector<double>& data, int first, int last) {
+  const int sort_size = last - first;
+  std::vector<uint64_t> converted(sort_size);
+
+#pragma omp parallel for
+  for (int i = 0; i < sort_size; ++i) {
+    double value = data[first + i];
+    uint64_t bits = 0;
+    std::memcpy(&bits, &value, sizeof(value));
+    converted[i] = (bits & (1ULL << 63)) ? ~bits : bits ^ (1ULL << 63);
+  }
+
+  std::vector<uint64_t> buffer(sort_size);
+  const int bits_in_byte = 8;
+  const int total_passes = sizeof(uint64_t);
+  const int max_byte_value = 255;
+
+  for (int shift = 0; shift < total_passes; ++shift) {
+    std::vector<size_t> count(256, 0);
+    const int shift_loc = shift * bits_in_byte;
+
+#pragma omp parallel
+    {
+      std::vector<size_t> local_count(256, 0);
+#pragma omp for
+      for (int i = 0; i < sort_size; ++i) {
+        ++local_count[(converted[i] >> shift_loc) & max_byte_value];
+      }
+#pragma omp critical
+      {
+        for (int j = 0; j < 256; ++j) {
+          count[j] += local_count[j];
+        }
+      }
+    }
+
+    size_t total = 0;
+    for (int j = 0; j < 256; ++j) {
+      size_t old = count[j];
+      count[j] = total;
+      total += old;
+    }
+
+    std::vector<std::atomic<size_t>> atomic_count(256);
+    for (int j = 0; j < 256; ++j) {
+      atomic_count[j] = count[j];
+    }
+#pragma omp parallel for
+    for (int i = 0; i < sort_size; ++i) {
+      const uint8_t byte = (converted[i] >> shift_loc) & max_byte_value;
+      size_t pos = atomic_count[byte].fetch_add(1, std::memory_order_seq_cst);
+      buffer[pos] = converted[i];
+    }
+
+    converted.swap(buffer);
+  }
+
+#pragma omp parallel for
+  for (int i = 0; i < sort_size; ++i) {
+    uint64_t bits = converted[i];
+    bits = (bits & (1ULL << 63)) ? (bits ^ (1ULL << 63)) : ~bits;
+    std::memcpy(&data[first + i], &bits, sizeof(double));
+  }
+}
+
+void kudryashova_i_radix_batcher_omp::BatcherMerge(std::vector<double>& target_array, size_t merge_start,
+                                                   size_t mid_point, size_t merge_end) {
+  const size_t total_elements = merge_end - merge_start;
+  std::vector<double> merge_buffer(total_elements);
+  const size_t left_size = mid_point - merge_start;
+  const size_t right_size = merge_end - mid_point;
+  std::vector<double> left_array(target_array.begin() + merge_start, target_array.begin() + mid_point);
+  std::vector<double> right_array(target_array.begin() + mid_point, target_array.begin() + merge_end);
+  size_t left_ptr = 0;
+  size_t right_ptr = 0;
+  size_t merge_ptr = merge_start;
+#pragma omp parallel
+  {
+    const int num_threads = omp_get_num_threads();
+    const int thread_id = omp_get_thread_num();
+    const size_t chunk = (total_elements + num_threads - 1) / num_threads;
+    const size_t start = std::min(thread_id * chunk, total_elements);
+    const size_t end = std::min((thread_id + 1) * chunk, total_elements);
+
+    for (size_t i = start; i < end; ++i) {
+      if (i % 2 == 0) {
+        if (left_ptr < left_size && (right_ptr >= right_size || left_array[left_ptr] <= right_array[right_ptr])) {
+          target_array[merge_ptr++] = left_array[left_ptr++];
+        } else {
+          target_array[merge_ptr++] = right_array[right_ptr++];
+        }
+      } else {
+        if (right_ptr < right_size && (left_ptr >= left_size || right_array[right_ptr] <= left_array[left_ptr])) {
+          target_array[merge_ptr++] = right_array[right_ptr++];
+        } else {
+          target_array[merge_ptr++] = left_array[left_ptr++];
+        }
+      }
+    }
+  }
+}
+
+bool kudryashova_i_radix_batcher_omp::TestTaskOpenMP::PreProcessingImpl() {
+  input_data_.resize(task_data->inputs_count[0]);
+  if (task_data->inputs[0] == nullptr || task_data->inputs_count[0] == 0) {
+    return false;
+  }
+  auto* tmp_ptr = reinterpret_cast<double*>(task_data->inputs[0]);
+  std::copy(tmp_ptr, tmp_ptr + task_data->inputs_count[0], input_data_.begin());
+  return true;
+}
+
+bool kudryashova_i_radix_batcher_omp::TestTaskOpenMP::ValidationImpl() {
+  return task_data->inputs_count[0] > 0 && task_data->outputs_count[0] == task_data->inputs_count[0];
+}
+
+bool kudryashova_i_radix_batcher_omp::TestTaskOpenMP::RunImpl() {
+  const size_t n = input_data_.size();
+  const int num_threads = omp_get_max_threads();
+  const size_t block_size = (n + num_threads - 1) / num_threads;
+
+#pragma omp parallel for schedule(static)
+  for (int i = 0; i < num_threads; ++i) {
+    const size_t start = i * block_size;
+    const size_t end = std::min(start + block_size, n);
+    if (start < n) {
+      RadixDoubleSort(input_data_, start, end);
+    }
+  }
+
+  for (size_t merge_size = block_size; merge_size < n; merge_size *= 2) {
+#pragma omp parallel for schedule(static)
+    for (int i = 0; i < n; i += (2 * merge_size)) {
+      const size_t mid = std::min(i + merge_size, n);
+      const size_t end = std::min(i + 2 * merge_size, n);
+      if (mid < end) {
+        BatcherMerge(input_data_, i, mid, end);
+      }
+    }
+  }
+  return true;
+}
+
+bool kudryashova_i_radix_batcher_omp::TestTaskOpenMP::PostProcessingImpl() {
+  std::ranges::copy(input_data_, reinterpret_cast<double*>(task_data->outputs[0]));
+  return true;
+}

--- a/tasks/omp/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherOMP.cpp
+++ b/tasks/omp/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherOMP.cpp
@@ -9,7 +9,6 @@
 #include <cstring>
 #include <vector>
 
-using namespace kudryashova_i_radix_batcher_omp;
 void kudryashova_i_radix_batcher_omp::RadixDoubleSort(std::vector<double>& data, size_t first, size_t last) {
   const size_t sort_size = last - first;
   std::vector<uint64_t> converted(sort_size);

--- a/tasks/omp/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherOMP.cpp
+++ b/tasks/omp/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherOMP.cpp
@@ -142,7 +142,7 @@ bool kudryashova_i_radix_batcher_omp::TestTaskOpenMP::RunImpl() {
 
   for (size_t merge_size = block_size; merge_size < n; merge_size *= 2) {
 #pragma omp parallel for schedule(static)
-    for (int i = 0; i < static_cast<int> (n); i += (2 * merge_size)) {
+    for (int i = 0; i < static_cast<int>(n); i += (2 * merge_size)) {
       const size_t mid = std::min(i + merge_size, n);
       const size_t end = std::min(i + 2 * merge_size, n);
       if (mid < end) {

--- a/tasks/omp/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherOMP.cpp
+++ b/tasks/omp/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherOMP.cpp
@@ -1,5 +1,4 @@
-﻿
-#include "omp/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherOmp.hpp"
+﻿#include "omp/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherOMP.hpp"
 
 #include <omp.h>
 
@@ -128,7 +127,7 @@ bool kudryashova_i_radix_batcher_omp::TestTaskOpenMP::ValidationImpl() {
 }
 
 bool kudryashova_i_radix_batcher_omp::TestTaskOpenMP::RunImpl() {
-  const size_t n = input_data_.size();
+  size_t n = input_data_.size();
   const int num_threads = omp_get_max_threads();
   const size_t block_size = (n + num_threads - 1) / num_threads;
 
@@ -143,7 +142,7 @@ bool kudryashova_i_radix_batcher_omp::TestTaskOpenMP::RunImpl() {
 
   for (size_t merge_size = block_size; merge_size < n; merge_size *= 2) {
 #pragma omp parallel for schedule(static)
-    for (int i = 0; i < n; i += (2 * merge_size)) {
+    for (int i = 0; i < static_cast<int> (n); i += (2 * merge_size)) {
       const size_t mid = std::min(i + merge_size, n);
       const size_t end = std::min(i + 2 * merge_size, n);
       if (mid < end) {

--- a/tasks/omp/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherOMP.cpp
+++ b/tasks/omp/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherOMP.cpp
@@ -15,7 +15,7 @@ void kudryashova_i_radix_batcher_omp::RadixDoubleSort(std::vector<double>& data,
   std::vector<uint64_t> converted(sort_size);
 
 #pragma omp parallel for
-  for (int i = 0; i < sort_size; ++i) {
+  for (int i = 0; i < static_cast<int>(sort_size); ++i) {
     double value = data[first + i];
     uint64_t bits = 0;
     std::memcpy(&bits, &value, sizeof(value));
@@ -35,7 +35,7 @@ void kudryashova_i_radix_batcher_omp::RadixDoubleSort(std::vector<double>& data,
     {
       std::vector<size_t> local_count(256, 0);
 #pragma omp for
-      for (int i = 0; i < sort_size; ++i) {
+      for (int i = 0; i < static_cast<int>(sort_size); ++i) {
         ++local_count[(converted[i] >> shift_loc) & max_byte_value];
       }
 #pragma omp critical
@@ -58,7 +58,7 @@ void kudryashova_i_radix_batcher_omp::RadixDoubleSort(std::vector<double>& data,
       atomic_count[j] = count[j];
     }
 #pragma omp parallel for
-    for (int i = 0; i < sort_size; ++i) {
+    for (int i = 0; i < static_cast<int>(sort_size); ++i) {
       const uint8_t byte = (converted[i] >> shift_loc) & max_byte_value;
       size_t pos = atomic_count[byte].fetch_add(1, std::memory_order_seq_cst);
       buffer[pos] = converted[i];
@@ -68,7 +68,7 @@ void kudryashova_i_radix_batcher_omp::RadixDoubleSort(std::vector<double>& data,
   }
 
 #pragma omp parallel for
-  for (int i = 0; i < sort_size; ++i) {
+  for (int i = 0; i < static_cast<int>(sort_size); ++i) {
     uint64_t bits = converted[i];
     bits = ((bits & (1ULL << 63)) != 0) ? (bits ^ (1ULL << 63)) : ~bits;
     std::memcpy(&data[first + i], &bits, sizeof(double));


### PR DESCRIPTION
Данная реализация демонстрирует поразрядную сортировку и чётно-нечётное слияние Бэтчера с использованием технологии OpenMP для параллелизации.
_RunImpl()_ организует процесс сортировки входных данных, разбивая их на блоки для параллельной обработки Сначала происходит параллельная сортировка блоков массива с использованием _RadixDoubleSort_. Затем, в цикле, происходит итеративное слияние отсортированных блоков с использованием _BatcherMerge_, где размер сливаемых блоков увеличивается вдвое на каждом шаге.
Функция _RadixDoubleSort_ сортирует массив чисел типа double, используя алгоритм поразрядной сортировки Каждое число преобразуется в uint64_t, при этом обрабатывается знак. После этого функция выполняет сортировку поразрядно, проходя через каждый байт числа от младшего к старшему. В каждом проходе создаём массив подсчета, который фиксирует количество вхождений каждого байта. Далее получим массив префиксных сумм, который позволяет определить, куда именно нужно разместить каждый элемент в отсортированном массиве. Здесь происходит перераспределение элементов на основе подсчитанных префиксных сумм. В конце каждым потоком выводится отсортированный массив, показывающий результат работы функции.
Функция _BatcherMerge_ отвечает за слияние двух отсортированных подмассивов, используя технологию четно-нечетного слияния. В этом подходе элементы из левой и правой половин массива чередуются, что позволяет эффективно объединять массивы в отсортированном порядке. Параллелизация осуществляется через разделение работы между потоками, где каждый поток обрабатывает свой участок массива. В рультате получим отсортированный массив исходных данных.