### PR TITLE
Громов Алексей. Вариант 2. Технология OMP. Умножение плотных матриц. Элементы типа double. Блочная схема, алгоритм Фокса.

### DIFF
--- a/tasks/omp/gromov_a_fox_algorithm/func_tests/main.cpp
+++ b/tasks/omp/gromov_a_fox_algorithm/func_tests/main.cpp
@@ -5,10 +5,25 @@
 #include <cstdint>
 #include <iterator>
 #include <memory>
+#include <random>
 #include <vector>
 
 #include "core/task/include/task.hpp"
 #include "omp/gromov_a_fox_algorithm/include/ops_omp.hpp"
+
+namespace {
+std::vector<double> GenerateRandomMatrix(size_t n, double min_val, double max_val) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<> dis(min_val, max_val);
+
+  std::vector<double> matrix(n * n);
+  for (size_t i = 0; i < n * n; ++i) {
+    matrix[i] = dis(gen);
+  }
+  return matrix;
+}
+}  // namespace
 
 TEST(gromov_a_fox_algorithm_omp, test_4x4) {
   constexpr size_t kN = 4;
@@ -154,6 +169,83 @@ TEST(gromov_a_fox_algorithm_omp, identity_times_arbitrary_3x3) {
   std::vector<double> b = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0};
   std::vector<double> out(kN * kN, 0.0);
   std::vector<double> expected = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0};
