### PR TITLE
Мухина Маргарита. Вариант 21. Технология TBB. Поиск кратчайших путей из одной вершины (алгоритм Дейкстры)

### DIFF
--- a/tasks/tbb/muhina_m_dijkstra/func_tests/main.cpp
+++ b/tasks/tbb/muhina_m_dijkstra/func_tests/main.cpp
@@ -1,0 +1,340 @@
+#include <gtest/gtest.h>
+
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <queue>
+#include <random>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "tbb/muhina_m_dijkstra/include/ops_tbb.hpp"
+
+namespace {
+std::vector<int> DijkstraSequential(const std::vector<std::vector<std::pair<size_t, int>>>& adj_list,
+                                    size_t start_vertex) {
+  const size_t num_vertices = adj_list.size();
+  std::vector<int> distances(num_vertices, INT_MAX);
+  distances[start_vertex] = 0;
+
+  std::priority_queue<std::pair<int, size_t>, std::vector<std::pair<int, size_t>>, std::greater<>> pq;
+  pq.emplace(0, start_vertex);
+
+  while (!pq.empty()) {
+    size_t u = pq.top().second;
+    int dist_u = pq.top().first;
+    pq.pop();
+
+    if (dist_u > distances[u]) {
+      continue;
+    }
+
+    for (const auto& edge : adj_list[u]) {
+      size_t v = edge.first;
+      int weight = edge.second;
+
+      if (distances[u] != INT_MAX && distances[u] + weight < distances[v]) {
+        distances[v] = distances[u] + weight;
+        pq.emplace(distances[v], v);
+      }
+    }
+  }
+
+  return distances;
+}
+
+std::vector<std::vector<std::pair<size_t, int>>> GenerateRandomGraph(size_t min_vertices = 5, size_t max_vertices = 20,
+                                                                     int min_weight = 1, int max_weight = 100,
+                                                                     size_t min_edges_per_vertex = 1,
+                                                                     size_t max_edges_per_vertex = 3) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<size_t> vertices_dist(min_vertices, max_vertices);
+  std::uniform_int_distribution<int> weight_dist(min_weight, max_weight);
+  std::uniform_int_distribution<size_t> edges_dist(min_edges_per_vertex, max_edges_per_vertex);
+
+  const size_t num_vertices = vertices_dist(gen);
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list(num_vertices);
+
+  for (size_t u = 0; u < num_vertices; ++u) {
+    size_t num_edges = edges_dist(gen);
+    for (size_t j = 0; j < num_edges; ++j) {
+      size_t v = std::uniform_int_distribution<size_t>(0, num_vertices - 1)(gen);
+      if (v == u) {
+        v = (v + 1) % num_vertices;
+      }
+      int weight = weight_dist(gen);
+      adj_list[u].emplace_back(v, weight);
+    }
+  }
+
+  return adj_list;
+}
+}  // namespace
+
+TEST(muhina_m_dijkstra_tbb, test_dijkstra_small_graph) {
+  constexpr size_t kNumVertices = 5;
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list(kNumVertices);
+  adj_list[0].emplace_back(1, 4);
+  adj_list[0].emplace_back(2, 2);
+  adj_list[1].emplace_back(2, 5);
+  adj_list[1].emplace_back(3, 10);
+  adj_list[2].emplace_back(3, 3);
+  adj_list[3].emplace_back(4, 4);
+  adj_list[2].emplace_back(4, 1);
+
+  size_t start_vertex = 0;
+
+  std::vector<int> distances(kNumVertices, INT_MAX);
+  std::vector<int> graph_data;
+  for (const auto& vertex_edges : adj_list) {
+    for (const auto& edge : vertex_edges) {
+      graph_data.push_back(static_cast<int>(edge.first));
+      graph_data.push_back(edge.second);
+    }
+    graph_data.push_back(-1);
+  }
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t*>(graph_data.data()));
+  task_data_tbb->inputs_count.emplace_back(graph_data.size());
+
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t*>(&start_vertex));
+  task_data_tbb->inputs_count.emplace_back(sizeof(start_vertex));
+
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t*>(distances.data()));
+  task_data_tbb->outputs_count.emplace_back(kNumVertices);
+
+  muhina_m_dijkstra_tbb::TestTaskTBB task_task_tbb(task_data_tbb);
+  ASSERT_TRUE(task_task_tbb.Validation());
+  task_task_tbb.PreProcessing();
+  ASSERT_TRUE(task_task_tbb.Run());
+  task_task_tbb.PostProcessing();
+
+  std::vector<int> expected_distances = {0, 4, 2, 5, 3};
+  for (size_t i = 0; i < kNumVertices; ++i) {
+    EXPECT_EQ(distances[i], expected_distances[i]);
+  }
+}
+
+TEST(muhina_m_dijkstra_tbb, test_dijkstra_validation_failure) {
+  std::vector<int> graph_data;
+  size_t start_vertex = 0;
+  size_t num_vertices = 0;
+  std::vector<int> distances(num_vertices, INT_MAX);
+
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t*>(graph_data.data()));
+  task_data_tbb->inputs_count.emplace_back(graph_data.size());
+
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t*>(&start_vertex));
+  task_data_tbb->inputs_count.emplace_back(sizeof(start_vertex));
+
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t*>(distances.data()));
+  task_data_tbb->outputs_count.emplace_back(num_vertices);
+
+  muhina_m_dijkstra_tbb::TestTaskTBB task_task_tbb(task_data_tbb);
+
+  ASSERT_FALSE(task_task_tbb.Validation());
+}
+
+TEST(muhina_m_dijkstra_tbb, test_dijkstra_small_graph_non_zero_start) {
+  constexpr size_t kNumVertices = 5;
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list(kNumVertices);
+  adj_list[0].emplace_back(1, 4);
+  adj_list[0].emplace_back(2, 2);
+  adj_list[1].emplace_back(2, 5);
+  adj_list[1].emplace_back(3, 10);
+  adj_list[2].emplace_back(3, 3);
+  adj_list[3].emplace_back(4, 4);
+  adj_list[2].emplace_back(4, 1);
+  adj_list[2].emplace_back(0, 2);
+  adj_list[2].emplace_back(1, 5);
+
+  size_t start_vertex = 2;
+
+  std::vector<int> distances(kNumVertices, INT_MAX);
+  std::vector<int> graph_data;
+  for (const auto& vertex_edges : adj_list) {
+    for (const auto& edge : vertex_edges) {
+      graph_data.push_back(static_cast<int>(edge.first));
+      graph_data.push_back(edge.second);
+    }
+    graph_data.push_back(-1);
+  }
+
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t*>(graph_data.data()));
+  task_data_tbb->inputs_count.emplace_back(graph_data.size());
+
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t*>(&start_vertex));
+  task_data_tbb->inputs_count.emplace_back(sizeof(start_vertex));
+
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t*>(distances.data()));
+  task_data_tbb->outputs_count.emplace_back(kNumVertices);
+
+  muhina_m_dijkstra_tbb::TestTaskTBB task_task_tbb(task_data_tbb);
+  ASSERT_TRUE(task_task_tbb.Validation());
+  task_task_tbb.PreProcessing();
+  ASSERT_TRUE(task_task_tbb.Run());
+  task_task_tbb.PostProcessing();
+
+  std::vector<int> expected_distances = {2, 5, 0, 3, 1};
+  for (size_t i = 0; i < kNumVertices; ++i) {
+    EXPECT_EQ(distances[i], expected_distances[i]);
+  }
+}
+
+TEST(muhina_m_dijkstra_tbb, test_negative_weight) {
+  constexpr size_t kNumVertices = 5;
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list(kNumVertices);
+  adj_list[0].emplace_back(1, -4);
+  adj_list[0].emplace_back(2, 2);
+  adj_list[1].emplace_back(2, 5);
+  adj_list[1].emplace_back(3, 10);
+  adj_list[2].emplace_back(3, -3);
+  adj_list[3].emplace_back(4, 4);
+  adj_list[2].emplace_back(4, 1);
+
+  size_t start_vertex = 0;
+
+  std::vector<int> distances(kNumVertices, INT_MAX);
+  std::vector<int> graph_data;
+  for (const auto& vertex_edges : adj_list) {
+    for (const auto& edge : vertex_edges) {
+      graph_data.push_back(static_cast<int>(edge.first));
+      graph_data.push_back(edge.second);
+    }
+    graph_data.push_back(-1);
+  }
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t*>(graph_data.data()));
+  task_data_tbb->inputs_count.emplace_back(graph_data.size());
+
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t*>(&start_vertex));
+  task_data_tbb->inputs_count.emplace_back(sizeof(start_vertex));
+
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t*>(distances.data()));
+  task_data_tbb->outputs_count.emplace_back(kNumVertices);
+
+  muhina_m_dijkstra_tbb::TestTaskTBB task_task_tbb(task_data_tbb);
+  ASSERT_TRUE(task_task_tbb.Validation());
+  task_task_tbb.PreProcessing();
+  ASSERT_FALSE(task_task_tbb.Run());
+  task_task_tbb.PostProcessing();
+}
+
+TEST(muhina_m_dijkstra_tbb, test_dijkstra_random_graph) {
+  auto adj_list = GenerateRandomGraph();
+  const size_t num_vertices = adj_list.size();
+  size_t start_vertex = 0;
+
+  auto expected_distances = DijkstraSequential(adj_list, start_vertex);
+
+  std::vector<int> distances(num_vertices, INT_MAX);
+  std::vector<int> graph_data;
+  for (const auto& vertex_edges : adj_list) {
+    for (const auto& edge : vertex_edges) {
+      graph_data.push_back(static_cast<int>(edge.first));
+      graph_data.push_back(edge.second);
+    }
+    graph_data.push_back(-1);
+  }
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t*>(graph_data.data()));
+  task_data_tbb->inputs_count.emplace_back(graph_data.size());
+
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t*>(&start_vertex));
+  task_data_tbb->inputs_count.emplace_back(sizeof(start_vertex));
+
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t*>(distances.data()));
+  task_data_tbb->outputs_count.emplace_back(num_vertices);
+
+  muhina_m_dijkstra_tbb::TestTaskTBB task_task_tbb(task_data_tbb);
+  ASSERT_TRUE(task_task_tbb.Validation());
+  task_task_tbb.PreProcessing();
+  ASSERT_TRUE(task_task_tbb.Run());
+  task_task_tbb.PostProcessing();
+
+  for (size_t i = 0; i < num_vertices; ++i) {
+    EXPECT_EQ(distances[i], expected_distances[i]);
+  }
+}
+
+TEST(muhina_m_dijkstra_tbb, single_vertex_graph) {
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list = {{}};
+  size_t start_vertex = 0;
+
+  std::vector<int> graph_data = {-1};
+  std::vector<int> distances(1, INT_MAX);
+
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t*>(graph_data.data()));
+  task_data_tbb->inputs_count.emplace_back(graph_data.size());
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t*>(&start_vertex));
+  task_data_tbb->inputs_count.emplace_back(sizeof(start_vertex));
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t*>(distances.data()));
+  task_data_tbb->outputs_count.emplace_back(1);
+
+  muhina_m_dijkstra_tbb::TestTaskTBB task_task_tbb(task_data_tbb);
+  ASSERT_TRUE(task_task_tbb.Validation());
+  task_task_tbb.PreProcessing();
+  ASSERT_TRUE(task_task_tbb.Run());
+  task_task_tbb.PostProcessing();
+
+  EXPECT_EQ(distances[0], 0);
+}
+
+TEST(muhina_m_dijkstra_tbb, two_connected_components) {
+  constexpr size_t kNumVertices = 6;
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list(kNumVertices);
+
+  adj_list[0].emplace_back(1, 2);
+  adj_list[0].emplace_back(2, 4);
+  adj_list[1].emplace_back(0, 2);
+  adj_list[1].emplace_back(2, 1);
+  adj_list[2].emplace_back(0, 4);
+  adj_list[2].emplace_back(1, 1);
+
+  adj_list[3].emplace_back(4, 3);
+  adj_list[3].emplace_back(5, 7);
+  adj_list[4].emplace_back(3, 3);
+  adj_list[4].emplace_back(5, 2);
+  adj_list[5].emplace_back(3, 7);
+  adj_list[5].emplace_back(4, 2);
+
+  size_t start_vertex = 0;
+
+  std::vector<int> distances(kNumVertices, INT_MAX);
+  std::vector<int> graph_data;
+  for (const auto& vertex_edges : adj_list) {
+    for (const auto& edge : vertex_edges) {
+      graph_data.push_back(static_cast<int>(edge.first));
+      graph_data.push_back(edge.second);
+    }
+    graph_data.push_back(-1);
+  }
+
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t*>(graph_data.data()));
+  task_data_tbb->inputs_count.emplace_back(graph_data.size());
+
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t*>(&start_vertex));
+  task_data_tbb->inputs_count.emplace_back(sizeof(start_vertex));
+
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t*>(distances.data()));
+  task_data_tbb->outputs_count.emplace_back(kNumVertices);
+
+  muhina_m_dijkstra_tbb::TestTaskTBB task_task_tbb(task_data_tbb);
+  ASSERT_TRUE(task_task_tbb.Validation());
+  task_task_tbb.PreProcessing();
+  ASSERT_TRUE(task_task_tbb.Run());
+  task_task_tbb.PostProcessing();
+
+  std::vector<int> expected_distances = {0, 2, 3, INT_MAX, INT_MAX, INT_MAX};
+  for (size_t i = 0; i < kNumVertices; ++i) {
+    EXPECT_EQ(distances[i], expected_distances[i]);
+  }
+}

