### PR TITLE
Капустин Иван. Вариант 23. Технология OMP. Построение выпуклой оболочки - проход Джарвиса.

### DIFF
--- a/tasks/omp/kapustin_i_jarv_alg/func_tests/main.cpp
+++ b/tasks/omp/kapustin_i_jarv_alg/func_tests/main.cpp
@@ -1,0 +1,324 @@
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "omp/kapustin_i_jarv_alg/include/ops_omp.hpp"
+
+namespace {
+std::vector<std::pair<int, int>> GenerateRandomPoints(size_t count, int min_x, int max_x, int min_y, int max_y) {
+  std::random_device rd;
+  std::mt19937 rng(rd());
+  std::uniform_int_distribution<int> dist_x(min_x, max_x);
+  std::uniform_int_distribution<int> dist_y(min_y, max_y);
+
+  std::vector<std::pair<int, int>> random_points;
+  random_points.reserve(count);
+
+  for (size_t i = 0; i < count; ++i) {
+    random_points.emplace_back(dist_x(rng), dist_y(rng));
+  }
+
+  return random_points;
+}
+}  // namespace
+
+TEST(KapustinJarvAlgOMPTest, FixedPointsWithRandomNoise) {
+  std::vector<std::pair<int, int>> fixed_points = {{-1000, -1000}, {1000, -1000}, {1000, 1000}, {-1000, 1000}};
+
+  auto random_points = GenerateRandomPoints(100, -900, 900, -900, 900);
+
+  std::vector<std::pair<int, int>> input_points = fixed_points;
+  input_points.insert(input_points.end(), random_points.begin(), random_points.end());
+
+  std::vector<std::pair<int, int>> output_result(fixed_points.size());
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_points.data()));
+  task_data_omp->inputs_count.emplace_back(input_points.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(output_result.data()));
+  task_data_omp->outputs_count.emplace_back(output_result.size());
+
+  kapustin_i_jarv_alg_omp::TestTaskOMP test_task_omp(task_data_omp);
+
+  ASSERT_TRUE(test_task_omp.Validation());
+
+  test_task_omp.PreProcessingImpl();
+  test_task_omp.RunImpl();
+  test_task_omp.PostProcessingImpl();
+
+  EXPECT_EQ(output_result.size(), fixed_points.size());
+  for (size_t i = 0; i < fixed_points.size(); ++i) {
+    EXPECT_EQ(output_result[i].first, fixed_points[i].first);
+    EXPECT_EQ(output_result[i].second, fixed_points[i].second);
+  }
+}
+
+TEST(KapustinJarvAlgOMPTest, HexagonWithInnerPoints) {
+  std::vector<std::pair<int, int>> input_points = {{0, 0}, {4, 0}, {6, 2}, {4, 4}, {0, 4}, {-2, 2},
+                                                   {2, 2}, {3, 1}, {1, 3}, {3, 3}, {2, 1}};
+
+  std::vector<std::pair<int, int>> expected_result = {{-2, 2}, {0, 0}, {4, 0}, {6, 2}, {4, 4}, {0, 4}};
+
+  std::vector<std::pair<int, int>> output_result(expected_result.size());
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_points.data()));
+  task_data_omp->inputs_count.emplace_back(input_points.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(output_result.data()));
+  task_data_omp->outputs_count.emplace_back(output_result.size());
+
+  kapustin_i_jarv_alg_omp::TestTaskOMP test_task_omp(task_data_omp);
+  ASSERT_TRUE(test_task_omp.Validation());
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  for (size_t i = 0; i < expected_result.size(); ++i) {
+    EXPECT_EQ(expected_result[i].first, output_result[i].first);
+    EXPECT_EQ(expected_result[i].second, output_result[i].second);
+  }
+}
+
+TEST(KapustinJarvAlgOMPTest, TriangleWithInnerPoints) {
+  std::vector<std::pair<int, int>> input_points = {{0, 0}, {5, 8}, {10, 0}, {5, 4}, {3, 2}, {7, 2}, {5, 6}};
+
+  std::vector<std::pair<int, int>> expected_result = {{0, 0}, {10, 0}, {5, 8}};
+
+  std::vector<std::pair<int, int>> output_result(expected_result.size());
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_points.data()));
+  task_data_omp->inputs_count.emplace_back(input_points.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(output_result.data()));
+  task_data_omp->outputs_count.emplace_back(output_result.size());
+
+  kapustin_i_jarv_alg_omp::TestTaskOMP test_task_omp(task_data_omp);
+  ASSERT_TRUE(test_task_omp.Validation());
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  for (size_t i = 0; i < expected_result.size(); ++i) {
+    EXPECT_EQ(expected_result[i].first, output_result[i].first);
+    EXPECT_EQ(expected_result[i].second, output_result[i].second);
+  }
+}
+
+TEST(KapustinJarvAlgOMPTest, PureTriangle) {
+  std::vector<std::pair<int, int>> input_points = {{0, 0}, {5, 8}, {10, 0}};
+  std::vector<std::pair<int, int>> expected_result = {{0, 0}, {10, 0}, {5, 8}};
+  std::vector<std::pair<int, int>> output_result(expected_result.size());
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_points.data()));
+  task_data_omp->inputs_count.emplace_back(input_points.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(output_result.data()));
+  task_data_omp->outputs_count.emplace_back(output_result.size());
+
+  kapustin_i_jarv_alg_omp::TestTaskOMP test_task_omp(task_data_omp);
+  ASSERT_TRUE(test_task_omp.Validation());
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  for (size_t i = 0; i < expected_result.size(); ++i) {
+    EXPECT_EQ(expected_result[i].first, output_result[i].first);
+    EXPECT_EQ(expected_result[i].second, output_result[i].second);
+  }
+}
+
+TEST(KapustinJarvAlgOMPTest, SquarePlusOne) {
+  std::vector<std::pair<int, int>> input_points = {{0, 0}, {0, 4}, {4, 4}, {4, 0}, {2, 2}};
+  std::vector<std::pair<int, int>> expected_result = {{0, 0}, {4, 0}, {4, 4}, {0, 4}};
+  std::vector<std::pair<int, int>> output_result(expected_result.size());
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_points.data()));
+  task_data_omp->inputs_count.emplace_back(input_points.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(output_result.data()));
+  task_data_omp->outputs_count.emplace_back(output_result.size());
+
+  kapustin_i_jarv_alg_omp::TestTaskOMP test_task_omp(task_data_omp);
+
+  ASSERT_TRUE(test_task_omp.Validation());
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  EXPECT_EQ(output_result.size(), expected_result.size());
+  for (size_t i = 0; i < expected_result.size(); ++i) {
+    EXPECT_EQ(expected_result[i], output_result[i]);
+  }
+}
+
+TEST(KapustinJarvAlgOMPTest, DuplicatePoints) {
+  std::vector<std::pair<int, int>> input_points = {{0, 0}, {0, 5}, {5, 5}, {5, 0}, {0, 5}, {5, 5}, {2, 2}};
+  std::vector<std::pair<int, int>> expected_result = {{0, 0}, {5, 0}, {5, 5}, {0, 5}};
+  std::vector<std::pair<int, int>> output_result(expected_result.size());
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_points.data()));
+  task_data_omp->inputs_count.emplace_back(input_points.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(output_result.data()));
+  task_data_omp->outputs_count.emplace_back(output_result.size());
+
+  kapustin_i_jarv_alg_omp::TestTaskOMP test_task_omp(task_data_omp);
+
+  ASSERT_TRUE(test_task_omp.Validation());
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  EXPECT_EQ(output_result.size(), expected_result.size());
+  for (size_t i = 0; i < expected_result.size(); ++i) {
+    EXPECT_EQ(expected_result[i], output_result[i]);
+  }
+}
+
+TEST(KapustinJarvAlgOMPTest, SinglePoint) {
+  std::vector<std::pair<int, int>> input_points = {{1, 1}};
+  std::vector<std::pair<int, int>> expected_result = {{1, 1}};
+  std::vector<std::pair<int, int>> output_result(expected_result.size());
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_points.data()));
+  task_data_omp->inputs_count.emplace_back(input_points.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(output_result.data()));
+  task_data_omp->outputs_count.emplace_back(output_result.size());
+
+  kapustin_i_jarv_alg_omp::TestTaskOMP test_task_omp(task_data_omp);
+  ASSERT_TRUE(test_task_omp.Validation());
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  ASSERT_EQ(output_result.size(), expected_result.size());
+  EXPECT_EQ(output_result[0].first, expected_result[0].first);
+  EXPECT_EQ(output_result[0].second, expected_result[0].second);
+}
+
+TEST(KapustinJarvAlgOMPTest, CollinearPoints2) {
+  std::vector<std::pair<int, int>> input_points = {{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}};
+  std::vector<std::pair<int, int>> expected_result = {{0, 0}, {4, 4}};
+  std::vector<std::pair<int, int>> output_result(expected_result.size());
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_points.data()));
+  task_data_omp->inputs_count.emplace_back(input_points.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(output_result.data()));
+  task_data_omp->outputs_count.emplace_back(output_result.size());
+
+  kapustin_i_jarv_alg_omp::TestTaskOMP test_task_omp(task_data_omp);
+
+  ASSERT_TRUE(test_task_omp.Validation());
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  EXPECT_EQ(output_result.size(), expected_result.size());
+  for (size_t i = 0; i < expected_result.size(); ++i) {
+    EXPECT_EQ(expected_result[i], output_result[i]);
+  }
+}
+
+TEST(KapustinJarvAlgOMPTest, TwoPoints) {
+  std::vector<std::pair<int, int>> input_points = {{0, 0}, {4, 4}};
+  std::vector<std::pair<int, int>> expected_result = {{0, 0}, {4, 4}};
+  std::vector<std::pair<int, int>> output_result(expected_result.size());
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_points.data()));
+  task_data_omp->inputs_count.emplace_back(input_points.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(output_result.data()));
+  task_data_omp->outputs_count.emplace_back(output_result.size());
+
+  kapustin_i_jarv_alg_omp::TestTaskOMP test_task_omp(task_data_omp);
+  ASSERT_TRUE(test_task_omp.Validation());
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  ASSERT_EQ(output_result.size(), expected_result.size());
+  EXPECT_EQ(output_result[0].first, expected_result[0].first);
+  EXPECT_EQ(output_result[0].second, expected_result[0].second);
+  EXPECT_EQ(output_result[1].first, expected_result[1].first);
+  EXPECT_EQ(output_result[1].second, expected_result[1].second);
+}
+
+TEST(KapustinJarvAlgOMPTest, Circle) {
+  std::vector<std::pair<int, int>> input_points = {{0, 5},  {3, 4},   {4, 3},   {5, 0},  {4, -3}, {3, -4},
+                                                   {0, -5}, {-3, -4}, {-4, -3}, {-5, 0}, {-4, 3}, {-3, 4}};
+  std::vector<std::pair<int, int>> expected_result = {{-5, 0}, {-4, -3}, {-3, -4}, {0, -5}, {3, -4}, {4, -3},
+                                                      {5, 0},  {4, 3},   {3, 4},   {0, 5},  {-3, 4}, {-4, 3}};
+  std::vector<std::pair<int, int>> output_result(expected_result.size());
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_points.data()));
+  task_data_omp->inputs_count.emplace_back(input_points.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(output_result.data()));
+  task_data_omp->outputs_count.emplace_back(output_result.size());
+
+  kapustin_i_jarv_alg_omp::TestTaskOMP test_task_omp(task_data_omp);
+  ASSERT_TRUE(test_task_omp.Validation());
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  for (size_t i = 0; i < expected_result.size(); ++i) {
+    EXPECT_EQ(expected_result[i].first, output_result[i].first);
+    EXPECT_EQ(expected_result[i].second, output_result[i].second);
+  }
+}
+
+TEST(KapustinJarvAlgOMPTest, Star4Points) {
+  std::vector<std::pair<int, int>> input_points = {{0, 5},   {3, 2},  {5, 0},  {3, -2}, {0, -5},
+                                                   {-3, -2}, {-5, 0}, {-3, 2}, {0, 0}};
+  std::vector<std::pair<int, int>> expected_result = {{-5, 0}, {0, -5}, {5, 0}, {0, 5}};
+  std::vector<std::pair<int, int>> output_result(expected_result.size());
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_points.data()));
+  task_data_omp->inputs_count.emplace_back(input_points.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(output_result.data()));
+  task_data_omp->outputs_count.emplace_back(output_result.size());
+
+  kapustin_i_jarv_alg_omp::TestTaskOMP test_task_omp(task_data_omp);
+  ASSERT_TRUE(test_task_omp.Validation());
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  for (size_t i = 0; i < expected_result.size(); ++i) {
+    EXPECT_EQ(expected_result[i].first, output_result[i].first);
+    EXPECT_EQ(expected_result[i].second, output_result[i].second);
+  }
+}
+
+TEST(KapustinJarvAlgOMPTest, CollinearPoints) {
+  std::vector<std::pair<int, int>> input_points = {{0, 0}, {5, 0}, {10, 0}, {15, 0}, {20, 0}};
+  std::vector<std::pair<int, int>> expected_result = {{0, 0}, {20, 0}};
+  std::vector<std::pair<int, int>> output_result(expected_result.size());
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_points.data()));
+  task_data_omp->inputs_count.emplace_back(input_points.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(output_result.data()));
+  task_data_omp->outputs_count.emplace_back(output_result.size());
+
+  kapustin_i_jarv_alg_omp::TestTaskOMP test_task_omp(task_data_omp);
+  ASSERT_TRUE(test_task_omp.Validation());
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  for (size_t i = 0; i < expected_result.size(); ++i) {
+    EXPECT_EQ(expected_result[i].first, output_result[i].first);
+    EXPECT_EQ(expected_result[i].second, output_result[i].second);
+  }
+}