+
+  std::vector<double> input;
+  input.reserve(a.size() + b.size());
+  std::ranges::copy(a, std::back_inserter(input));
+  std::ranges::copy(b, std::back_inserter(input));
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(input.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  gromov_a_fox_algorithm_omp::TestTaskOpenMP test_task_omp(task_data_omp);
+  ASSERT_TRUE(test_task_omp.Validation());
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  for (size_t i = 0; i < out.size(); ++i) {
+    EXPECT_NEAR(out[i], expected[i], 1e-9);
+  }
+}
+
+TEST(gromov_a_fox_algorithm_omp, test_random_6x6) {
+  constexpr size_t kN = 6;
+
+  std::vector<double> a = GenerateRandomMatrix(kN, -10.0, 10.0);
+  std::vector<double> b = GenerateRandomMatrix(kN, -10.0, 10.0);
+  std::vector<double> out(kN * kN, 0.0);
+
+  std::vector<double> expected(kN * kN, 0.0);
+  for (size_t i = 0; i < kN; ++i) {
+    for (size_t j = 0; j < kN; ++j) {
+      for (size_t k = 0; k < kN; ++k) {
+        expected[(i * kN) + j] += a[(i * kN) + k] * b[(k * kN) + j];
+      }
+    }
+  }
+
+  std::vector<double> input;
+  input.reserve(a.size() + b.size());
+  std::ranges::copy(a, std::back_inserter(input));
+  std::ranges::copy(b, std::back_inserter(input));
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(input.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  gromov_a_fox_algorithm_omp::TestTaskOpenMP test_task_omp(task_data_omp);
+  ASSERT_TRUE(test_task_omp.Validation());
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  for (size_t i = 0; i < out.size(); ++i) {
+    EXPECT_NEAR(out[i], expected[i], 1e-9);
+  }
+}
+
+TEST(gromov_a_fox_algorithm_omp, test_negative_numbers_4x4) {
+  constexpr size_t kN = 4;
+
+  std::vector<double> a = {-1.0, -2.0,  -3.0,  -4.0,  -5.0,  -6.0,  -7.0,  -8.0,
+                           -9.0, -10.0, -11.0, -12.0, -13.0, -14.0, -15.0, -16.0};
+  std::vector<double> b = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0};
+  std::vector<double> out(kN * kN, 0.0);
+
+  std::vector<double> expected(kN * kN, 0.0);
+  for (size_t i = 0; i < kN; ++i) {
+    for (size_t j = 0; j < kN; ++j) {
+      for (size_t k = 0; k < kN; ++k) {
+        expected[(i * kN) + j] += a[(i * kN) + k] * b[(k * kN) + j];
+      }
+    }
+  }
 
   std::vector<double> input;
   input.reserve(a.size() + b.size());

--- a/tasks/omp/gromov_a_fox_algorithm/func_tests/main.cpp
+++ b/tasks/omp/gromov_a_fox_algorithm/func_tests/main.cpp
@@ -5,7 +5,6 @@
 #include <cstdint>
 #include <iterator>
 #include <memory>
-#include <random>
 #include <vector>
 
 #include "core/task/include/task.hpp"

--- a/tasks/omp/gromov_a_fox_algorithm/func_tests/main.cpp
+++ b/tasks/omp/gromov_a_fox_algorithm/func_tests/main.cpp
@@ -1,0 +1,179 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "omp/gromov_a_fox_algorithm/include/ops_omp.hpp"
+
+TEST(gromov_a_fox_algorithm_omp, test_4x4) {
+  constexpr size_t kN = 4;
+
+  std::vector<double> a = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0};
+  std::vector<double> b = {16.0, 15.0, 14.0, 13.0, 12.0, 11.0, 10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0};
+  std::vector<double> out(kN * kN, 0.0);
+
+  std::vector<double> expected = {80.0,  70.0,  60.0,  50.0,  240.0, 214.0, 188.0, 162.0,
+                                  400.0, 358.0, 316.0, 274.0, 560.0, 502.0, 444.0, 386.0};
+
+  std::vector<double> input;
+  input.reserve(a.size() + b.size());
+  std::ranges::copy(a, std::back_inserter(input));
+  std::ranges::copy(b, std::back_inserter(input));
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(input.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  gromov_a_fox_algorithm_omp::TestTaskOpenMP test_task_omp(task_data_omp);
+  ASSERT_TRUE(test_task_omp.Validation());
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  for (size_t i = 0; i < out.size(); ++i) {
+    EXPECT_NEAR(out[i], expected[i], 1e-9);
+  }
+}
+
+TEST(gromov_a_fox_algorithm_omp, test_50x50) {
+  constexpr size_t kN = 50;
+
+  std::vector<double> a(kN * kN, 0.0);
+  std::vector<double> b(kN * kN, 0.0);
+  std::vector<double> out(kN * kN, 0.0);
+
+  for (size_t i = 0; i < kN; ++i) {
+    for (size_t j = 0; j < kN; ++j) {
+      a[(i * kN) + j] = static_cast<double>((i * kN) + j + 1);
+      b[(i * kN) + j] = static_cast<double>((kN * kN) - (i * kN + j));
+    }
+  }
+
+  std::vector<double> input;
+  input.reserve(a.size() + b.size());
+  std::ranges::copy(a, std::back_inserter(input));
+  std::ranges::copy(b, std::back_inserter(input));
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(input.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  gromov_a_fox_algorithm_omp::TestTaskOpenMP test_task_omp(task_data_omp);
+  ASSERT_TRUE(test_task_omp.Validation());
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  std::vector<double> expected(kN * kN, 0.0);
+  for (size_t i = 0; i < kN; ++i) {
+    for (size_t j = 0; j < kN; ++j) {
+      for (size_t k = 0; k < kN; ++k) {
+        expected[(i * kN) + j] += a[(i * kN) + k] * b[(k * kN) + j];
+      }
+    }
+  }
+
+  for (size_t i = 0; i < out.size(); ++i) {
+    EXPECT_NEAR(out[i], expected[i], 1e-9);
+  }
+}
+
+TEST(gromov_a_fox_algorithm_omp, identity_3x3) {
+  constexpr size_t kN = 3;
+
+  std::vector<double> a = {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
+  std::vector<double> b = {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
+  std::vector<double> out(kN * kN, 0.0);
+
+  std::vector<double> expected = {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
+
+  std::vector<double> input;
+  input.reserve(a.size() + b.size());
+  std::ranges::copy(a, std::back_inserter(input));
+  std::ranges::copy(b, std::back_inserter(input));
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(input.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  gromov_a_fox_algorithm_omp::TestTaskOpenMP test_task_omp(task_data_omp);
+  ASSERT_TRUE(test_task_omp.Validation());
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  for (size_t i = 0; i < out.size(); ++i) {
+    EXPECT_NEAR(out[i], expected[i], 1e-9);
+  }
+}
+
+TEST(gromov_a_fox_algorithm_omp, test_run_small_matrix) {
+  constexpr size_t kN = 4;
+
+  std::vector<double> a(kN * kN, 1.0);
+  std::vector<double> b(kN * kN, 1.0);
+  std::vector<double> out(kN * kN, 0.0);
+
+  std::vector<double> input;
+  input.reserve(a.size() + b.size());
+  std::ranges::copy(a, std::back_inserter(input));
+  std::ranges::copy(b, std::back_inserter(input));
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(input.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  gromov_a_fox_algorithm_omp::TestTaskOpenMP test_task_omp(task_data_omp);
+  ASSERT_TRUE(test_task_omp.Validation());
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  std::vector<double> expected(kN * kN, static_cast<double>(kN));
+  for (size_t i = 0; i < out.size(); ++i) {
+    EXPECT_NEAR(out[i], expected[i], 1e-9);
+  }
+}
+
+TEST(gromov_a_fox_algorithm_omp, identity_times_arbitrary_3x3) {
+  constexpr size_t kN = 3;
+  std::vector<double> a = {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
+  std::vector<double> b = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0};
+  std::vector<double> out(kN * kN, 0.0);
+  std::vector<double> expected = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0};
+
+  std::vector<double> input;
+  input.reserve(a.size() + b.size());
+  std::ranges::copy(a, std::back_inserter(input));
+  std::ranges::copy(b, std::back_inserter(input));
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(input.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  gromov_a_fox_algorithm_omp::TestTaskOpenMP test_task_omp(task_data_omp);
+  ASSERT_TRUE(test_task_omp.Validation());
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  for (size_t i = 0; i < out.size(); ++i) {
+    EXPECT_NEAR(out[i], expected[i], 1e-9);
+  }
+}

--- a/tasks/omp/gromov_a_fox_algorithm/include/ops_omp.hpp
+++ b/tasks/omp/gromov_a_fox_algorithm/include/ops_omp.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace gromov_a_fox_algorithm_omp {
+
+class TestTaskOpenMP : public ppc::core::Task {
+ public:
+  explicit TestTaskOpenMP(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<double> A_, B_, output_;
+  int n_;
+  int block_size_;
+};
+
+}  // namespace gromov_a_fox_algorithm_omp

--- a/tasks/omp/gromov_a_fox_algorithm/perf_tests/main.cpp
+++ b/tasks/omp/gromov_a_fox_algorithm/perf_tests/main.cpp
@@ -1,0 +1,121 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "omp/gromov_a_fox_algorithm/include/ops_omp.hpp"
+
+TEST(gromov_a_fox_algorithm_omp, test_pipeline_run) {
+  constexpr size_t kN = 400;
+
+  std::vector<double> a(kN * kN, 0.0);
+  std::vector<double> b(kN * kN, 0.0);
+  std::vector<double> out(kN * kN, 0.0);
+
+  for (size_t i = 0; i < kN; ++i) {
+    for (size_t j = 0; j < kN; ++j) {
+      a[(i * kN) + j] = static_cast<double>(i + j + 1);
+      b[(i * kN) + j] = static_cast<double>(kN - i + j + 1);
+    }
+  }
+
+  std::vector<double> input;
+  input.insert(input.end(), a.begin(), a.end());
+  input.insert(input.end(), b.begin(), b.end());
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(input.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  auto test_task_omp = std::make_shared<gromov_a_fox_algorithm_omp::TestTaskOpenMP>(task_data_omp);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  std::vector<double> expected(kN * kN, 0.0);
+  for (size_t i = 0; i < kN; ++i) {
+    for (size_t j = 0; j < kN; ++j) {
+      for (size_t k = 0; k < kN; ++k) {
+        expected[(i * kN) + j] += a[(i * kN) + k] * b[(k * kN) + j];
+      }
+    }
+  }
+
+  for (size_t i = 0; i < out.size(); ++i) {
+    EXPECT_NEAR(out[i], expected[i], 1e-9);
+  }
+}
+
+TEST(gromov_a_fox_algorithm_omp, test_task_run) {
+  constexpr size_t kN = 400;
+
+  std::vector<double> a(kN * kN, 0.0);
+  std::vector<double> b(kN * kN, 0.0);
+  std::vector<double> out(kN * kN, 0.0);
+
+  for (size_t i = 0; i < kN; ++i) {
+    for (size_t j = 0; j < kN; ++j) {
+      a[(i * kN) + j] = static_cast<double>(i + j + 1);
+      b[(i * kN) + j] = static_cast<double>(kN - i + j + 1);
+    }
+  }
+
+  std::vector<double> input;
+  input.insert(input.end(), a.begin(), a.end());
+  input.insert(input.end(), b.begin(), b.end());
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(input.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  auto test_task_omp = std::make_shared<gromov_a_fox_algorithm_omp::TestTaskOpenMP>(task_data_omp);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  std::vector<double> expected(kN * kN, 0.0);
+  for (size_t i = 0; i < kN; ++i) {
+    for (size_t j = 0; j < kN; ++j) {
+      for (size_t k = 0; k < kN; ++k) {
+        expected[(i * kN) + j] += a[(i * kN) + k] * b[(k * kN) + j];
+      }
+    }
+  }
+
+  for (size_t i = 0; i < out.size(); ++i) {
+    EXPECT_NEAR(out[i], expected[i], 1e-9);
+  }
+}

--- a/tasks/omp/gromov_a_fox_algorithm/perf_tests/main.cpp
+++ b/tasks/omp/gromov_a_fox_algorithm/perf_tests/main.cpp
@@ -11,7 +11,7 @@
 #include "omp/gromov_a_fox_algorithm/include/ops_omp.hpp"
 
 TEST(gromov_a_fox_algorithm_omp, test_pipeline_run) {
-  constexpr size_t kN = 400;
+  constexpr size_t kN = 450;
 
   std::vector<double> a(kN * kN, 0.0);
   std::vector<double> b(kN * kN, 0.0);
@@ -66,7 +66,7 @@ TEST(gromov_a_fox_algorithm_omp, test_pipeline_run) {
 }
 
 TEST(gromov_a_fox_algorithm_omp, test_task_run) {
-  constexpr size_t kN = 400;
+  constexpr size_t kN = 450;
 
   std::vector<double> a(kN * kN, 0.0);
   std::vector<double> b(kN * kN, 0.0);

--- a/tasks/omp/gromov_a_fox_algorithm/perf_tests/main.cpp
+++ b/tasks/omp/gromov_a_fox_algorithm/perf_tests/main.cpp
@@ -11,7 +11,7 @@
 #include "omp/gromov_a_fox_algorithm/include/ops_omp.hpp"
 
 TEST(gromov_a_fox_algorithm_omp, test_pipeline_run) {
-  constexpr size_t kN = 450;
+  constexpr size_t kN = 400;
 
   std::vector<double> a(kN * kN, 0.0);
   std::vector<double> b(kN * kN, 0.0);
@@ -66,7 +66,7 @@ TEST(gromov_a_fox_algorithm_omp, test_pipeline_run) {
 }
 
 TEST(gromov_a_fox_algorithm_omp, test_task_run) {
-  constexpr size_t kN = 450;
+  constexpr size_t kN = 400;
 
   std::vector<double> a(kN * kN, 0.0);
   std::vector<double> b(kN * kN, 0.0);

--- a/tasks/omp/gromov_a_fox_algorithm/src/ops_omp.cpp
+++ b/tasks/omp/gromov_a_fox_algorithm/src/ops_omp.cpp
@@ -45,24 +45,23 @@ bool gromov_a_fox_algorithm_omp::TestTaskOpenMP::ValidationImpl() {
 }
 
 bool gromov_a_fox_algorithm_omp::TestTaskOpenMP::RunImpl() {
-  int num_blocks = (n_ + block_size_ - 1) / block_size_;  // Ceiling division to ensure all indices are covered
+  int num_blocks = (n_ + block_size_ - 1) / block_size_;
 
-  // Create local pointers to member variables to use in OpenMP
-  std::vector<double>& A_ref = A_;
-  std::vector<double>& B_ref = B_;
+  std::vector<double>& a_ref = A_;
+  std::vector<double>& b_ref = B_;
   std::vector<double>& output_ref = output_;
   int n_ref = n_;
   int block_size_ref = block_size_;
 
   for (int stage = 0; stage < num_blocks; ++stage) {
-#pragma omp parallel for default(none) shared(A_ref, B_ref, output_ref, n_ref, block_size_ref, stage)
+#pragma omp parallel for default(none) shared(a_ref, b_ref, output_ref, n_ref, block_size_ref, stage)
     for (int i = 0; i < n_ref; i += block_size_ref) {
       for (int j = 0; j < n_ref; j += block_size_ref) {
         for (int bi = i; bi < i + block_size_ref && bi < n_ref; ++bi) {
           for (int bj = j; bj < j + block_size_ref && bj < n_ref; ++bj) {
             int start_k = stage * block_size_ref;
             for (int bk = start_k; bk < std::min((stage + 1) * block_size_ref, n_ref); ++bk) {
-              output_ref[(bi * n_ref) + bj] += A_ref[(bi * n_ref) + bk] * B_ref[(bk * n_ref) + bj];
+              output_ref[(bi * n_ref) + bj] += a_ref[(bi * n_ref) + bk] * b_ref[(bk * n_ref) + bj];
             }
           }
         }

--- a/tasks/omp/gromov_a_fox_algorithm/src/ops_omp.cpp
+++ b/tasks/omp/gromov_a_fox_algorithm/src/ops_omp.cpp
@@ -1,0 +1,78 @@
+#include "omp/gromov_a_fox_algorithm/include/ops_omp.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+bool gromov_a_fox_algorithm_omp::TestTaskOpenMP::PreProcessingImpl() {
+  unsigned int input_size = task_data->inputs_count[0];
+  if (input_size % 2 != 0) {
+    return false;
+  }
+
+  unsigned int matrix_size = input_size / 2;
+  auto* in_ptr = reinterpret_cast<double*>(task_data->inputs[0]);
+
+  A_ = std::vector<double>(in_ptr, in_ptr + matrix_size);
+  B_ = std::vector<double>(in_ptr + matrix_size, in_ptr + input_size);
+
+  unsigned int output_size = task_data->outputs_count[0];
+  output_ = std::vector<double>(output_size, 0.0);
+
+  n_ = static_cast<int>(std::sqrt(matrix_size));
+  if (n_ * n_ != static_cast<int>(matrix_size)) {
+    return false;
+  }
+
+  block_size_ = n_ / 2;
+  for (int i = 1; i <= n_; ++i) {
+    if (n_ % i == 0) {
+      block_size_ = i;
+      break;
+    }
+  }
+  return block_size_ > 0;
+}
+
+bool gromov_a_fox_algorithm_omp::TestTaskOpenMP::ValidationImpl() {
+  unsigned int input_size = task_data->inputs_count[0];
+  if (input_size % 2 != 0) {
+    return false;
+  }
+  unsigned int matrix_size = input_size / 2;
+  auto sqrt_matrix_size = static_cast<unsigned int>(std::sqrt(matrix_size));
+  return matrix_size == task_data->outputs_count[0] && sqrt_matrix_size * sqrt_matrix_size == matrix_size;
+}
+
+bool gromov_a_fox_algorithm_omp::TestTaskOpenMP::RunImpl() {
+  int num_blocks = (n_ + block_size_ - 1) / block_size_;  // Ceiling division to ensure all indices are covered
+
+  // Create local pointers to member variables to use in OpenMP
+  std::vector<double>& A_ref = A_;
+  std::vector<double>& B_ref = B_;
+  std::vector<double>& output_ref = output_;
+  int n_ref = n_;
+  int block_size_ref = block_size_;
+
+  for (int stage = 0; stage < num_blocks; ++stage) {
+#pragma omp parallel for default(none) shared(A_ref, B_ref, output_ref, n_ref, block_size_ref, stage)
+    for (int i = 0; i < n_ref; i += block_size_ref) {
+      for (int j = 0; j < n_ref; j += block_size_ref) {
+        for (int bi = i; bi < i + block_size_ref && bi < n_ref; ++bi) {
+          for (int bj = j; bj < j + block_size_ref && bj < n_ref; ++bj) {
+            int start_k = stage * block_size_ref;
+            for (int bk = start_k; bk < std::min((stage + 1) * block_size_ref, n_ref); ++bk) {
+              output_ref[(bi * n_ref) + bj] += A_ref[(bi * n_ref) + bk] * B_ref[(bk * n_ref) + bj];
+            }
+          }
+        }
+      }
+    }
+  }
+  return true;
+}
+
+bool gromov_a_fox_algorithm_omp::TestTaskOpenMP::PostProcessingImpl() {
+  std::ranges::copy(output_, reinterpret_cast<double*>(task_data->outputs[0]));
+  return true;
+}


### PR DESCRIPTION
`PreProcessingImpl()`
- Делит входные данные на две матрицы `𝐴` и `𝐵`
- Определяет размер матрицы 𝑛 и размер блока `block_size_`
- Проверяет, что матрица квадратная

`ValidationImpl():`
- Проверяет корректность входных данных: размеры должны быть чётными (две матрицы), сама матрица — квадратной

`RunImpl():`
- Делит матрицы на блоки размером `block_size_`
- Выполняет блочное умножение в несколько стадий с использованием OpenMP
- Использует три вычислительных цикла для обработки блоков: Внешний цикл по `i` параллелизуется через `#pragma omp parallel for default(none)`. Внутренние циклы по `bi`, `bj`, `bk` выполняются последовательно внутри каждого потока

`PostProcessingImpl():`
- Копирует результат из `output_` в выходной буфер