### PR TITLE
Хованский Дмитрий. Вариант 20. Технология OMP. Поразрядная сортировка для вещественных чисел (тип double) с четно-нечетным слиянием Бэтчера.

### DIFF
--- a/tasks/omp/khovansky_d_double_radix_batcher/func_tests/main.cpp
+++ b/tasks/omp/khovansky_d_double_radix_batcher/func_tests/main.cpp
@@ -146,3 +146,17 @@ TEST(khovansky_d_double_radix_batcher_omp, large_array) {
   test_task_omp.PostProcessingImpl();
   EXPECT_EQ(exp_out, out);
 }
+
+TEST(khovansky_d_double_radix_batcher_omp, invalid_input) {
+  std::vector<double> in{1.0};
+  std::vector<double> out(1);
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  khovansky_d_double_radix_batcher_omp::RadixOMP test_task_omp(task_data_omp);
+  EXPECT_EQ(test_task_omp.ValidationImpl(), false);
+}

--- a/tasks/omp/khovansky_d_double_radix_batcher/func_tests/main.cpp
+++ b/tasks/omp/khovansky_d_double_radix_batcher/func_tests/main.cpp
@@ -1,0 +1,148 @@
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "omp/khovansky_d_double_radix_batcher/include/ops_omp.hpp"
+
+TEST(khovansky_d_double_radix_batcher_omp, negative_values) {
+  std::vector<double> in{-3.14, -1.0, -100.5, -0.1, -999.99};
+  std::vector<double> exp_out{-999.99, -100.5, -3.14, -1.0, -0.1};
+  std::vector<double> out(5);
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  khovansky_d_double_radix_batcher_omp::RadixOMP test_task_omp(task_data_omp);
+  ASSERT_EQ(test_task_omp.ValidationImpl(), true);
+  test_task_omp.PreProcessingImpl();
+  test_task_omp.RunImpl();
+  test_task_omp.PostProcessingImpl();
+  EXPECT_EQ(exp_out, out);
+}
+
+TEST(khovansky_d_double_radix_batcher_omp, positive_values) {
+  std::vector<double> in{3.14, 1.0, 100.5, 0.1, 999.99};
+  std::vector<double> exp_out{0.1, 1.0, 3.14, 100.5, 999.99};
+  std::vector<double> out(5);
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  khovansky_d_double_radix_batcher_omp::RadixOMP test_task_omp(task_data_omp);
+  ASSERT_EQ(test_task_omp.ValidationImpl(), true);
+  test_task_omp.PreProcessingImpl();
+  test_task_omp.RunImpl();
+  test_task_omp.PostProcessingImpl();
+  EXPECT_EQ(exp_out, out);
+}
+
+TEST(khovansky_d_double_radix_batcher_omp, mixed_values) {
+  std::vector<double> in{0.0, -2.5, 3.3, -1.1, 2.2};
+  std::vector<double> exp_out{-2.5, -1.1, 0.0, 2.2, 3.3};
+  std::vector<double> out(5);
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  khovansky_d_double_radix_batcher_omp::RadixOMP test_task_omp(task_data_omp);
+  ASSERT_EQ(test_task_omp.ValidationImpl(), true);
+  test_task_omp.PreProcessingImpl();
+  test_task_omp.RunImpl();
+  test_task_omp.PostProcessingImpl();
+  EXPECT_EQ(exp_out, out);
+}
+
+TEST(khovansky_d_double_radix_batcher_omp, duplicate_values) {
+  std::vector<double> in{5.5, 2.2, 5.5, 3.3, 2.2};
+  std::vector<double> exp_out{2.2, 2.2, 3.3, 5.5, 5.5};
+  std::vector<double> out(5);
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  khovansky_d_double_radix_batcher_omp::RadixOMP test_task_omp(task_data_omp);
+  ASSERT_EQ(test_task_omp.ValidationImpl(), true);
+  test_task_omp.PreProcessingImpl();
+  test_task_omp.RunImpl();
+  test_task_omp.PostProcessingImpl();
+  EXPECT_EQ(exp_out, out);
+}
+
+TEST(khovansky_d_double_radix_batcher_omp, sorted_input) {
+  std::vector<double> in{-2.2, -1.1, 0.0, 1.1, 2.2};
+  std::vector<double> exp_out{-2.2, -1.1, 0.0, 1.1, 2.2};
+  std::vector<double> out(5);
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  khovansky_d_double_radix_batcher_omp::RadixOMP test_task_omp(task_data_omp);
+  ASSERT_EQ(test_task_omp.ValidationImpl(), true);
+  test_task_omp.PreProcessingImpl();
+  test_task_omp.RunImpl();
+  test_task_omp.PostProcessingImpl();
+  EXPECT_EQ(exp_out, out);
+}
+
+TEST(khovansky_d_double_radix_batcher_omp, large_numbers) {
+  std::vector<double> in{1e308, -1e308, 1e307, -1e307, 0.0};
+  std::vector<double> exp_out{-1e308, -1e307, 0.0, 1e307, 1e308};
+  std::vector<double> out(5);
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  khovansky_d_double_radix_batcher_omp::RadixOMP test_task_omp(task_data_omp);
+  ASSERT_EQ(test_task_omp.ValidationImpl(), true);
+  test_task_omp.PreProcessingImpl();
+  test_task_omp.RunImpl();
+  test_task_omp.PostProcessingImpl();
+  EXPECT_EQ(exp_out, out);
+}
+
+TEST(khovansky_d_double_radix_batcher_omp, large_array) {
+  constexpr size_t kSize = 1000000;
+  std::vector<double> in(kSize);
+  std::vector<double> exp_out(kSize);
+
+  for (size_t i = 0; i < kSize; ++i) {
+    in[i] = static_cast<double>(kSize - i);
+    exp_out[i] = static_cast<double>(i + 1);
+  }
+
+  std::vector<double> out(kSize);
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  khovansky_d_double_radix_batcher_omp::RadixOMP test_task_omp(task_data_omp);
+  ASSERT_EQ(test_task_omp.ValidationImpl(), true);
+  test_task_omp.PreProcessingImpl();
+  test_task_omp.RunImpl();
+  test_task_omp.PostProcessingImpl();
+  EXPECT_EQ(exp_out, out);
+}

