### PR TITLE
Fix perf Колоколова Дарья. Вариант 11. Технология SEQ. Вычисление многомерных интегралов с использованием многошаговой схемы (метод Симпсона).

### DIFF
--- a/tasks/seq/kolokolova_d_integral_simpson_method_seq/perf_tests/main.cpp
+++ b/tasks/seq/kolokolova_d_integral_simpson_method_seq/perf_tests/main.cpp
@@ -13,8 +13,8 @@ TEST(kolokolova_d_integral_simpson_method_seq, test_pipeline_run) {
   auto func = [](std::vector<double> vec) {
     return (2 * vec[2]) + (vec[1] * vec[1] / 5) + (4 * vec[0] * vec[0] * vec[0]) - 100;
   };
-  std::vector<int> step = {90, 90, 90};
-  std::vector<int> bord = {10, 11, 8, 10, 0, 2};
+  std::vector<int> step = {130, 130, 130};
+  std::vector<int> bord = {3, 12, 2, 10, 0, 14};
   double func_result = 0.0;
 
   // Create task_data
@@ -50,7 +50,7 @@ TEST(kolokolova_d_integral_simpson_method_seq, test_pipeline_run) {
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
-  double ans = 18235.7;
+  double ans = 2244276.9;
   double error = 0.1;
   ASSERT_NEAR(func_result, ans, error);
 }
@@ -59,8 +59,8 @@ TEST(kolokolova_d_integral_simpson_method_seq, test_task_run) {
   auto func = [](std::vector<double> vec) {
     return (vec[2] * vec[2] * vec[2] * vec[1] * vec[1] / 10) + (4 * vec[0] * vec[0]) - (10 * vec[2]);
   };
-  std::vector<int> step = {90, 90, 90};
-  std::vector<int> bord = {10, 11, 8, 10, 0, 2};
+  std::vector<int> step = {130, 130, 130};
+  std::vector<int> bord = {1, 11, 2, 10, 0, 10};
   double func_result = 0.0;
 
   // Create task_data
@@ -95,7 +95,7 @@ TEST(kolokolova_d_integral_simpson_method_seq, test_task_run) {
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
-  double ans = 1790.2;
+  double ans = 927300.25;
   double error = 0.1;
   ASSERT_NEAR(func_result, ans, error);
 }


### PR DESCRIPTION
Благодаря ревью в https://github.com/learning-process/ppc-2025-threads/pull/266 было замечено, что в seq версии также слишком быстро проходят тесты, так что размер входных данных был немного увеличен