--- a/tasks/tbb/muhina_m_dijkstra/include/ops_tbb.hpp
+++ b/tasks/tbb/muhina_m_dijkstra/include/ops_tbb.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace muhina_m_dijkstra_tbb {
+
+class TestTaskTBB : public ppc::core::Task {
+ public:
+  explicit TestTaskTBB(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> graph_data_;
+  std::vector<int> distances_;
+  size_t start_vertex_;
+  size_t num_vertices_;
+  static const int kEndOfVertexList;
+};
+
+}  // namespace muhina_m_dijkstra_tbb

--- a/tasks/tbb/muhina_m_dijkstra/perf_tests/main.cpp
+++ b/tasks/tbb/muhina_m_dijkstra/perf_tests/main.cpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <memory>
+#include <queue>
 #include <utility>
 #include <vector>
 
@@ -29,6 +30,7 @@ std::vector<std::vector<std::pair<size_t, int>>> GenerateLargeGraph(size_t k_num
   }
   return adj_list;
 }
+
 std::vector<int> ConvertGraphToData(const std::vector<std::vector<std::pair<size_t, int>>>& adj_list) {
   std::vector<int> graph_data;
   for (const auto& vertex_edges : adj_list) {
@@ -40,15 +42,46 @@ std::vector<int> ConvertGraphToData(const std::vector<std::vector<std::pair<size
   }
   return graph_data;
 }
+
+std::vector<int> Dijkstra(const std::vector<std::vector<std::pair<size_t, int>>>& adj_list, size_t start_vertex) {
+  const size_t num_vertices = adj_list.size();
+  std::vector<int> distances(num_vertices, INT_MAX);
+  distances[start_vertex] = 0;
+
+  std::priority_queue<std::pair<int, size_t>, std::vector<std::pair<int, size_t>>, std::greater<>> pq;
+  pq.emplace(0, start_vertex);
+
+  while (!pq.empty()) {
+    size_t u = pq.top().second;
+    int dist_u = pq.top().first;
+    pq.pop();
+
+    if (dist_u > distances[u]) {
+      continue;
+    }
+
+    for (const auto& edge : adj_list[u]) {
+      size_t v = edge.first;
+      int weight = edge.second;
+
+      if (distances[u] != INT_MAX && distances[u] + weight < distances[v]) {
+        distances[v] = distances[u] + weight;
+        pq.emplace(distances[v], v);
+      }
+    }
+  }
+
+  return distances;
+}
 }  // namespace
 
 TEST(muhina_m_dijkstra_tbb, test_pipeline_run) {
-  constexpr size_t kNumVertices = 6000;
+  constexpr size_t kNumVertices = 5000;
   size_t start_vertex = 0;
 
   auto adj_list = GenerateLargeGraph(kNumVertices);
   auto graph_data = ConvertGraphToData(adj_list);
-
+  auto expected_distances = Dijkstra(adj_list, start_vertex);
   std::vector<int> distances(kNumVertices, INT_MAX);
 
   auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
@@ -77,15 +110,19 @@ TEST(muhina_m_dijkstra_tbb, test_pipeline_run) {
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_tbb);
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  for (size_t i = 0; i < kNumVertices; ++i) {
+    EXPECT_EQ(distances[i], expected_distances[i]);
+  }
 }
 
 TEST(muhina_m_dijkstra_tbb, test_task_run) {
-  constexpr size_t kNumVertices = 6000;
+  constexpr size_t kNumVertices = 5000;
   size_t start_vertex = 0;
 
   auto adj_list = GenerateLargeGraph(kNumVertices);
   auto graph_data = ConvertGraphToData(adj_list);
-
+  auto expected_distances = Dijkstra(adj_list, start_vertex);
   std::vector<int> distances(kNumVertices, INT_MAX);
 
   auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
@@ -113,4 +150,8 @@ TEST(muhina_m_dijkstra_tbb, test_task_run) {
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_tbb);
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  for (size_t i = 0; i < kNumVertices; ++i) {
+    EXPECT_EQ(distances[i], expected_distances[i]);
+  }
 }