--- a/tasks/omp/khovansky_d_double_radix_batcher/include/ops_omp.hpp
+++ b/tasks/omp/khovansky_d_double_radix_batcher/include/ops_omp.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace khovansky_d_double_radix_batcher_omp {
+
+class RadixOMP : public ppc::core::Task {
+ public:
+  explicit RadixOMP(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<double> input_, output_;
+};
+}  // namespace khovansky_d_double_radix_batcher_omp

--- a/tasks/omp/khovansky_d_double_radix_batcher/perf_tests/main.cpp
+++ b/tasks/omp/khovansky_d_double_radix_batcher/perf_tests/main.cpp
@@ -1,0 +1,99 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "omp/khovansky_d_double_radix_batcher/include/ops_omp.hpp"
+
+TEST(khovansky_d_double_radix_batcher_omp, test_pipeline_run) {
+  constexpr int kCount = 1000000;
+
+  // Create data
+  std::vector<double> in(kCount);
+  std::vector<double> exp_out(kCount);
+
+  for (size_t i = 0; i < kCount; ++i) {
+    in[i] = static_cast<double>(kCount - i);
+    exp_out[i] = static_cast<double>(i + 1);
+  }
+
+  std::vector<double> out(kCount);
+
+  // Create task_data
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_omp = std::make_shared<khovansky_d_double_radix_batcher_omp::RadixOMP>(task_data_omp);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(exp_out, out);
+}
+
+TEST(khovansky_d_double_radix_batcher_omp, test_task_run) {
+  constexpr int kCount = 1000000;
+
+  // Create data
+  std::vector<double> in(kCount);
+  std::vector<double> exp_out(kCount);
+
+  for (size_t i = 0; i < kCount; ++i) {
+    in[i] = static_cast<double>(kCount - i);
+    exp_out[i] = static_cast<double>(i + 1);
+  }
+
+  std::vector<double> out(kCount);
+
+  // Create task_data
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_omp = std::make_shared<khovansky_d_double_radix_batcher_omp::RadixOMP>(task_data_omp);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(exp_out, out);
+}

--- a/tasks/omp/khovansky_d_double_radix_batcher/src/ops_omp.cpp
+++ b/tasks/omp/khovansky_d_double_radix_batcher/src/ops_omp.cpp
@@ -98,7 +98,7 @@ void OddEvenMergeSort(std::vector<uint64_t>& array, int left, int right) {
 
 void RadixBatcherSort(std::vector<double>& data) {
   std::vector<uint64_t> transformed_data(data.size(), 0);
-  
+
 #pragma omp parallel for
   for (int64_t i = 0; i < static_cast<int64_t>(data.size()); i++) {
     transformed_data[i] = EncodeDoubleToUint64(data[i]);
@@ -106,7 +106,7 @@ void RadixBatcherSort(std::vector<double>& data) {
 
   RadixSort(transformed_data);
   OddEvenMergeSort(transformed_data, 0, static_cast<int>(transformed_data.size()));
-  
+
 #pragma omp parallel for
   for (int64_t i = 0; i < static_cast<int64_t>(data.size()); i++) {
     data[i] = DecodeUint64ToDouble(transformed_data[i]);

--- a/tasks/omp/khovansky_d_double_radix_batcher/src/ops_omp.cpp
+++ b/tasks/omp/khovansky_d_double_radix_batcher/src/ops_omp.cpp
@@ -1,0 +1,162 @@
+#include "omp/khovansky_d_double_radix_batcher/include/ops_omp.hpp"
+
+#include <omp.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace khovansky_d_double_radix_batcher_omp {
+namespace {
+uint64_t EncodeDoubleToUint64(double value) {
+  uint64_t bit_representation = 0;
+  std::memcpy(&bit_representation, &value, sizeof(value));
+
+  if ((bit_representation >> 63) != 0) {
+    return ~bit_representation;
+  }
+  return bit_representation ^ (1ULL << 63);
+}
+
+double DecodeUint64ToDouble(uint64_t encoded) {
+  if ((encoded >> 63) != 0) {
+    encoded ^= (1ULL << 63);
+  } else {
+    encoded = ~encoded;
+  }
+
+  double result = 0.0;
+  std::memcpy(&result, &encoded, sizeof(result));
+  return result;
+}
+
+void RadixSort(std::vector<uint64_t>& array) {
+  const int bits_in_byte = 8;
+  const int total_bits = 64;
+  const int bucket_count = 256;
+
+  std::vector<uint64_t> buffer(array.size(), 0);
+  std::vector<int> frequency(bucket_count, 0);
+
+  for (int shift = 0; shift < total_bits; shift += bits_in_byte) {
+    std::vector<int> local_frequency(bucket_count, 0);
+  
+#pragma omp parallel
+    {
+      std::vector<int> private_frequency(bucket_count, 0);
+  
+#pragma omp for nowait
+      for (int64_t i = 0; i < static_cast<int64_t>(array.size()); i++) {
+        auto bucket = static_cast<uint8_t>((array[i] >> shift) & 0xFF);
+        private_frequency[bucket]++;
+      }
+  
+#pragma omp critical
+      for (int i = 0; i < bucket_count; i++) {
+        local_frequency[i] += private_frequency[i];
+      }
+    }
+
+    for (int i = 1; i < bucket_count; i++) {
+      local_frequency[i] += local_frequency[i - 1];
+    }
+
+    for (int i = static_cast<int>(array.size()) - 1; i >= 0; i--) {
+      auto bucket = static_cast<uint8_t>((array[i] >> shift) & 0xFF);
+      buffer[--local_frequency[bucket]] = array[i];
+    }
+
+    array.swap(buffer);
+  }
+}
+
+void OddEvenMergeSort(std::vector<uint64_t>& array, int left, int right) {
+  if (right - left <= 1) {
+    return;
+  }
+
+  int middle = left + ((right - left) / 2);
+  
+#pragma omp parallel sections
+  {
+
+#pragma omp section
+    OddEvenMergeSort(array, left, middle);
+
+#pragma omp section
+    OddEvenMergeSort(array, middle, right);
+  }
+  
+#pragma omp parallel for
+  for (int i = left; i < right - 1; i += 2) {
+    if (array[i] > array[i + 1]) {
+      std::swap(array[i], array[i + 1]);
+    }
+  }
+}
+
+void RadixBatcherSort(std::vector<double>& data) {
+  std::vector<uint64_t> transformed_data(data.size(), 0);
+
+  for (int64_t i = 0; i < static_cast<int64_t>(data.size()); i++) {
+    transformed_data[i] = EncodeDoubleToUint64(data[i]);
+  }
+
+  RadixSort(transformed_data);
+  OddEvenMergeSort(transformed_data, 0, static_cast<int>(transformed_data.size()));
+
+  for (int64_t i = 0; i < static_cast<int64_t>(data.size()); i++) {
+    data[i] = DecodeUint64ToDouble(transformed_data[i]);
+  }
+}
+}  // namespace
+}  // namespace khovansky_d_double_radix_batcher_omp
+
+bool khovansky_d_double_radix_batcher_omp::RadixOMP::PreProcessingImpl() {
+  auto* in_ptr = reinterpret_cast<double*>(task_data->inputs[0]);
+
+  unsigned int input_size = task_data->inputs_count[0];
+  unsigned int output_size = task_data->outputs_count[0];
+
+  input_ = std::vector<double>(in_ptr, in_ptr + input_size);
+  output_ = std::vector<double>(output_size, 0);
+
+  return true;
+}
+
+bool khovansky_d_double_radix_batcher_omp::RadixOMP::ValidationImpl() {
+  if (!task_data) {
+    return false;
+  }
+
+  if (task_data->inputs[0] == nullptr && task_data->inputs_count[0] == 0) {
+    return false;
+  }
+
+  if (task_data->outputs[0] == nullptr) {
+    return false;
+  }
+
+  if (task_data->inputs_count[0] < 2) {
+    return false;
+  }
+
+  return task_data->inputs_count[0] == task_data->outputs_count[0];
+}
+
+bool khovansky_d_double_radix_batcher_omp::RadixOMP::RunImpl() {
+  output_ = input_;
+  khovansky_d_double_radix_batcher_omp::RadixBatcherSort(output_);
+  return true;
+}
+
+bool khovansky_d_double_radix_batcher_omp::RadixOMP::PostProcessingImpl() {
+  for (size_t i = 0; i < output_.size(); i++) {
+    reinterpret_cast<double*>(task_data->outputs[0])[i] = output_[i];
+  }
+
+  return true;
+}

--- a/tasks/omp/khovansky_d_double_radix_batcher/src/ops_omp.cpp
+++ b/tasks/omp/khovansky_d_double_radix_batcher/src/ops_omp.cpp
@@ -98,14 +98,16 @@ void OddEvenMergeSort(std::vector<uint64_t>& array, int left, int right) {
 
 void RadixBatcherSort(std::vector<double>& data) {
   std::vector<uint64_t> transformed_data(data.size(), 0);
-
+  
+#pragma omp parallel for
   for (int64_t i = 0; i < static_cast<int64_t>(data.size()); i++) {
     transformed_data[i] = EncodeDoubleToUint64(data[i]);
   }
 
   RadixSort(transformed_data);
   OddEvenMergeSort(transformed_data, 0, static_cast<int>(transformed_data.size()));
-
+  
+#pragma omp parallel for
   for (int64_t i = 0; i < static_cast<int64_t>(data.size()); i++) {
     data[i] = DecodeUint64ToDouble(transformed_data[i]);
   }

--- a/tasks/omp/khovansky_d_double_radix_batcher/src/ops_omp.cpp
+++ b/tasks/omp/khovansky_d_double_radix_batcher/src/ops_omp.cpp
@@ -43,17 +43,17 @@ void RadixSort(std::vector<uint64_t>& array) {
 
   for (int shift = 0; shift < total_bits; shift += bits_in_byte) {
     std::vector<int> local_frequency(bucket_count, 0);
-  
+
 #pragma omp parallel
     {
       std::vector<int> private_frequency(bucket_count, 0);
-  
+
 #pragma omp for nowait
       for (int64_t i = 0; i < static_cast<int64_t>(array.size()); i++) {
         auto bucket = static_cast<uint8_t>((array[i] >> shift) & 0xFF);
         private_frequency[bucket]++;
       }
-  
+
 #pragma omp critical
       for (int i = 0; i < bucket_count; i++) {
         local_frequency[i] += private_frequency[i];
@@ -79,7 +79,7 @@ void OddEvenMergeSort(std::vector<uint64_t>& array, int left, int right) {
   }
 
   int middle = left + ((right - left) / 2);
-  
+
 #pragma omp parallel sections
   {
 

--- a/tasks/omp/khovansky_d_double_radix_batcher/src/ops_omp.cpp
+++ b/tasks/omp/khovansky_d_double_radix_batcher/src/ops_omp.cpp
@@ -82,14 +82,12 @@ void OddEvenMergeSort(std::vector<uint64_t>& array, int left, int right) {
 
 #pragma omp parallel sections
   {
-
 #pragma omp section
     OddEvenMergeSort(array, left, middle);
-
 #pragma omp section
     OddEvenMergeSort(array, middle, right);
   }
-  
+
 #pragma omp parallel for
   for (int i = left; i < right - 1; i += 2) {
     if (array[i] > array[i + 1]) {


### PR DESCRIPTION
Поразрядная сортировка для вещественных чисел (тип double) с четно-нечетным слиянием Бэтчера.

1. Validation

    Проверяется наличие входного и выходного массивов.

    Убеждается, что массивы имеют одинаковый размер.

    Если данные некорректны, выполнение завершается.

2. Preprocessing

    Входной массив копируется во внутреннюю структуру данных, чтобы избежать модификации исходных данных.

3. Run

    Преобразование чисел:
         Числа типа double конвертируются в 64-битное представление (uint64_t), что позволяет корректно работать с их битовой структурой.

    Поразрядная сортировка:

        Выполняется сортировка по битам с использованием разбиения на 256 бакетов (значения байтов).

        Частоты значений рассчитываются параллельно с помощью OpenMP.

        Выполняется перестановка элементов на основе накопленных частот.

    Сортировка нечётно-чётным слиянием Бэтчера:

        Массив делится на две части, которые рекурсивно сортируются.

        Затем выполняется попарное сравнение и перестановка элементов.

    Обратное преобразование:

        Отсортированные 64-битные значения преобразуются обратно в числа типа double.

4. Postprocessing

    Отсортированные данные из внутренней структуры записываются в выходной массив.