### PR TITLE
Коровин Никита. Вариант 14. Технология TBB. Сортировка Хоара с четно-нечетным слиянием Бэтчера.

### DIFF
--- a/tasks/tbb/korovin_n_qsort_batcher/func_tests/main.cpp
+++ b/tasks/tbb/korovin_n_qsort_batcher/func_tests/main.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <climits>
 #include <cstdint>
 #include <memory>
 #include <random>
@@ -58,6 +59,21 @@ TEST(korovin_n_qsort_batcher_tbb, test_reverse_sort) {
 
 TEST(korovin_n_qsort_batcher_tbb, test_double_reverse_sort) {
   std::vector<int> in = {5, 4, 3, 2, 1, 5, 4, 3, 2, 1};
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_tbb, test_repeating_25_87) {
+  std::vector<int> in = {25, 87, 25, 87, 1, 25, 87, 0, -5};
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_tbb, test_all_elements_equal_25) {
+  std::vector<int> in(50, 25);
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_tbb, test_extreme_values_with_25_87) {
+  std::vector<int> in = {INT_MIN, 25, INT_MAX, 87, INT_MIN, 25, 0, INT_MAX, 87};
   RunTest(in);
 }
 

--- a/tasks/tbb/korovin_n_qsort_batcher/func_tests/main.cpp
+++ b/tasks/tbb/korovin_n_qsort_batcher/func_tests/main.cpp
@@ -1,0 +1,109 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "tbb/korovin_n_qsort_batcher/include/ops_tbb.hpp"
+
+namespace {
+struct GenParams {
+  int size;
+  int lower_bound = -500;
+  int upper_bound = 500;
+};
+
+std::vector<int> GenerateRndVector(GenParams param) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> dist(param.lower_bound, param.upper_bound);
+
+  std::vector<int> v1(param.size);
+  for (auto &num : v1) {
+    num = dist(gen);
+  }
+  return v1;
+}
+
+void RunTest(std::vector<int> &in) {
+  std::vector<int> out(in.size());
+
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_tbb->inputs_count.emplace_back(in.size());
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(out.size());
+
+  korovin_n_qsort_batcher_tbb::TestTaskTBB test_task_tbb(task_data_tbb);
+  ASSERT_TRUE(test_task_tbb.Validation());
+  ASSERT_TRUE(test_task_tbb.PreProcessing());
+  ASSERT_TRUE(test_task_tbb.Run());
+  ASSERT_TRUE(test_task_tbb.PostProcessing());
+  ASSERT_TRUE(std::ranges::is_sorted(out));
+}
+}  // namespace
+
+TEST(korovin_n_qsort_batcher_tbb, test_unsort) {
+  std::vector<int> in = {11, 5, 1, 42, 3, 8, 7, 25, 6};
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_tbb, test_reverse_sort) {
+  std::vector<int> in = {10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_tbb, test_double_reverse_sort) {
+  std::vector<int> in = {5, 4, 3, 2, 1, 5, 4, 3, 2, 1};
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_tbb, test_empty_sort) {
+  std::vector<int> in = {};
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_tbb, test_one_el_sort) {
+  std::vector<int> in = {42};
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_tbb, test_already_sort) {
+  std::vector<int> in = {1, 2, 3, 4, 5, 6};
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_tbb, test_random_sort) {
+  auto param = GenParams();
+  param.size = 20;
+
+  std::vector<int> in = GenerateRndVector(param);
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_tbb, test_random_sort_100) {
+  auto param = GenParams();
+  param.size = 100;
+
+  std::vector<int> in = GenerateRndVector(param);
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_tbb, test_random_sort_500) {
+  auto param = GenParams();
+  param.size = 500;
+
+  std::vector<int> in = GenerateRndVector(param);
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_tbb, test_random_sort_1000) {
+  auto param = GenParams();
+  param.size = 1000;
+
+  std::vector<int> in = GenerateRndVector(param);
+  RunTest(in);
+}

--- a/tasks/tbb/korovin_n_qsort_batcher/include/ops_tbb.hpp
+++ b/tasks/tbb/korovin_n_qsort_batcher/include/ops_tbb.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace korovin_n_qsort_batcher_tbb {
+
+struct BlockRange {
+  std::vector<int>::iterator low;
+  std::vector<int>::iterator high;
+};
+
+class TestTaskTBB : public ppc::core::Task {
+ public:
+  explicit TestTaskTBB(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> input_;
+  static int GetRandomIndex(int low, int high);
+  static void QuickSort(std::vector<int>::iterator low, std::vector<int>::iterator high, int depth = 0);
+  static bool InPlaceMerge(const BlockRange& a, const BlockRange& b, std::vector<int>& buffer);
+  static std::vector<BlockRange> PartitionBlocks(std::vector<int>& arr, int p);
+  static void OddEvenMerge(std::vector<BlockRange>& blocks);
+};
+
+}  // namespace korovin_n_qsort_batcher_tbb

--- a/tasks/tbb/korovin_n_qsort_batcher/perf_tests/main.cpp
+++ b/tasks/tbb/korovin_n_qsort_batcher/perf_tests/main.cpp
@@ -12,7 +12,7 @@
 #include "tbb/korovin_n_qsort_batcher/include/ops_tbb.hpp"
 
 namespace {
-constexpr int kSize = 250000;
+constexpr int kSize = 7000000;
 constexpr int kSeed = 25;
 
 std::vector<int> GenerateRndArray(int size, int seed) {
@@ -40,7 +40,7 @@ TEST(korovin_n_qsort_batcher_tbb, test_pipeline_run) {
   auto test_task_tbb = std::make_shared<korovin_n_qsort_batcher_tbb::TestTaskTBB>(task_data_tbb);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 25;
+  perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&] {
     auto current_time_point = std::chrono::high_resolution_clock::now();
@@ -69,7 +69,7 @@ TEST(korovin_n_qsort_batcher_tbb, test_task_run) {
   auto test_task_tbb = std::make_shared<korovin_n_qsort_batcher_tbb::TestTaskTBB>(task_data_tbb);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 25;
+  perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&] {
     auto current_time_point = std::chrono::high_resolution_clock::now();

--- a/tasks/tbb/korovin_n_qsort_batcher/perf_tests/main.cpp
+++ b/tasks/tbb/korovin_n_qsort_batcher/perf_tests/main.cpp
@@ -4,7 +4,6 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
-#include <numeric>
 #include <random>
 #include <vector>
 
@@ -14,9 +13,9 @@
 
 namespace {
 constexpr int kSize = 250000;
-constexpr unsigned int kSeed = 25;
+constexpr int kSeed = 25;
 
-std::vector<int> GenerateRndArray(int size, unsigned int seed) {
+std::vector<int> GenerateRndArray(int size, int seed) {
   std::mt19937 gen(seed);
   std::uniform_int_distribution<int> dist(-1000, 1000);
 

--- a/tasks/tbb/korovin_n_qsort_batcher/perf_tests/main.cpp
+++ b/tasks/tbb/korovin_n_qsort_batcher/perf_tests/main.cpp
@@ -5,17 +5,32 @@
 #include <cstdint>
 #include <memory>
 #include <numeric>
+#include <random>
 #include <vector>
 
 #include "core/perf/include/perf.hpp"
 #include "core/task/include/task.hpp"
 #include "tbb/korovin_n_qsort_batcher/include/ops_tbb.hpp"
 
+namespace {
+constexpr int kSize = 250000;
+constexpr unsigned int kSeed = 25;
+
+std::vector<int> GenerateRndArray(int size, unsigned int seed) {
+  std::mt19937 gen(seed);
+  std::uniform_int_distribution<int> dist(-1000, 1000);
+
+  std::vector<int> result(size);
+  for (auto &elem : result) {
+    elem = dist(gen);
+  }
+  return result;
+}
+}  // namespace
+
 TEST(korovin_n_qsort_batcher_tbb, test_pipeline_run) {
-  constexpr int kSize = 250000;
-  std::vector<int> in(kSize);
+  std::vector<int> in = GenerateRndArray(kSize, kSeed);
   std::vector<int> out(in.size());
-  std::iota(in.rbegin(), in.rend(), 1);
 
   auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
   task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
@@ -43,10 +58,8 @@ TEST(korovin_n_qsort_batcher_tbb, test_pipeline_run) {
 }
 
 TEST(korovin_n_qsort_batcher_tbb, test_task_run) {
-  constexpr int kSize = 250000;
-  std::vector<int> in(kSize);
+  std::vector<int> in = GenerateRndArray(kSize, kSeed);
   std::vector<int> out(in.size());
-  std::iota(in.rbegin(), in.rend(), 1);
 
   auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
   task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));

--- a/tasks/tbb/korovin_n_qsort_batcher/perf_tests/main.cpp
+++ b/tasks/tbb/korovin_n_qsort_batcher/perf_tests/main.cpp
@@ -11,7 +11,7 @@
 #include "tbb/korovin_n_qsort_batcher/include/ops_tbb.hpp"
 
 TEST(korovin_n_qsort_batcher_tbb, test_pipeline_run) {
-  constexpr int kSize = 3000000;
+  constexpr int kSize = 250000;
   std::vector<int> in(kSize);
   std::vector<int> out(in.size());
   std::iota(in.rbegin(), in.rend(), 1);
@@ -41,7 +41,7 @@ TEST(korovin_n_qsort_batcher_tbb, test_pipeline_run) {
 }
 
 TEST(korovin_n_qsort_batcher_tbb, test_task_run) {
-  constexpr int kSize = 3000000;
+  constexpr int kSize = 250000;
   std::vector<int> in(kSize);
   std::vector<int> out(in.size());
   std::iota(in.rbegin(), in.rend(), 1);

--- a/tasks/tbb/korovin_n_qsort_batcher/perf_tests/main.cpp
+++ b/tasks/tbb/korovin_n_qsort_batcher/perf_tests/main.cpp
@@ -25,7 +25,7 @@ TEST(korovin_n_qsort_batcher_tbb, test_pipeline_run) {
   auto test_task_tbb = std::make_shared<korovin_n_qsort_batcher_tbb::TestTaskTBB>(task_data_tbb);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 10;
+  perf_attr->num_running = 25;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&] {
     auto current_time_point = std::chrono::high_resolution_clock::now();
@@ -55,7 +55,7 @@ TEST(korovin_n_qsort_batcher_tbb, test_task_run) {
   auto test_task_tbb = std::make_shared<korovin_n_qsort_batcher_tbb::TestTaskTBB>(task_data_tbb);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 10;
+  perf_attr->num_running = 25;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&] {
     auto current_time_point = std::chrono::high_resolution_clock::now();

--- a/tasks/tbb/korovin_n_qsort_batcher/perf_tests/main.cpp
+++ b/tasks/tbb/korovin_n_qsort_batcher/perf_tests/main.cpp
@@ -1,0 +1,71 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <numeric>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "tbb/korovin_n_qsort_batcher/include/ops_tbb.hpp"
+
+TEST(korovin_n_qsort_batcher_tbb, test_pipeline_run) {
+  constexpr int kSize = 3000000;
+  std::vector<int> in(kSize);
+  std::vector<int> out(in.size());
+  std::iota(in.rbegin(), in.rend(), 1);
+
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_tbb->inputs_count.emplace_back(in.size());
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(out.size());
+
+  auto test_task_tbb = std::make_shared<korovin_n_qsort_batcher_tbb::TestTaskTBB>(task_data_tbb);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_tbb);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}
+
+TEST(korovin_n_qsort_batcher_tbb, test_task_run) {
+  constexpr int kSize = 3000000;
+  std::vector<int> in(kSize);
+  std::vector<int> out(in.size());
+  std::iota(in.rbegin(), in.rend(), 1);
+
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_tbb->inputs_count.emplace_back(in.size());
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(out.size());
+
+  auto test_task_tbb = std::make_shared<korovin_n_qsort_batcher_tbb::TestTaskTBB>(task_data_tbb);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_tbb);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}

--- a/tasks/tbb/korovin_n_qsort_batcher/perf_tests/main.cpp
+++ b/tasks/tbb/korovin_n_qsort_batcher/perf_tests/main.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <memory>
@@ -38,6 +39,7 @@ TEST(korovin_n_qsort_batcher_tbb, test_pipeline_run) {
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_tbb);
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_TRUE(std::ranges::is_sorted(out.begin(), out.end()));
 }
 
 TEST(korovin_n_qsort_batcher_tbb, test_task_run) {
@@ -68,4 +70,5 @@ TEST(korovin_n_qsort_batcher_tbb, test_task_run) {
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_tbb);
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_TRUE(std::ranges::is_sorted(out.begin(), out.end()));
 }

--- a/tasks/tbb/korovin_n_qsort_batcher/src/ops_tbb.cpp
+++ b/tasks/tbb/korovin_n_qsort_batcher/src/ops_tbb.cpp
@@ -11,6 +11,7 @@
 #include <span>
 #include <vector>
 
+#include "core/util/include/util.hpp"
 #include "oneapi/tbb/blocked_range.h"
 #include "oneapi/tbb/enumerable_thread_specific.h"
 #include "oneapi/tbb/parallel_for.h"
@@ -37,7 +38,7 @@ void TestTaskTBB::QuickSort(std::vector<int>::iterator low, std::vector<int>::it
   auto partition_iter = std::partition(low, high, [pivot](int elem) { return elem <= pivot; });
   auto mid_iter = std::partition(low, partition_iter, [pivot](int elem) { return elem < pivot; });
 
-  int max_depth = static_cast<int>(std::log2(tbb::this_task_arena::max_concurrency())) + 1;
+  int max_depth = static_cast<int>(std::log2(ppc::util::GetPPCNumThreads())) + 1;
 
   if (depth < max_depth) {
     tbb::task_group group;
@@ -153,7 +154,7 @@ bool TestTaskTBB::RunImpl() {
   if (n <= 1) {
     return true;
   }
-  int num_threads = tbb::this_task_arena::max_concurrency();
+  int num_threads = ppc::util::GetPPCNumThreads();
   int p = std::max(num_threads / 2, 1);
   auto blocks = PartitionBlocks(input_, p);
 

--- a/tasks/tbb/korovin_n_qsort_batcher/src/ops_tbb.cpp
+++ b/tasks/tbb/korovin_n_qsort_batcher/src/ops_tbb.cpp
@@ -15,7 +15,6 @@
 #include "oneapi/tbb/blocked_range.h"
 #include "oneapi/tbb/enumerable_thread_specific.h"
 #include "oneapi/tbb/parallel_for.h"
-#include "oneapi/tbb/task_arena.h"
 #include "oneapi/tbb/task_group.h"
 
 namespace korovin_n_qsort_batcher_tbb {

--- a/tasks/tbb/korovin_n_qsort_batcher/src/ops_tbb.cpp
+++ b/tasks/tbb/korovin_n_qsort_batcher/src/ops_tbb.cpp
@@ -1,5 +1,6 @@
 #include "tbb/korovin_n_qsort_batcher/include/ops_tbb.hpp"
 
+#include <oneapi/tbb/parallel_invoke.h>
 #include <tbb/tbb.h>
 
 #include <algorithm>
@@ -116,7 +117,7 @@ void TestTaskTBB::OddEvenMerge(std::vector<BlockRange>& blocks) {
     tbb::parallel_for(tbb::blocked_range<int>(0, p / 2), [&](const tbb::blocked_range<int>& range) {
       auto& buffer = thread_buffers.local();
       for (int idx = range.begin(); idx < range.end(); idx++) {
-        int i = (iter + idx * 2) % 2 + idx * 2;
+        int i = ((iter + idx * 2) % 2) + (idx * 2);
         if (i + 1 < p) {
           bool changed_local = InPlaceMerge(blocks[i], blocks[i + 1], buffer);
           if (changed_local) {

--- a/tasks/tbb/korovin_n_qsort_batcher/src/ops_tbb.cpp
+++ b/tasks/tbb/korovin_n_qsort_batcher/src/ops_tbb.cpp
@@ -1,0 +1,171 @@
+#include "tbb/korovin_n_qsort_batcher/include/ops_tbb.hpp"
+
+#include <tbb/tbb.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <cstddef>
+#include <iterator>
+#include <random>
+#include <span>
+#include <vector>
+
+#include "oneapi/tbb/blocked_range.h"
+#include "oneapi/tbb/enumerable_thread_specific.h"
+#include "oneapi/tbb/parallel_for.h"
+#include "oneapi/tbb/task_arena.h"
+#include "oneapi/tbb/task_group.h"
+
+namespace korovin_n_qsort_batcher_tbb {
+
+int TestTaskTBB::GetRandomIndex(int low, int high) {
+  static thread_local std::mt19937 gen(std::random_device{}());
+  std::uniform_int_distribution<int> dist(low, high);
+  return dist(gen);
+}
+
+void TestTaskTBB::QuickSort(std::vector<int>::iterator low, std::vector<int>::iterator high, int depth) {
+  if (std::distance(low, high) <= 1) {
+    return;
+  }
+
+  int n = static_cast<int>(std::distance(low, high));
+  int random_index = GetRandomIndex(0, n - 1);
+  int pivot = *(low + random_index);
+
+  auto partition_iter = std::partition(low, high, [pivot](int elem) { return elem <= pivot; });
+  auto mid_iter = std::partition(low, partition_iter, [pivot](int elem) { return elem < pivot; });
+
+  int max_depth = static_cast<int>(std::log2(tbb::this_task_arena::max_concurrency())) + 1;
+
+  if (depth < max_depth) {
+    tbb::task_group group;
+    group.run([=] { QuickSort(low, mid_iter, depth + 1); });
+    group.run([=] { QuickSort(partition_iter, high, depth + 1); });
+    group.wait();
+  } else {
+    QuickSort(low, mid_iter, depth + 1);
+    QuickSort(partition_iter, high, depth + 1);
+  }
+}
+
+bool TestTaskTBB::InPlaceMerge(const BlockRange& a, const BlockRange& b, std::vector<int>& buffer) {
+  bool changed = false;
+  int len_a = static_cast<int>(std::distance(a.low, a.high));
+  int len_b = static_cast<int>(std::distance(b.low, b.high));
+
+  std::span<int> span_a{a.low, static_cast<size_t>(len_a)};
+  std::span<int> span_b{b.low, static_cast<size_t>(len_b)};
+
+  size_t i = 0;
+  size_t j = 0;
+  size_t k = 0;
+
+  while (i < span_a.size() && j < span_b.size()) {
+    if (span_a[i] <= span_b[j]) {
+      buffer[k++] = span_a[i++];
+    } else {
+      changed = true;
+      buffer[k++] = span_b[j++];
+    }
+  }
+  while (i < span_a.size()) {
+    buffer[k++] = span_a[i++];
+  }
+  while (j < span_b.size()) {
+    changed = true;
+    buffer[k++] = span_b[j++];
+  }
+
+  std::ranges::copy(buffer.begin(), buffer.begin() + len_a, a.low);
+  std::ranges::copy(buffer.begin() + len_a, buffer.begin() + len_a + len_b, b.low);
+
+  return changed;
+}
+
+std::vector<BlockRange> TestTaskTBB::PartitionBlocks(std::vector<int>& arr, int p) {
+  std::vector<BlockRange> blocks;
+  blocks.reserve(p);
+  int n = static_cast<int>(arr.size());
+  int chunk_size = n / p;
+  int remainder = n % p;
+
+  auto it = arr.begin();
+  for (int i = 0; i < p; i++) {
+    int size = chunk_size + (i < remainder ? 1 : 0);
+    blocks.push_back({it, it + size});
+    it += size;
+  }
+  return blocks;
+}
+
+void TestTaskTBB::OddEvenMerge(std::vector<BlockRange>& blocks) {
+  if (blocks.size() <= 1) {
+    return;
+  }
+
+  int p = static_cast<int>(blocks.size());
+  int max_iters = p * 2;
+  int max_block_len = 0;
+  for (const auto& b : blocks) {
+    int len = static_cast<int>(std::distance(b.low, b.high));
+    max_block_len = std::max(max_block_len, len);
+  }
+  int buffer_size = max_block_len * 2;
+  tbb::enumerable_thread_specific<std::vector<int>> thread_buffers;
+  for (int iter = 0; iter < max_iters; iter++) {
+    std::atomic<bool> changed_global = false;
+    tbb::parallel_for(tbb::blocked_range<int>(iter % 2, p, 2), [&](const tbb::blocked_range<int>& range) {
+      auto& buffer = thread_buffers.local();
+      if (static_cast<int>(buffer.size()) < buffer_size) {
+        buffer.resize(buffer_size);
+      }
+      for (int i = range.begin(); i < range.end(); i += 2) {
+        if (i + 1 < p) {
+          bool changed_local = InPlaceMerge(blocks[i], blocks[i + 1], buffer);
+          if (changed_local) {
+            changed_global.store(true, std::memory_order_relaxed);
+          }
+        }
+      }
+    });
+    if (!changed_global.load()) {
+      break;
+    }
+  }
+}
+
+bool TestTaskTBB::PreProcessingImpl() {
+  unsigned int input_size = task_data->inputs_count[0];
+  auto* in_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
+  input_.assign(in_ptr, in_ptr + input_size);
+  return true;
+}
+
+bool TestTaskTBB::ValidationImpl() {
+  return (!task_data->inputs.empty()) && (!task_data->outputs.empty()) &&
+         (task_data->inputs_count[0] == task_data->outputs_count[0]);
+}
+
+bool TestTaskTBB::RunImpl() {
+  int n = static_cast<int>(input_.size());
+  if (n <= 1) {
+    return true;
+  }
+  int num_threads = tbb::this_task_arena::max_concurrency();
+  int p = std::max(num_threads / 2, 1);
+  auto blocks = PartitionBlocks(input_, p);
+
+  tbb::parallel_for(0, p, [&](int i) { QuickSort(blocks[i].low, blocks[i].high, 0); });
+
+  OddEvenMerge(blocks);
+  return true;
+}
+
+bool TestTaskTBB::PostProcessingImpl() {
+  std::ranges::copy(input_, reinterpret_cast<int*>(task_data->outputs[0]));
+  return true;
+}
+
+}  // namespace korovin_n_qsort_batcher_tbb


### PR DESCRIPTION
# Постановка задачи

Данный код реализует сортировку Хоара с четно-нечетным слиянием Бэтчера. Основная идея состоит в том, чтобы:
- Разбить исходный массив на независимые блоки
- Локально отсортировать каждый блок с помощью рекурсивной QuickSort с параллелизмом на ранних этапах рекурсии
- Объединить отсортированные блоки в единый массив через итеративное четно-нечетное слияние, выполняемое параллельно

---
# Схема распараллеливания

## 1. Локальная сортировка с параллелизмом (QuickSort)

- **Выбор опорного элемента**  

- **Разбиение массива**  

- **Параллелизация рекурсии:**  
  - Определяется максимальная глубина параллельных вызовов как `max_depth = log2(tbb::this_task_arena::max_concurrency()) + 1`
  - Если текущая глубина меньше `max_depth`, рекурсивные вызовы для левой и правой частей запускаются параллельно с использованием `tbb::task_group::run`
  - При достижении порога глубины рекурсия продолжается последовательно, чтобы не создавать слишком мелкие задачи

---

## 2. Объединение блоков: четно-нечетное слияние (Odd-Even Merge)

- **Разбиение на блоки:**  
  Функция `PartitionBlocks` делит исходный массив на `p` блоков с равномерным количеством элементов

- **Итеративное слияние:**  
  Функция `OddEvenMerge` объединяет соседние блоки, используя вспомогательную функцию `InPlaceMerge`
  - **InPlaceMerge:**  
    Сливает два диапазона (блоки) из массива, копируя элементы во временный буфер и затем возвращая их обратно. Функция возвращает флаг `changed`, который указывает, было ли произведено изменение порядка
  - **Цикл слияния:**  
    Итеративно сливаются пары блоков:
    - На каждом шаге слияния обрабатываются либо четные, либо нечетные пары 
    - Для каждой итерации используется параллельный цикл `tbb::parallel_for`, в котором используется `tbb::enumerable_thread_specific` для управления локальными буферами. 
---

# Основной этап алгоритма

### RunImpl()
  - Если массив содержит более одного элемента, определяется число блоков для сортировки. Число блоков `p` выбирается как максимум между `num_threads / 2` и 1
  - С помощью `PartitionBlocks` массив разбивается на блоки
  - Каждый блок сортируется локально: запускается параллельный цикл `tbb::parallel_for`, где для каждого блока вызывается QuickSort с начальной глубиной 0
  - После локальной сортировки блоков вызывается функция `OddEvenMerge` для итеративного объединения блоков в один отсортированный массив