--- a/tasks/tbb/muhina_m_dijkstra/perf_tests/main.cpp
+++ b/tasks/tbb/muhina_m_dijkstra/perf_tests/main.cpp
@@ -1,0 +1,123 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "tbb/muhina_m_dijkstra/include/ops_tbb.hpp"
+
+TEST(muhina_m_dijkstra_tbb, test_pipeline_run) {
+  constexpr size_t kNumVertices = 6000;
+  size_t start_vertex = 0;
+
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list(kNumVertices);
+  for (size_t i = 0; i < kNumVertices; ++i) {
+    for (size_t j = 0; j < kNumVertices; ++j) {
+      if (i != j) {
+        if (rand() % 3 == 0) {
+          int weight = (rand() % 10) + 1;
+          adj_list[i].emplace_back(j, weight);
+        }
+      }
+    }
+  }
+
+  std::vector<int> graph_data;
+  for (const auto& vertex_edges : adj_list) {
+    for (const auto& edge : vertex_edges) {
+      graph_data.push_back(static_cast<int>(edge.first));
+      graph_data.push_back(edge.second);
+    }
+    graph_data.push_back(-1);
+  }
+
+  std::vector<int> distances(kNumVertices, INT_MAX);
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(graph_data.data()));
+  task_data_omp->inputs_count.emplace_back(graph_data.size());
+
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(&start_vertex));
+  task_data_omp->inputs_count.emplace_back(sizeof(start_vertex));
+
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(distances.data()));
+  task_data_omp->outputs_count.emplace_back(kNumVertices);
+
+  auto test_task_open_mp = std::make_shared<muhina_m_dijkstra_tbb::TestTaskTBB>(task_data_omp);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_open_mp);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}
+
+TEST(muhina_m_dijkstra_tbb, test_task_run) {
+  constexpr size_t kNumVertices = 6000;
+  size_t start_vertex = 0;
+
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list(kNumVertices);
+  for (size_t i = 0; i < kNumVertices; ++i) {
+    for (size_t j = 0; j < kNumVertices; ++j) {
+      if (i != j) {
+        if (rand() % 3 == 0) {
+          int weight = (rand() % 10) + 1;
+          adj_list[i].emplace_back(j, weight);
+        }
+      }
+    }
+  }
+
+  std::vector<int> graph_data;
+  for (const auto& vertex_edges : adj_list) {
+    for (const auto& edge : vertex_edges) {
+      graph_data.push_back(static_cast<int>(edge.first));
+      graph_data.push_back(edge.second);
+    }
+    graph_data.push_back(-1);
+  }
+
+  std::vector<int> distances(kNumVertices, INT_MAX);
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(graph_data.data()));
+  task_data_omp->inputs_count.emplace_back(graph_data.size());
+
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(&start_vertex));
+  task_data_omp->inputs_count.emplace_back(sizeof(start_vertex));
+
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(distances.data()));
+  task_data_omp->outputs_count.emplace_back(kNumVertices);
+
+  auto test_task_open_mp = std::make_shared<muhina_m_dijkstra_tbb::TestTaskTBB>(task_data_omp);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_open_mp);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}

