### PR TITLE
Ковальчук Александр. Вариант 15. Технология OMP.  Сортировка Шелла с простым слиянием

### DIFF
--- a/tasks/omp/kovalchuk_a_shell_sort_omp/func_tests/main.cpp
+++ b/tasks/omp/kovalchuk_a_shell_sort_omp/func_tests/main.cpp
@@ -1,0 +1,150 @@
+#include "core/task/include/task.hpp"
+#include "omp/kovalchuk_a_shell_sort_omp/include/ops_omp.hpp"
+#include <gtest/gtest.h>
+#include <memory>
+#include <vector>
+
+TEST(kovalchuk_a_shell_sort_omp, Test_EmptyArray) {
+  std::vector<int> input = {};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort_omp::ShellSortOMP>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  ASSERT_TRUE(output.empty());
+}
+
+TEST(kovalchuk_a_shell_sort_omp, Test_SingleElement) {
+  std::vector<int> input = {42};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort_omp::ShellSortOMP>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  ASSERT_EQ(input, output);
+}
+
+TEST(kovalchuk_a_shell_sort_omp, Test_ReverseSorted) {
+  std::vector<int> input = {9, 7, 5, 3, 1};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort_omp::ShellSortOMP>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  std::vector<int> expected = {1, 3, 5, 7, 9};
+  ASSERT_EQ(expected, output);
+}
+
+TEST(kovalchuk_a_shell_sort_omp, Test_Duplicates) {
+  std::vector<int> input = {5, 2, 5, 1, 2};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort_omp::ShellSortOMP>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  std::vector<int> expected = {1, 2, 2, 5, 5};
+  ASSERT_EQ(expected, output);
+}
+
+TEST(kovalchuk_a_shell_sort_omp, Test_NegativeNumbers) {
+  std::vector<int> input = {-5, 0, -3, 10, -1};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort_omp::ShellSortOMP>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  std::vector<int> expected = {-5, -3, -1, 0, 10};
+  ASSERT_EQ(expected, output);
+}
+
+TEST(kovalchuk_a_shell_sort_omp, Test_ExtremeValues) {
+  std::vector<int> input = {INT32_MIN, 0, INT32_MAX};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort_omp::ShellSortOMP>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  std::vector<int> expected = {INT32_MIN, 0, INT32_MAX};
+  ASSERT_EQ(expected, output);
+}
+
+TEST(kovalchuk_a_shell_sort_omp, Test_OddSizeArray) {
+  std::vector<int> input = {4, 1, 7, 2, 9};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort_omp::ShellSortOMP>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  std::vector<int> expected = {1, 2, 4, 7, 9};
+  ASSERT_EQ(expected, output);
+}

--- a/tasks/omp/kovalchuk_a_shell_sort_omp/include/ops_omp.hpp
+++ b/tasks/omp/kovalchuk_a_shell_sort_omp/include/ops_omp.hpp
@@ -1,0 +1,20 @@
+#pragma once
+#include "core/task/include/task.hpp"
+#include <vector>
+
+namespace kovalchuk_a_shell_sort_omp {
+
+class ShellSortOMP : public ppc::core::Task {
+public:
+  explicit ShellSortOMP(ppc::core::TaskDataPtr task_data);
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+private:
+  std::vector<int> input_;
+  void ShellSort();
+};
+
+} // namespace kovalchuk_a_shell_sort_omp

--- a/tasks/omp/kovalchuk_a_shell_sort_omp/perf_tests/main.cpp
+++ b/tasks/omp/kovalchuk_a_shell_sort_omp/perf_tests/main.cpp
@@ -1,0 +1,79 @@
+#include <chrono>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "omp/kovalchuk_a_shell_sort_omp/include/ops_omp.hpp"
+
+TEST(kovalchuk_a_shell_sort_omp, test_pipeline_run) {
+  constexpr int kCount = 1000000;
+
+  std::vector<int> in(kCount);
+  for (int i = 0; i < kCount; ++i) {
+    in[i] = kCount / 2 - i;
+  }
+  std::vector<int> out(kCount);
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  auto test_task =
+      std::make_shared<kovalchuk_a_shell_sort_omp::ShellSortOMP>(task_data_omp);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        current_time_point - t0)
+                        .count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}
+
+TEST(kovalchuk_a_shell_sort_omp, test_task_run) {
+  constexpr int kCount = 1000000;
+
+  std::vector<int> in(kCount);
+  for (int i = 0; i < kCount; ++i) {
+    in[i] = kCount / 2 - i;
+  }
+  std::vector<int> out(kCount);
+
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  auto test_task =
+      std::make_shared<kovalchuk_a_shell_sort_omp::ShellSortOMP>(task_data_omp);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        current_time_point - t0)
+                        .count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}

--- a/tasks/omp/kovalchuk_a_shell_sort_omp/src/ops_omp.cpp
+++ b/tasks/omp/kovalchuk_a_shell_sort_omp/src/ops_omp.cpp
@@ -1,0 +1,57 @@
+#include "omp/kovalchuk_a_shell_sort_omp/include/ops_omp.hpp"
+
+#include <omp.h>
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kovalchuk_a_shell_sort_omp {
+
+ShellSortOMP::ShellSortOMP(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+
+bool ShellSortOMP::PreProcessingImpl() {
+  auto* input_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
+  input_.assign(input_ptr, input_ptr + task_data->inputs_count[0]);
+  return true;
+}
+
+bool ShellSortOMP::ValidationImpl() {
+  return !task_data->inputs_count.empty() && !task_data->outputs_count.empty() &&
+         task_data->inputs_count[0] == task_data->outputs_count[0];
+}
+
+bool ShellSortOMP::RunImpl() {
+  ShellSort();
+  return true;
+}
+
+void ShellSortOMP::ShellSort() {
+  if (input_.empty()) return;
+
+  // Создаем локальную ссылку для корректной работы с OpenMP
+  std::vector<int>& local_input = input_;
+  const int n = static_cast<int>(local_input.size());
+
+  for (int gap = n / 2; gap > 0; gap /= 2) {
+#pragma omp parallel for default(none) shared(local_input) firstprivate(gap, n)
+    for (int i = gap; i < n; ++i) {
+      int temp = local_input[i];
+      int j = i;
+      for (; j >= gap && local_input[j - gap] > temp; j -= gap) {
+        local_input[j] = local_input[j - gap];
+      }
+      local_input[j] = temp;
+    }
+  }
+}
+
+bool ShellSortOMP::PostProcessingImpl() {
+  auto* output_ptr = reinterpret_cast<int*>(task_data->outputs[0]);
+  std::copy(input_.begin(), input_.end(), output_ptr);
+  return true;
+}
+
+}  // namespace kovalchuk_a_shell_sort_omp


### PR DESCRIPTION
Внешний цикл по элементам с шагом gap распараллеливаем, каждый поток обрабатывает свою часть массива независимо.


"std::vector<int>& local_input = input_ "   - для обхода ограничения OpenMP