### PR TITLE
Созонов Илья. Вариант 26. Технология OMP. Линейная фильтрация изображений (блочное разбиение). Ядро Гаусса 3x3.

### DIFF
--- a/tasks/omp/sozonov_i_image_filtering_block_partitioning/func_tests/main.cpp
+++ b/tasks/omp/sozonov_i_image_filtering_block_partitioning/func_tests/main.cpp
@@ -8,6 +8,23 @@
 #include "core/task/include/task.hpp"
 #include "omp/sozonov_i_image_filtering_block_partitioning/include/ops_omp.hpp"
 
+namespace sozonov_i_image_filtering_block_partitioning_omp {
+
+std::vector<double> zeroImageEdges(std::vector<double> img, int wdth, int hght) {
+  for (int i = 0; i < wdth; ++i) {
+    img[i] = 0;
+    img[((hght - 1) * wdth) + i] = 0;
+  }
+  for (int i = 1; i < hght - 1; ++i) {
+    img[i * wdth] = 0;
+    img[(i * wdth) + wdth - 1] = 0;
+  }
+
+  return img;
+}
+
+}  // namespace sozonov_i_image_filtering_block_partitioning_omp
+
 TEST(sozonov_i_image_filtering_block_partitioning_omp, test_empty_image) {
   const int width = 0;
   const int height = 0;
@@ -223,14 +240,7 @@ TEST(sozonov_i_image_filtering_block_partitioning_omp, test_100x100) {
   std::vector<double> out(width * height, 0);
   std::vector<double> ans(width * height, 1);
 
-  for (int i = 0; i < width; ++i) {
-    ans[i] = 0;
-    ans[((height - 1) * width) + i] = 0;
-  }
-  for (int i = 1; i < height - 1; ++i) {
-    ans[i * width] = 0;
-    ans[(i * width) + width - 1] = 0;
-  }
+  ans = sozonov_i_image_filtering_block_partitioning_omp::zeroImageEdges(ans, width, height);
 
   // Create task_data
   auto task_data_omp = std::make_shared<ppc::core::TaskData>();
@@ -259,14 +269,7 @@ TEST(sozonov_i_image_filtering_block_partitioning_omp, test_150x100) {
   std::vector<double> out(width * height, 0);
   std::vector<double> ans(width * height, 1);
 
-  for (int i = 0; i < width; ++i) {
-    ans[i] = 0;
-    ans[((height - 1) * width) + i] = 0;
-  }
-  for (int i = 1; i < height - 1; ++i) {
-    ans[i * width] = 0;
-    ans[(i * width) + width - 1] = 0;
-  }
+  ans = sozonov_i_image_filtering_block_partitioning_omp::zeroImageEdges(ans, width, height);
 
   // Create task_data
   auto task_data_omp = std::make_shared<ppc::core::TaskData>();
@@ -295,14 +298,7 @@ TEST(sozonov_i_image_filtering_block_partitioning_omp, test_120x200) {
   std::vector<double> out(width * height, 0);
   std::vector<double> ans(width * height, 1);
 
-  for (int i = 0; i < width; ++i) {
-    ans[i] = 0;
-    ans[((height - 1) * width) + i] = 0;
-  }
-  for (int i = 1; i < height - 1; ++i) {
-    ans[i * width] = 0;
-    ans[(i * width) + width - 1] = 0;
-  }
+  ans = sozonov_i_image_filtering_block_partitioning_omp::zeroImageEdges(ans, width, height);
 
   // Create task_data
   auto task_data_omp = std::make_shared<ppc::core::TaskData>();

--- a/tasks/omp/sozonov_i_image_filtering_block_partitioning/func_tests/main.cpp
+++ b/tasks/omp/sozonov_i_image_filtering_block_partitioning/func_tests/main.cpp
@@ -1,15 +1,11 @@
 #include <gtest/gtest.h>
 
-#include <cstddef>
 #include <cstdint>
-#include <fstream>
 #include <memory>
 #include <numeric>
-#include <string>
 #include <vector>
 
 #include "core/task/include/task.hpp"
-#include "core/util/include/util.hpp"
 #include "omp/sozonov_i_image_filtering_block_partitioning/include/ops_omp.hpp"
 
 TEST(sozonov_i_image_filtering_block_partitioning_omp, test_image_less_than_3x3) {

--- a/tasks/omp/sozonov_i_image_filtering_block_partitioning/func_tests/main.cpp
+++ b/tasks/omp/sozonov_i_image_filtering_block_partitioning/func_tests/main.cpp
@@ -8,6 +8,28 @@
 #include "core/task/include/task.hpp"
 #include "omp/sozonov_i_image_filtering_block_partitioning/include/ops_omp.hpp"
 
+TEST(sozonov_i_image_filtering_block_partitioning_omp, test_empty_image) {
+  const int width = 0;
+  const int height = 0;
+
+  // Create data
+  std::vector<double> in;
+  std::vector<double> out;
+
+  // Create task_data
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->inputs_count.emplace_back(width);
+  task_data_omp->inputs_count.emplace_back(height);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_block_partitioning_omp::TestTaskOpenMP test_task_omp(task_data_omp);
+  ASSERT_FALSE(test_task_omp.Validation());
+}
+
 TEST(sozonov_i_image_filtering_block_partitioning_omp, test_image_less_than_3x3) {
   const int width = 2;
   const int height = 2;

--- a/tasks/omp/sozonov_i_image_filtering_block_partitioning/func_tests/main.cpp
+++ b/tasks/omp/sozonov_i_image_filtering_block_partitioning/func_tests/main.cpp
@@ -10,7 +10,7 @@
 
 namespace sozonov_i_image_filtering_block_partitioning_omp {
 
-std::vector<double> zeroImageEdges(std::vector<double> img, int wdth, int hght) {
+std::vector<double> ZeroEdges(std::vector<double> img, int wdth, int hght) {
   for (int i = 0; i < wdth; ++i) {
     img[i] = 0;
     img[((hght - 1) * wdth) + i] = 0;
@@ -240,7 +240,7 @@ TEST(sozonov_i_image_filtering_block_partitioning_omp, test_100x100) {
   std::vector<double> out(width * height, 0);
   std::vector<double> ans(width * height, 1);
 
-  ans = sozonov_i_image_filtering_block_partitioning_omp::zeroImageEdges(ans, width, height);
+  ans = sozonov_i_image_filtering_block_partitioning_omp::ZeroEdges(ans, width, height);
 
   // Create task_data
   auto task_data_omp = std::make_shared<ppc::core::TaskData>();
@@ -269,7 +269,7 @@ TEST(sozonov_i_image_filtering_block_partitioning_omp, test_150x100) {
   std::vector<double> out(width * height, 0);
   std::vector<double> ans(width * height, 1);
 
-  ans = sozonov_i_image_filtering_block_partitioning_omp::zeroImageEdges(ans, width, height);
+  ans = sozonov_i_image_filtering_block_partitioning_omp::ZeroEdges(ans, width, height);
 
   // Create task_data
   auto task_data_omp = std::make_shared<ppc::core::TaskData>();
@@ -298,7 +298,7 @@ TEST(sozonov_i_image_filtering_block_partitioning_omp, test_120x200) {
   std::vector<double> out(width * height, 0);
   std::vector<double> ans(width * height, 1);
 
-  ans = sozonov_i_image_filtering_block_partitioning_omp::zeroImageEdges(ans, width, height);
+  ans = sozonov_i_image_filtering_block_partitioning_omp::ZeroEdges(ans, width, height);
 
   // Create task_data
   auto task_data_omp = std::make_shared<ppc::core::TaskData>();

--- a/tasks/omp/sozonov_i_image_filtering_block_partitioning/func_tests/main.cpp
+++ b/tasks/omp/sozonov_i_image_filtering_block_partitioning/func_tests/main.cpp
@@ -1,0 +1,305 @@
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "core/util/include/util.hpp"
+#include "omp/sozonov_i_image_filtering_block_partitioning/include/ops_omp.hpp"
+
+TEST(sozonov_i_image_filtering_block_partitioning_omp, test_image_less_than_3x3) {
+  const int width = 2;
+  const int height = 2;
+
+  // Create data
+  std::vector<double> in = {4, 6, 8, 24};
+  std::vector<double> out(width * height, 0);
+
+  // Create task_data
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->inputs_count.emplace_back(width);
+  task_data_omp->inputs_count.emplace_back(height);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_block_partitioning_omp::TestTaskOpenMP test_task_omp(task_data_omp);
+  ASSERT_FALSE(test_task_omp.Validation());
+}
+
+TEST(sozonov_i_image_filtering_block_partitioning_omp, test_wrong_pixels) {
+  const int width = 5;
+  const int height = 3;
+
+  // Create data
+  std::vector<double> in = {143, 6, 853, -24, 31, -25, 1, 5, -7, 361, 28, 98, -45, 982, 461};
+  std::vector<double> out(width * height, 0);
+
+  // Create task_data
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->inputs_count.emplace_back(width);
+  task_data_omp->inputs_count.emplace_back(height);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_block_partitioning_omp::TestTaskOpenMP test_task_omp(task_data_omp);
+  ASSERT_FALSE(test_task_omp.Validation());
+}
+
+TEST(sozonov_i_image_filtering_block_partitioning_omp, test_3x3) {
+  const int width = 3;
+  const int height = 3;
+
+  // Create data
+  std::vector<double> in = {4, 6, 8, 24, 31, 25, 1, 5, 7};
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans = {0, 0, 0, 0, 16.5, 0, 0, 0, 0};
+
+  // Create task_data
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->inputs_count.emplace_back(width);
+  task_data_omp->inputs_count.emplace_back(height);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_block_partitioning_omp::TestTaskOpenMP test_task_omp(task_data_omp);
+  ASSERT_EQ(test_task_omp.Validation(), true);
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+  EXPECT_EQ(out, ans);
+}
+
+TEST(sozonov_i_image_filtering_block_partitioning_omp, test_5x3) {
+  const int width = 5;
+  const int height = 3;
+
+  // Create data
+  std::vector<double> in = {34, 24, 27, 67, 42, 48, 93, 26, 47, 2, 34, 13, 81, 24, 32};
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans = {0, 0, 0, 0, 0, 0, 48.125, 45.5, 38, 0, 0, 0, 0, 0, 0};
+
+  // Create task_data
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->inputs_count.emplace_back(width);
+  task_data_omp->inputs_count.emplace_back(height);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_block_partitioning_omp::TestTaskOpenMP test_task_omp(task_data_omp);
+  ASSERT_EQ(test_task_omp.Validation(), true);
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+  EXPECT_EQ(out, ans);
+}
+
+TEST(sozonov_i_image_filtering_block_partitioning_omp, test_5x5) {
+  const int width = 5;
+  const int height = 5;
+
+  // Create data
+  std::vector<double> in(width * height);
+  std::iota(in.begin(), in.end(), 0);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans = {0, 0, 0, 0, 0, 0, 6, 7, 8, 0, 0, 11, 12, 13, 0, 0, 16, 17, 18, 0, 0, 0, 0, 0, 0};
+
+  // Create task_data
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->inputs_count.emplace_back(width);
+  task_data_omp->inputs_count.emplace_back(height);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_block_partitioning_omp::TestTaskOpenMP test_task_omp(task_data_omp);
+  ASSERT_EQ(test_task_omp.Validation(), true);
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+  EXPECT_EQ(out, ans);
+}
+
+TEST(sozonov_i_image_filtering_block_partitioning_omp, test_5x7) {
+  const int width = 5;
+  const int height = 7;
+
+  // Create data
+  std::vector<double> in(width * height);
+  std::iota(in.begin(), in.end(), 0);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans = {0,  0, 0, 0,  0,  0,  6, 7, 8,  0,  0,  11, 12, 13, 0, 0, 16, 17,
+                             18, 0, 0, 21, 22, 23, 0, 0, 26, 27, 28, 0,  0,  0,  0, 0, 0};
+
+  // Create task_data
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->inputs_count.emplace_back(width);
+  task_data_omp->inputs_count.emplace_back(height);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_block_partitioning_omp::TestTaskOpenMP test_task_omp(task_data_omp);
+  ASSERT_EQ(test_task_omp.Validation(), true);
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+  EXPECT_EQ(out, ans);
+}
+
+TEST(sozonov_i_image_filtering_block_partitioning_omp, test_10x4) {
+  const int width = 10;
+  const int height = 4;
+
+  // Create data
+  std::vector<double> in(width * height);
+  std::iota(in.begin(), in.end(), 0);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans = {0, 0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 11, 12, 13, 14, 15, 16, 17, 18, 0,
+                             0, 21, 22, 23, 24, 25, 26, 27, 28, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0};
+
+  // Create task_data
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->inputs_count.emplace_back(width);
+  task_data_omp->inputs_count.emplace_back(height);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_block_partitioning_omp::TestTaskOpenMP test_task_omp(task_data_omp);
+  ASSERT_EQ(test_task_omp.Validation(), true);
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+  EXPECT_EQ(out, ans);
+}
+
+TEST(sozonov_i_image_filtering_block_partitioning_omp, test_100x100) {
+  const int width = 100;
+  const int height = 100;
+
+  // Create data
+  std::vector<double> in(width * height, 1);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans(width * height, 1);
+
+  for (int i = 0; i < width; ++i) {
+    ans[i] = 0;
+    ans[((height - 1) * width) + i] = 0;
+  }
+  for (int i = 1; i < height - 1; ++i) {
+    ans[i * width] = 0;
+    ans[(i * width) + width - 1] = 0;
+  }
+
+  // Create task_data
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->inputs_count.emplace_back(width);
+  task_data_omp->inputs_count.emplace_back(height);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_block_partitioning_omp::TestTaskOpenMP test_task_omp(task_data_omp);
+  ASSERT_EQ(test_task_omp.Validation(), true);
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+  EXPECT_EQ(out, ans);
+}
+
+TEST(sozonov_i_image_filtering_block_partitioning_omp, test_150x100) {
+  const int width = 150;
+  const int height = 100;
+
+  // Create data
+  std::vector<double> in(width * height, 1);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans(width * height, 1);
+
+  for (int i = 0; i < width; ++i) {
+    ans[i] = 0;
+    ans[((height - 1) * width) + i] = 0;
+  }
+  for (int i = 1; i < height - 1; ++i) {
+    ans[i * width] = 0;
+    ans[(i * width) + width - 1] = 0;
+  }
+
+  // Create task_data
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->inputs_count.emplace_back(width);
+  task_data_omp->inputs_count.emplace_back(height);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_block_partitioning_omp::TestTaskOpenMP test_task_omp(task_data_omp);
+  ASSERT_EQ(test_task_omp.Validation(), true);
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+  EXPECT_EQ(out, ans);
+}
+
+TEST(sozonov_i_image_filtering_block_partitioning_omp, test_120x200) {
+  const int width = 120;
+  const int height = 200;
+
+  // Create data
+  std::vector<double> in(width * height, 1);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans(width * height, 1);
+
+  for (int i = 0; i < width; ++i) {
+    ans[i] = 0;
+    ans[((height - 1) * width) + i] = 0;
+  }
+  for (int i = 1; i < height - 1; ++i) {
+    ans[i * width] = 0;
+    ans[(i * width) + width - 1] = 0;
+  }
+
+  // Create task_data
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->inputs_count.emplace_back(width);
+  task_data_omp->inputs_count.emplace_back(height);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_block_partitioning_omp::TestTaskOpenMP test_task_omp(task_data_omp);
+  ASSERT_EQ(test_task_omp.Validation(), true);
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+  EXPECT_EQ(out, ans);
+}

--- a/tasks/omp/sozonov_i_image_filtering_block_partitioning/include/ops_omp.hpp
+++ b/tasks/omp/sozonov_i_image_filtering_block_partitioning/include/ops_omp.hpp
@@ -7,6 +7,8 @@
 
 namespace sozonov_i_image_filtering_block_partitioning_omp {
 
+std::vector<double> ZeroEdges(std::vector<double> img, int wdth, int hght);
+
 class TestTaskOpenMP : public ppc::core::Task {
  public:
   explicit TestTaskOpenMP(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}

--- a/tasks/omp/sozonov_i_image_filtering_block_partitioning/include/ops_omp.hpp
+++ b/tasks/omp/sozonov_i_image_filtering_block_partitioning/include/ops_omp.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace sozonov_i_image_filtering_block_partitioning_omp {
+
+class TestTaskOpenMP : public ppc::core::Task {
+ public:
+  explicit TestTaskOpenMP(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<double> image_, filtered_image_;
+  int width_{}, height_{};
+};
+
+}  // namespace sozonov_i_image_filtering_block_partitioning_omp

--- a/tasks/omp/sozonov_i_image_filtering_block_partitioning/perf_tests/main.cpp
+++ b/tasks/omp/sozonov_i_image_filtering_block_partitioning/perf_tests/main.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
-#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <vector>

--- a/tasks/omp/sozonov_i_image_filtering_block_partitioning/perf_tests/main.cpp
+++ b/tasks/omp/sozonov_i_image_filtering_block_partitioning/perf_tests/main.cpp
@@ -1,0 +1,113 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "omp/sozonov_i_image_filtering_block_partitioning/include/ops_omp.hpp"
+
+TEST(sozonov_i_image_filtering_block_partitioning_omp, test_pipeline_run) {
+  const int width = 5000;
+  const int height = 5000;
+
+  // Create data
+  std::vector<double> in(width * height, 1);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans(width * height, 1);
+
+  for (int i = 0; i < width; ++i) {
+    ans[i] = 0;
+    ans[((height - 1) * width) + i] = 0;
+  }
+  for (int i = 1; i < height - 1; ++i) {
+    ans[i * width] = 0;
+    ans[(i * width) + width - 1] = 0;
+  }
+
+  // Create task_data
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->inputs_count.emplace_back(width);
+  task_data_omp->inputs_count.emplace_back(height);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_omp =
+      std::make_shared<sozonov_i_image_filtering_block_partitioning_omp::TestTaskOpenMP>(task_data_omp);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  EXPECT_EQ(out, ans);
+}
+
+TEST(sozonov_i_image_filtering_block_partitioning_omp, test_task_run) {
+  const int width = 5000;
+  const int height = 5000;
+
+  // Create data
+  std::vector<double> in(width * height, 1);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans(width * height, 1);
+
+  for (int i = 0; i < width; ++i) {
+    ans[i] = 0;
+    ans[((height - 1) * width) + i] = 0;
+  }
+  for (int i = 1; i < height - 1; ++i) {
+    ans[i * width] = 0;
+    ans[(i * width) + width - 1] = 0;
+  }
+
+  // Create task_data
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->inputs_count.emplace_back(width);
+  task_data_omp->inputs_count.emplace_back(height);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_omp =
+      std::make_shared<sozonov_i_image_filtering_block_partitioning_omp::TestTaskOpenMP>(task_data_omp);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  EXPECT_EQ(out, ans);
+}

--- a/tasks/omp/sozonov_i_image_filtering_block_partitioning/perf_tests/main.cpp
+++ b/tasks/omp/sozonov_i_image_filtering_block_partitioning/perf_tests/main.cpp
@@ -9,6 +9,23 @@
 #include "core/task/include/task.hpp"
 #include "omp/sozonov_i_image_filtering_block_partitioning/include/ops_omp.hpp"
 
+namespace sozonov_i_image_filtering_block_partitioning_omp {
+
+std::vector<double> zeroImageEdges(std::vector<double> img, int wdth, int hght) {
+  for (int i = 0; i < wdth; ++i) {
+    img[i] = 0;
+    img[((hght - 1) * wdth) + i] = 0;
+  }
+  for (int i = 1; i < hght - 1; ++i) {
+    img[i * wdth] = 0;
+    img[(i * wdth) + wdth - 1] = 0;
+  }
+
+  return img;
+}
+
+}  // namespace sozonov_i_image_filtering_block_partitioning_omp
+
 TEST(sozonov_i_image_filtering_block_partitioning_omp, test_pipeline_run) {
   const int width = 5000;
   const int height = 5000;
@@ -18,14 +35,7 @@ TEST(sozonov_i_image_filtering_block_partitioning_omp, test_pipeline_run) {
   std::vector<double> out(width * height, 0);
   std::vector<double> ans(width * height, 1);
 
-  for (int i = 0; i < width; ++i) {
-    ans[i] = 0;
-    ans[((height - 1) * width) + i] = 0;
-  }
-  for (int i = 1; i < height - 1; ++i) {
-    ans[i * width] = 0;
-    ans[(i * width) + width - 1] = 0;
-  }
+  ans = sozonov_i_image_filtering_block_partitioning_omp::zeroImageEdges(ans, width, height);
 
   // Create task_data
   auto task_data_omp = std::make_shared<ppc::core::TaskData>();
@@ -69,14 +79,7 @@ TEST(sozonov_i_image_filtering_block_partitioning_omp, test_task_run) {
   std::vector<double> out(width * height, 0);
   std::vector<double> ans(width * height, 1);
 
-  for (int i = 0; i < width; ++i) {
-    ans[i] = 0;
-    ans[((height - 1) * width) + i] = 0;
-  }
-  for (int i = 1; i < height - 1; ++i) {
-    ans[i * width] = 0;
-    ans[(i * width) + width - 1] = 0;
-  }
+  ans = sozonov_i_image_filtering_block_partitioning_omp::zeroImageEdges(ans, width, height);
 
   // Create task_data
   auto task_data_omp = std::make_shared<ppc::core::TaskData>();

--- a/tasks/omp/sozonov_i_image_filtering_block_partitioning/perf_tests/main.cpp
+++ b/tasks/omp/sozonov_i_image_filtering_block_partitioning/perf_tests/main.cpp
@@ -11,7 +11,7 @@
 
 namespace sozonov_i_image_filtering_block_partitioning_omp {
 
-std::vector<double> zeroImageEdges(std::vector<double> img, int wdth, int hght) {
+std::vector<double> ZeroEdges(std::vector<double> img, int wdth, int hght) {
   for (int i = 0; i < wdth; ++i) {
     img[i] = 0;
     img[((hght - 1) * wdth) + i] = 0;
@@ -35,7 +35,7 @@ TEST(sozonov_i_image_filtering_block_partitioning_omp, test_pipeline_run) {
   std::vector<double> out(width * height, 0);
   std::vector<double> ans(width * height, 1);
 
-  ans = sozonov_i_image_filtering_block_partitioning_omp::zeroImageEdges(ans, width, height);
+  ans = sozonov_i_image_filtering_block_partitioning_omp::ZeroEdges(ans, width, height);
 
   // Create task_data
   auto task_data_omp = std::make_shared<ppc::core::TaskData>();
@@ -79,7 +79,7 @@ TEST(sozonov_i_image_filtering_block_partitioning_omp, test_task_run) {
   std::vector<double> out(width * height, 0);
   std::vector<double> ans(width * height, 1);
 
-  ans = sozonov_i_image_filtering_block_partitioning_omp::zeroImageEdges(ans, width, height);
+  ans = sozonov_i_image_filtering_block_partitioning_omp::ZeroEdges(ans, width, height);
 
   // Create task_data
   auto task_data_omp = std::make_shared<ppc::core::TaskData>();

--- a/tasks/omp/sozonov_i_image_filtering_block_partitioning/src/ops_omp.cpp
+++ b/tasks/omp/sozonov_i_image_filtering_block_partitioning/src/ops_omp.cpp
@@ -47,7 +47,7 @@ bool sozonov_i_image_filtering_block_partitioning_omp::TestTaskOpenMP::RunImpl()
   int num_blocks_x = (width_ + block_size - 1) / block_size;
   int num_blocks_y = (height_ + block_size - 1) / block_size;
 
-#pragma omp parallel for schedule(dynamic)
+#pragma omp parallel for schedule(dynamic, 1)
   for (int block_y = 0; block_y < num_blocks_y; ++block_y) {
     for (int block_x = 0; block_x < num_blocks_x; ++block_x) {
       int start_i = block_y * block_size;

--- a/tasks/omp/sozonov_i_image_filtering_block_partitioning/src/ops_omp.cpp
+++ b/tasks/omp/sozonov_i_image_filtering_block_partitioning/src/ops_omp.cpp
@@ -1,0 +1,77 @@
+#include "omp/sozonov_i_image_filtering_block_partitioning/include/ops_omp.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+bool sozonov_i_image_filtering_block_partitioning_omp::TestTaskOpenMP::PreProcessingImpl() {
+  // Init image
+  image_ = std::vector<double>(task_data->inputs_count[0]);
+  auto *image_ptr = reinterpret_cast<double *>(task_data->inputs[0]);
+  std::ranges::copy(image_ptr, image_ptr + task_data->inputs_count[0], image_.begin());
+
+  width_ = static_cast<int>(task_data->inputs_count[1]);
+  height_ = static_cast<int>(task_data->inputs_count[2]);
+
+  // Init filtered image
+  filtered_image_ = std::vector<double>(width_ * height_, 0);
+  return true;
+}
+
+bool sozonov_i_image_filtering_block_partitioning_omp::TestTaskOpenMP::ValidationImpl() {
+  // Init image
+  image_ = std::vector<double>(task_data->inputs_count[0]);
+  auto *image_ptr = reinterpret_cast<double *>(task_data->inputs[0]);
+  std::ranges::copy(image_ptr, image_ptr + task_data->inputs_count[0], image_.begin());
+
+  size_t img_size = task_data->inputs_count[1] * task_data->inputs_count[2];
+
+  // Check pixels range from 0 to 255
+  for (size_t i = 0; i < img_size; ++i) {
+    if (image_[i] < 0 || image_[i] > 255) {
+      return false;
+    }
+  }
+
+  // Check size of image
+  return task_data->inputs_count[0] > 0 && task_data->inputs_count[0] == img_size &&
+         task_data->outputs_count[0] == img_size && task_data->inputs_count[1] >= 3 && task_data->inputs_count[2] >= 3;
+}
+
+bool sozonov_i_image_filtering_block_partitioning_omp::TestTaskOpenMP::RunImpl() {
+  std::vector<double> kernel = {0.0625, 0.125, 0.0625, 0.125, 0.25, 0.125, 0.0625, 0.125, 0.0625};
+
+  int block_size = 32;
+
+  int num_blocks_x = (width_ + block_size - 1) / block_size;
+  int num_blocks_y = (height_ + block_size - 1) / block_size;
+
+#pragma omp parallel for schedule(dynamic)
+  for (int block_y = 0; block_y < num_blocks_y; ++block_y) {
+    for (int block_x = 0; block_x < num_blocks_x; ++block_x) {
+      int start_i = block_y * block_size;
+      int start_j = block_x * block_size;
+      int end_i = std::min(start_i + block_size, height_ - 1);
+      int end_j = std::min(start_j + block_size, width_ - 1);
+
+      for (int i = std::max(1, start_i); i < end_i; ++i) {
+        for (int j = std::max(1, start_j); j < end_j; ++j) {
+          double sum = 0;
+          for (int l = -1; l <= 1; ++l) {
+            for (int k = -1; k <= 1; ++k) {
+              sum += image_[(i - l) * width_ + (j - k)] * kernel[(l + 1) * 3 + (k + 1)];
+            }
+          }
+          filtered_image_[i * width_ + j] = sum;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+bool sozonov_i_image_filtering_block_partitioning_omp::TestTaskOpenMP::PostProcessingImpl() {
+  auto *out = reinterpret_cast<double *>(task_data->outputs[0]);
+  std::ranges::copy(filtered_image_.begin(), filtered_image_.end(), out);
+  return true;
+}

--- a/tasks/omp/sozonov_i_image_filtering_block_partitioning/src/ops_omp.cpp
+++ b/tasks/omp/sozonov_i_image_filtering_block_partitioning/src/ops_omp.cpp
@@ -1,5 +1,6 @@
 #include "omp/sozonov_i_image_filtering_block_partitioning/include/ops_omp.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <vector>
@@ -59,10 +60,10 @@ bool sozonov_i_image_filtering_block_partitioning_omp::TestTaskOpenMP::RunImpl()
           double sum = 0;
           for (int l = -1; l <= 1; ++l) {
             for (int k = -1; k <= 1; ++k) {
-              sum += image_[(i - l) * width_ + (j - k)] * kernel[(l + 1) * 3 + (k + 1)];
+              sum += image_[((i - l) * width_) + (j - k)] * kernel[((l + 1) * 3) + (k + 1)];
             }
           }
-          filtered_image_[i * width_ + j] = sum;
+          filtered_image_[(i * width_) + j] = sum;
         }
       }
     }


### PR DESCRIPTION
**Стандартная свертка Гаусса (3×3):**

Ядро Гаусса 3x3 (нормированное) для σ=1 имеет вид: 

![image](https://github.com/user-attachments/assets/b76da6d4-aeeb-4625-8cdf-225cb0bd479b)

Каждому пикселю изображения ставится в соответствие новая величина, полученная как сумма произведений значений пикселей из окрестности 3×3 на коэффициенты ядра Гаусса.

Например, если центральный пиксель изображения **𝐼(𝑥, 𝑦)**, то его новое значение **𝐼′(𝑥, 𝑦)** будет: 

![image](https://github.com/user-attachments/assets/ea99a373-c034-4981-888d-ce98fde24597)

**Параллельная реализация:**

Для ускорения вычислений разбиваем изображение на блоки и обрабатываем их параллельно, используя OpenMP.

**1. Разбиение на блоки**
- Определяем размер блоков `block_size`.
- Двигаемся по изображению, обрабатывая его кусочками, а не по всей ширине/высоте сразу.

**2. Параллельная обработка**
- Используем `#pragma omp parallel for schedule(dynamic, 1)`, чтобы каждый поток обрабатывал по одной строке блоков.
- Внутри каждого блока применяем стандартную свертку Гаусса (3×3), но только к пикселям внутри блока.
- Учитываем границы блоков, чтобы избежать выхода за границы массива.

**3. Запись результата**
- После завершения вычислений все потоки записывают отфильтрованные данные в общий массив.