--- a/tasks/tbb/muhina_m_dijkstra/perf_tests/main.cpp
+++ b/tasks/tbb/muhina_m_dijkstra/perf_tests/main.cpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <functional>
 #include <memory>
 #include <queue>
 #include <utility>

--- a/tasks/tbb/muhina_m_dijkstra/src/ops_tbb.cpp
+++ b/tasks/tbb/muhina_m_dijkstra/src/ops_tbb.cpp
@@ -14,8 +14,8 @@
 const int muhina_m_dijkstra_tbb::TestTaskTBB::kEndOfVertexList = -1;
 
 namespace {
-void RunDijkstraAlgorithm(const std::vector<std::vector<std::pair<size_t, int>>> &adj_list,
-                            std::vector<int> &distances, size_t start_vertex) {
+void RunDijkstraAlgorithm(const std::vector<std::vector<std::pair<size_t, int>>> &adj_list, std::vector<int> &distances,
+                          size_t start_vertex) {
   oneapi::tbb::concurrent_priority_queue<std::pair<int, size_t>, std::greater<>> pq;
   pq.push({0, start_vertex});
   oneapi::tbb::spin_mutex mutex;

--- a/tasks/tbb/muhina_m_dijkstra/src/ops_tbb.cpp
+++ b/tasks/tbb/muhina_m_dijkstra/src/ops_tbb.cpp
@@ -77,8 +77,8 @@ bool muhina_m_dijkstra_tbb::TestTaskTBB::PreProcessingImpl() {
 }
 
 bool muhina_m_dijkstra_tbb::TestTaskTBB::ValidationImpl() {
-  return !task_data->inputs_count.empty() && task_data->inputs_count[0] > 0;
-  return !task_data->outputs_count.empty() && task_data->outputs_count[0] > 0;
+  return !task_data->inputs_count.empty() && task_data->inputs_count[0] > 0 && !task_data->outputs_count.empty() &&
+         task_data->outputs_count[0] > 0;
 }
 
 bool muhina_m_dijkstra_tbb::TestTaskTBB::RunImpl() {

--- a/tasks/tbb/muhina_m_dijkstra/src/ops_tbb.cpp
+++ b/tasks/tbb/muhina_m_dijkstra/src/ops_tbb.cpp
@@ -14,7 +14,7 @@
 const int muhina_m_dijkstra_tbb::TestTaskTBB::kEndOfVertexList = -1;
 
 namespace {
-void run_dijkstra_algorithm(const std::vector<std::vector<std::pair<size_t, int>>> &adj_list,
+void RunDijkstraAlgorithm(const std::vector<std::vector<std::pair<size_t, int>>> &adj_list,
                             std::vector<int> &distances, size_t start_vertex) {
   oneapi::tbb::concurrent_priority_queue<std::pair<int, size_t>, std::greater<>> pq;
   pq.push({0, start_vertex});
@@ -109,7 +109,7 @@ bool muhina_m_dijkstra_tbb::TestTaskTBB::RunImpl() {
 
     i += 2;
   }
-  run_dijkstra_algorithm(adj_list, distances_, start_vertex_);
+  RunDijkstraAlgorithm(adj_list, distances_, start_vertex_);
 
   return true;
 }

--- a/tasks/tbb/muhina_m_dijkstra/src/ops_tbb.cpp
+++ b/tasks/tbb/muhina_m_dijkstra/src/ops_tbb.cpp
@@ -1,0 +1,115 @@
+#include "tbb/muhina_m_dijkstra/include/ops_tbb.hpp"
+
+#include <oneapi/tbb/concurrent_priority_queue.h>
+#include <oneapi/tbb/parallel_for.h>
+#include <oneapi/tbb/blocked_range.h>
+#include <oneapi/tbb/spin_mutex.h>
+
+#include <climits>
+#include <cstddef>
+#include <functional>
+#include <queue>
+#include <utility>
+#include <vector>
+
+const int muhina_m_dijkstra_tbb::TestTaskTBB::kEndOfVertexList = -1;
+
+bool muhina_m_dijkstra_tbb::TestTaskTBB::PreProcessingImpl() {
+  unsigned int input_size = task_data->inputs_count[0];
+  auto *in_ptr = reinterpret_cast<int *>(task_data->inputs[0]);
+  graph_data_.assign(in_ptr, in_ptr + input_size);
+
+  num_vertices_ = task_data->outputs_count[0];
+  distances_.resize(num_vertices_);
+  for (size_t i = 0; i < num_vertices_; ++i) {
+    distances_[i] = INT_MAX;
+  }
+  if (task_data->inputs.size() > 1 && task_data->inputs[1] != nullptr) {
+    start_vertex_ = *reinterpret_cast<int *>(task_data->inputs[1]);
+  } else {
+    start_vertex_ = 0;
+  }
+  distances_[start_vertex_] = 0;
+
+  return true;
+}
+
+bool muhina_m_dijkstra_tbb::TestTaskTBB::ValidationImpl() {
+  return !task_data->inputs_count.empty() && task_data->inputs_count[0] > 0;
+  return !task_data->outputs_count.empty() && task_data->outputs_count[0] > 0;
+}
+
+bool muhina_m_dijkstra_tbb::TestTaskTBB::RunImpl() {
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list(num_vertices_);
+  size_t current_vertex = 0;
+  size_t i = 0;
+
+  while (i < graph_data_.size() && current_vertex < num_vertices_) {
+    if (graph_data_[i] == kEndOfVertexList) {
+      current_vertex++;
+      i++;
+      continue;
+    }
+
+    if (i + 1 >= graph_data_.size()) {
+      break;
+    }
+
+    size_t dest = graph_data_[i];
+    int weight = graph_data_[i + 1];
+    if (weight < 0) {
+      return false;
+    }
+
+    if (dest < num_vertices_) {
+      adj_list[current_vertex].emplace_back(dest, weight);
+    }
+
+    i += 2;
+  }
+
+  oneapi::tbb::concurrent_priority_queue<std::pair<int, size_t>, 
+                                       std::greater<std::pair<int, size_t>>> pq;
+  pq.push({0, start_vertex_});
+  oneapi::tbb::spin_mutex mutex;
+
+  while (true) {
+    std::pair<int, size_t> top;
+    if (!pq.try_pop(top)) {
+      if (pq.empty()) break;
+      continue;
+    }
+
+    size_t u = top.second;
+    int dist_u = top.first;
+
+    if (dist_u > distances_[u]) {
+      continue;
+    }
+
+    oneapi::tbb::parallel_for(oneapi::tbb::blocked_range<size_t>(0, adj_list[u].size()), [&](const oneapi::tbb::blocked_range<size_t> &r) {
+      for (size_t i = r.begin(); i != r.end(); ++i) {
+        size_t v = adj_list[u][i].first;
+        int weight = adj_list[u][i].second;
+        int new_dist = distances_[u] + weight;
+
+        if (new_dist < distances_[v]) {
+          oneapi::tbb::spin_mutex::scoped_lock lock(mutex);
+          if (new_dist < distances_[v]) {
+            distances_[v] = new_dist;
+            pq.push({new_dist, v});
+          }
+        }
+      }
+    });
+  }
+
+  return true;
+}
+
+bool muhina_m_dijkstra_tbb::TestTaskTBB::PostProcessingImpl() {
+  for (size_t i = 0; i < distances_.size(); ++i) {
+    reinterpret_cast<int *>(task_data->outputs[0])[i] = distances_[i];
+  }
+  return true;
+}


### PR DESCRIPTION

## Алгоритм Дейкстры с использованием TBB

1.  **`PreProcessingImpl()`**:
    *   Граф представлен в виде последовательности целых чисел, где `kEndOfVertexList` обозначает конец списка соседей для каждой вершины.
    *   Инициализируется вектор `distances_` значением `INT_MAX` для всех вершин.
    *   Определяется начальная вершина `start_vertex_` из `task_data->inputs[1]`  или используется вершина 0 по умолчанию.
    *   Устанавливается расстояние до `start_vertex_` равным 0.

2.  **`RunImpl()`**:
    *   **Построение списка смежности (`adj_list`)**:  Обрабатываются входные данные графа и строится список смежности (`std::vector<std::vector<std::pair<size_t, int>>>`) для представления графа. Каждая запись в списке содержит целевую вершину и вес ребра.
    *   **Инициализация приоритетной очереди (`pq`)**: Создается `oneapi::tbb::concurrent_priority_queue` и добавляется начальная вершина с расстоянием 0.
	•   Использование `oneapi::tbb::concurrent_priority_queue` обеспечивает потокобезопасный доступ к очереди.
    *   **Основной цикл**:
        *   Цикл продолжается до тех пор, пока очередь не пуста.
        *   Извлекается вершина `u` с наименьшим расстоянием `dist_u` из очереди (`pq.try_pop()`).  Если очередь пуста или `try_pop()` не удался, цикл продолжается.
        *   **Проверка актуальности расстояния**: Если извлеченное расстояние `dist_u` больше, чем текущее расстояние до вершины `u` (`distances_[u]`), это означает, что вершина уже была обработана с более коротким путем, и итерация пропускается.
        *   **Параллельная обработка соседей**: Используется `oneapi::tbb::parallel_for` для обработки соседей вершины `u`.
        *   Для каждого соседа `v`:
            *   Вычисляется новое расстояние `new_dist` как `distances_[u] + weight`.
            *   Выполняется Критическая секция (с использованием `oneapi::tbb::spin_mutex`)