--- a/tasks/omp/kapustin_i_jarv_alg/include/ops_omp.hpp
+++ b/tasks/omp/kapustin_i_jarv_alg/include/ops_omp.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kapustin_i_jarv_alg_omp {
+
+class TestTaskOMP : public ppc::core::Task {
+ public:
+  explicit TestTaskOMP(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<std::pair<int, int>> input_;
+  std::vector<std::pair<int, int>> output_;
+  std::pair<int, int> current_point_;
+  std::pair<int, int> next_point_;
+  size_t leftmost_index_;
+
+  [[nodiscard]] static int Orientation(const std::pair<int, int>& p, const std::pair<int, int>& q,
+                                       const std::pair<int, int>& r);
+  [[nodiscard]] static int CalculateDistance(const std::pair<int, int>& p1, const std::pair<int, int>& p2);
+};
+
+}  // namespace kapustin_i_jarv_alg_omp

--- a/tasks/omp/kapustin_i_jarv_alg/include/ops_omp.hpp
+++ b/tasks/omp/kapustin_i_jarv_alg/include/ops_omp.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <utility>
 #include <vector>
 

--- a/tasks/omp/kapustin_i_jarv_alg/include/ops_omp.hpp
+++ b/tasks/omp/kapustin_i_jarv_alg/include/ops_omp.hpp
@@ -22,7 +22,7 @@ class TestTaskOMP : public ppc::core::Task {
   std::vector<std::pair<int, int>> output_;
   std::pair<int, int> current_point_;
   std::pair<int, int> next_point_;
-  size_t leftmost_index_;
+  int leftmost_index_;
 
   [[nodiscard]] static int Orientation(const std::pair<int, int>& p, const std::pair<int, int>& q,
                                        const std::pair<int, int>& r);

--- a/tasks/omp/kapustin_i_jarv_alg/include/ops_omp.hpp
+++ b/tasks/omp/kapustin_i_jarv_alg/include/ops_omp.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cstddef>
 #include <utility>
 #include <vector>
 
@@ -22,7 +21,7 @@ class TestTaskOMP : public ppc::core::Task {
   std::vector<std::pair<int, int>> output_;
   std::pair<int, int> current_point_;
   std::pair<int, int> next_point_;
-  int leftmost_index_;
+  size_t leftmost_index_;
 
   [[nodiscard]] static int Orientation(const std::pair<int, int>& p, const std::pair<int, int>& q,
                                        const std::pair<int, int>& r);

--- a/tasks/omp/kapustin_i_jarv_alg/perf_tests/main.cpp
+++ b/tasks/omp/kapustin_i_jarv_alg/perf_tests/main.cpp
@@ -1,0 +1,104 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "omp/kapustin_i_jarv_alg/include/ops_omp.hpp" 
+
+TEST(kapustin_i_jarv_alg_omp, test_pipeline_run) {
+  constexpr int kCount = 10000000;
+
+  std::vector<std::pair<int, int>> expected_result = {{0, 0}, {1000, 0}, {1000, 1000}, {0, 1000}};
+
+  std::vector<std::pair<int, int>> input_points(kCount, {500, 500});
+  input_points[0] = {0, 0};
+  input_points[1] = {1000, 0};
+  input_points[2] = {1000, 1000};
+  input_points[3] = {0, 1000};
+
+  std::vector<std::pair<int, int>> output_result(kCount);
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_points.data()));
+  task_data_omp->inputs_count.emplace_back(input_points.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(output_result.data()));
+  task_data_omp->outputs_count.emplace_back(output_result.size());
+
+  auto test_task_omp = std::make_shared<kapustin_i_jarv_alg_omp::TestTaskOMP>(task_data_omp);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  output_result.resize(expected_result.size());
+
+  ASSERT_EQ(output_result.size(), expected_result.size());
+  for (size_t i = 0; i < expected_result.size(); ++i) {
+    EXPECT_EQ(output_result[i], expected_result[i]);
+  }
+}
+
+TEST(kapustin_i_jarv_alg_omp, test_task_run) {
+  constexpr int kCount = 10000000;
+
+  std::vector<std::pair<int, int>> input_points(kCount, {500, 500});
+
+  input_points[0] = {0, 0};
+  input_points[1] = {1000, 0};
+  input_points[2] = {1000, 1000};
+  input_points[3] = {0, 1000};
+
+  for (int i = 4; i < kCount; ++i) {
+    input_points[i] = {500, 500};
+  }
+
+  std::vector<std::pair<int, int>> output_result(4);
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input_points.data()));
+  task_data_omp->inputs_count.emplace_back(input_points.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(output_result.data()));
+  task_data_omp->outputs_count.emplace_back(output_result.size());
+
+  auto test_task_omp = std::make_shared<kapustin_i_jarv_alg_omp::TestTaskOMP>(task_data_omp);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  std::vector<std::pair<int, int>> expected_result = {{0, 0}, {1000, 0}, {1000, 1000}, {0, 1000}};
+
+  EXPECT_EQ(output_result.size(), expected_result.size());
+  for (size_t i = 0; i < expected_result.size(); ++i) {
+    EXPECT_EQ(output_result[i], expected_result[i]);
+  }
+}

--- a/tasks/omp/kapustin_i_jarv_alg/perf_tests/main.cpp
+++ b/tasks/omp/kapustin_i_jarv_alg/perf_tests/main.cpp
@@ -10,7 +10,7 @@
 
 #include "core/perf/include/perf.hpp"
 #include "core/task/include/task.hpp"
-#include "omp/kapustin_i_jarv_alg/include/ops_omp.hpp" 
+#include "omp/kapustin_i_jarv_alg/include/ops_omp.hpp"
 
 TEST(kapustin_i_jarv_alg_omp, test_pipeline_run) {
   constexpr int kCount = 10000000;

--- a/tasks/omp/kapustin_i_jarv_alg/src/ops_omp.cpp
+++ b/tasks/omp/kapustin_i_jarv_alg/src/ops_omp.cpp
@@ -41,9 +41,7 @@ bool kapustin_i_jarv_alg_omp::TestTaskOMP::PreProcessingImpl() {
   return true;
 }
 
-bool kapustin_i_jarv_alg_omp::TestTaskOMP::ValidationImpl() { 
-    return !task_data->inputs.empty();
-}
+bool kapustin_i_jarv_alg_omp::TestTaskOMP::ValidationImpl() { return !task_data->inputs.empty(); }
 
 bool kapustin_i_jarv_alg_omp::TestTaskOMP::RunImpl() {
   std::pair<int, int> start_point = current_point_;
@@ -70,10 +68,9 @@ bool kapustin_i_jarv_alg_omp::TestTaskOMP::RunImpl() {
           int dist_next = CalculateDistance(input_[local_next], input_[current_index]);
           int dist_i = CalculateDistance(input_[i], input_[current_index]);
           if (dist_i > dist_next) {
-            local_next = i; 
+            local_next = i;
           }
-        }
-        else if (orientation > 0) {
+        } else if (orientation > 0) {
           local_next = i;
         }
       }

--- a/tasks/omp/kapustin_i_jarv_alg/src/ops_omp.cpp
+++ b/tasks/omp/kapustin_i_jarv_alg/src/ops_omp.cpp
@@ -30,7 +30,7 @@ bool kapustin_i_jarv_alg_omp::TestTaskOMP::PreProcessingImpl() {
   input_ = points;
 
   leftmost_index_ = 0;
-  for (size_t i = 1; i < input_.size(); ++i) {
+  for (int i = 1; i < input_.size(); ++i) {
     if (input_[i].first < input_[leftmost_index_].first) {
       leftmost_index_ = i;
     }
@@ -45,19 +45,19 @@ bool kapustin_i_jarv_alg_omp::TestTaskOMP::ValidationImpl() { return !task_data-
 
 bool kapustin_i_jarv_alg_omp::TestTaskOMP::RunImpl() {
   std::pair<int, int> start_point = current_point_;
-  int current_index = leftmost_index_;
+  size_t current_index = leftmost_index_;
   output_.clear();
   output_.push_back(start_point);
 
   do {
-    int next_index = (current_index + 1) % input_.size();
+    size_t next_index = (current_index + 1) % input_.size();
 
 #pragma omp parallel
     {
-      int local_next = next_index;
+      size_t local_next = next_index;
 
 #pragma omp for nowait
-      for (int i = 0; i < static_cast<int>(input_.size()); ++i) {
+      for (size_t i = 0; i < input_.size(); ++i) {
         if (i == current_index) {
           continue;
         }

--- a/tasks/omp/kapustin_i_jarv_alg/src/ops_omp.cpp
+++ b/tasks/omp/kapustin_i_jarv_alg/src/ops_omp.cpp
@@ -103,7 +103,6 @@ bool kapustin_i_jarv_alg_omp::TestTaskOMP::RunImpl() {
   return true;
 }
 
-
 bool kapustin_i_jarv_alg_omp::TestTaskOMP::PostProcessingImpl() {
   auto* result_ptr = reinterpret_cast<std::pair<int, int>*>(task_data->outputs[0]);
   std::ranges::copy(output_, result_ptr);

--- a/tasks/omp/kapustin_i_jarv_alg/src/ops_omp.cpp
+++ b/tasks/omp/kapustin_i_jarv_alg/src/ops_omp.cpp
@@ -54,11 +54,11 @@ bool kapustin_i_jarv_alg_omp::TestTaskOMP::RunImpl() {
 
 #pragma omp parallel
     {
-      size_t local_next = next_index;
+      int local_next = static_cast<int>(next_index);
 
 #pragma omp for nowait
-      for (size_t i = 0; i < input_.size(); ++i) {
-        if (i == current_index) {
+      for (int i = 0; i < static_cast<int>(input_.size()); ++i) {
+        if (static_cast<size_t>(i) == current_index) {
           continue;
         }
 
@@ -79,12 +79,12 @@ bool kapustin_i_jarv_alg_omp::TestTaskOMP::RunImpl() {
       {
         int orientation = Orientation(input_[current_index], input_[next_index], input_[local_next]);
         if (orientation > 0) {
-          next_index = local_next;
+          next_index = static_cast<size_t>(local_next);
         } else if (orientation == 0) {
           int dist_next = CalculateDistance(input_[next_index], input_[current_index]);
           int dist_local = CalculateDistance(input_[local_next], input_[current_index]);
           if (dist_local > dist_next) {
-            next_index = local_next;
+            next_index = static_cast<size_t>(local_next);
           }
         }
       }
@@ -102,6 +102,7 @@ bool kapustin_i_jarv_alg_omp::TestTaskOMP::RunImpl() {
 
   return true;
 }
+
 
 bool kapustin_i_jarv_alg_omp::TestTaskOMP::PostProcessingImpl() {
   auto* result_ptr = reinterpret_cast<std::pair<int, int>*>(task_data->outputs[0]);

--- a/tasks/omp/kapustin_i_jarv_alg/src/ops_omp.cpp
+++ b/tasks/omp/kapustin_i_jarv_alg/src/ops_omp.cpp
@@ -1,0 +1,113 @@
+#include "omp/kapustin_i_jarv_alg/include/ops_omp.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+int kapustin_i_jarv_alg_omp::TestTaskOMP::CalculateDistance(const std::pair<int, int>& p1,
+                                                            const std::pair<int, int>& p2) {
+  return static_cast<int>(std::pow(p1.first - p2.first, 2) + std::pow(p1.second - p2.second, 2));
+}
+int kapustin_i_jarv_alg_omp::TestTaskOMP::Orientation(const std::pair<int, int>& p, const std::pair<int, int>& q,
+                                                      const std::pair<int, int>& r) {
+  int val = ((q.second - p.second) * (r.first - q.first)) - ((q.first - p.first) * (r.second - q.second));
+  if (val == 0) {
+    return 0;
+  }
+  return (val > 0) ? 1 : -1;
+}
+
+bool kapustin_i_jarv_alg_omp::TestTaskOMP::PreProcessingImpl() {
+  std::vector<std::pair<int, int>> points;
+
+  for (size_t i = 0; i < task_data->inputs.size(); ++i) {
+    auto* data = reinterpret_cast<std::pair<int, int>*>(task_data->inputs[i]);
+    size_t count = task_data->inputs_count[i];
+    points.assign(data, data + count);
+  }
+  input_ = points;
+
+  leftmost_index_ = 0;
+  for (size_t i = 1; i < input_.size(); ++i) {
+    if (input_[i].first < input_[leftmost_index_].first) {
+      leftmost_index_ = i;
+    }
+  }
+
+  current_point_ = input_[leftmost_index_];
+
+  return true;
+}
+
+bool kapustin_i_jarv_alg_omp::TestTaskOMP::ValidationImpl() { 
+    return !task_data->inputs.empty();
+}
+
+bool kapustin_i_jarv_alg_omp::TestTaskOMP::RunImpl() {
+  std::pair<int, int> start_point = current_point_;
+  size_t current_index = leftmost_index_;
+  output_.clear();
+  output_.push_back(start_point);
+
+  do {
+    size_t next_index = (current_index + 1) % input_.size();
+
+#pragma omp parallel
+    {
+      size_t local_next = next_index;
+
+#pragma omp for nowait
+      for (int i = 0; i < static_cast<int>(input_.size()); ++i) {
+        if (i == current_index) {
+          continue;
+        }
+
+        int orientation = Orientation(input_[current_index], input_[local_next], input_[i]);
+
+        if (orientation == 0) {
+          int dist_next = CalculateDistance(input_[local_next], input_[current_index]);
+          int dist_i = CalculateDistance(input_[i], input_[current_index]);
+          if (dist_i > dist_next) {
+            local_next = i; 
+          }
+        }
+        else if (orientation > 0) {
+          local_next = i;
+        }
+      }
+
+#pragma omp critical
+      {
+        int orientation = Orientation(input_[current_index], input_[next_index], input_[local_next]);
+        if (orientation > 0) {
+          next_index = local_next;
+        } else if (orientation == 0) {
+          int dist_next = CalculateDistance(input_[next_index], input_[current_index]);
+          int dist_local = CalculateDistance(input_[local_next], input_[current_index]);
+          if (dist_local > dist_next) {
+            next_index = local_next;
+          }
+        }
+      }
+    }
+
+    if (!output_.empty() && input_[next_index] == output_.front()) {
+      break;
+    }
+
+    current_point_ = input_[next_index];
+    output_.push_back(current_point_);
+    current_index = next_index;
+
+  } while (current_point_ != start_point);
+
+  return true;
+}
+
+bool kapustin_i_jarv_alg_omp::TestTaskOMP::PostProcessingImpl() {
+  auto* result_ptr = reinterpret_cast<std::pair<int, int>*>(task_data->outputs[0]);
+  std::ranges::copy(output_, result_ptr);
+  return true;
+}

--- a/tasks/omp/kapustin_i_jarv_alg/src/ops_omp.cpp
+++ b/tasks/omp/kapustin_i_jarv_alg/src/ops_omp.cpp
@@ -50,11 +50,11 @@ bool kapustin_i_jarv_alg_omp::TestTaskOMP::RunImpl() {
   output_.push_back(start_point);
 
   do {
-    size_t next_index = (current_index + 1) % input_.size();
+    int next_index = (current_index + 1) % input_.size();
 
 #pragma omp parallel
     {
-      size_t local_next = next_index;
+      int local_next = next_index;
 
 #pragma omp for nowait
       for (int i = 0; i < static_cast<int>(input_.size()); ++i) {

--- a/tasks/omp/kapustin_i_jarv_alg/src/ops_omp.cpp
+++ b/tasks/omp/kapustin_i_jarv_alg/src/ops_omp.cpp
@@ -30,7 +30,7 @@ bool kapustin_i_jarv_alg_omp::TestTaskOMP::PreProcessingImpl() {
   input_ = points;
 
   leftmost_index_ = 0;
-  for (int i = 1; i < input_.size(); ++i) {
+  for (size_t i = 1; i < input_.size(); ++i) {
     if (input_[i].first < input_[leftmost_index_].first) {
       leftmost_index_ = i;
     }

--- a/tasks/omp/kapustin_i_jarv_alg/src/ops_omp.cpp
+++ b/tasks/omp/kapustin_i_jarv_alg/src/ops_omp.cpp
@@ -45,7 +45,7 @@ bool kapustin_i_jarv_alg_omp::TestTaskOMP::ValidationImpl() { return !task_data-
 
 bool kapustin_i_jarv_alg_omp::TestTaskOMP::RunImpl() {
   std::pair<int, int> start_point = current_point_;
-  size_t current_index = leftmost_index_;
+  int current_index = leftmost_index_;
   output_.clear();
   output_.push_back(start_point);
 


### PR DESCRIPTION
Основные этапы работы:
1)Предварительная обработка (PreProcessing):
-Загружает входные точки из task_data.
-Находит самую левую точку (стартовую точку для алгоритма).
2)Параллельный поиск выпуклой оболочки (RunImpl):
-Использует идею алгоритма Джарвиса: на каждом шаге выбирается точка, которая образует наименьший угол с текущей точкой.
-OpenMP (#pragma omp parallel) распараллеливает перебор точек, ускоряя поиск следующей точки оболочки.
-В критической секции (#pragma omp critical) корректируется глобально лучший кандидат на следующую точку.
-Процесс повторяется, пока алгоритм не вернётся в начальную точку, замыкая оболочку.
3)Постобработка (PostProcessing):
-Копирует полученную выпуклую оболочку в выходные данные task_data.