### PR TITLE
Ермилова Дарья. Задача 2. Вариант 16. Технология OMP. Сортировка Шелла с четно-нечетным слиянием Бэтчера. 

### DIFF
--- a/tasks/omp/ermilova_d_shell_sort_batcher_even-odd_merger/func_tests/main.cpp
+++ b/tasks/omp/ermilova_d_shell_sort_batcher_even-odd_merger/func_tests/main.cpp
@@ -1,0 +1,1154 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "omp/ermilova_d_shell_sort_batcher_even-odd_merger/include/ops_omp.hpp"
+
+namespace {
+std::vector<int> GenerateRandomVector(size_t size, int lower_bound = -1000, int upper_bound = 1000) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  std::vector<int> vec(size);
+  for (size_t i = 0; i < size; i++) {
+    vec[i] = static_cast<int>(lower_bound + (gen() % (upper_bound - lower_bound + 1)));
+  }
+  return vec;
+}
+}  // namespace
+
+TEST(ermilova_d_shell_sort_batcher_even_odd_merger_omp, test_create_empty_input) {
+  // Create data
+  std::vector<int> in = {};
+  std::vector<int> out(in);
+
+  // Create task_data
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask sut(task_data);
+  ASSERT_FALSE(sut.Validation());
+}
+
+TEST(ermilova_d_shell_sort_batcher_even_odd_merger_omp, test_create_input_and_output_with_different_size) {
+  // Create data
+  std::vector<int> in = GenerateRandomVector(5);
+  std::vector<int> out(1, 0);
+
+  // Create task_data
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask sut(task_data);
+  ASSERT_FALSE(sut.Validation());
+}
+
+TEST(ermilova_d_shell_sort_batcher_even_odd_merger_omp, test_sort_single_element) {
+  // Create data
+  std::vector<int> in = GenerateRandomVector(1);
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+
+  // Create task_data
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask sut(task_data);
+  sut.Validation();
+  sut.PreProcessing();
+  sut.Run();
+  sut.PostProcessing();
+  ASSERT_EQ(expected, out);
+}
+
+TEST(ermilova_d_shell_sort_batcher_even_odd_merger_omp, test_sort_small_even_size) {
+  // Create data
+  std::vector<int> in = {3, 1, 4, 2};
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+
+  // Create task_data
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask sut(task_data);
+  sut.Validation();
+  sut.PreProcessing();
+  sut.Run();
+  sut.PostProcessing();
+  ASSERT_EQ(expected, out);
+}
+
+TEST(ermilova_d_shell_sort_batcher_even_odd_merger_omp, test_sort_small_odd_size) {
+  // Create data
+  std::vector<int> in = {5, 2, 3};
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+
+  // Create task_data
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask sut(task_data);
+  sut.Validation();
+  sut.PreProcessing();
+  sut.Run();
+  sut.PostProcessing();
+  ASSERT_EQ(expected, out);
+}
+
+TEST(ermilova_d_shell_sort_batcher_even_odd_merger_omp, test_sort_descending_sorted) {
+  // Create data
+  std::vector<int> in = {1, 2, 3, 4, 5};
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+
+  // Create task_data
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask sut(task_data);
+  sut.Validation();
+  sut.PreProcessing();
+  sut.Run();
+  sut.PostProcessing();
+  ASSERT_EQ(expected, out);
+}
+
+TEST(ermilova_d_shell_sort_batcher_even_odd_merger_omp, test_sort_ascending_sorted) {
+  // Create data
+  std::vector<int> in = {1, 2, 3, 4, 5};
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+
+  // Create task_data
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask sut(task_data);
+  sut.Validation();
+  sut.PreProcessing();
+  sut.Run();
+  sut.PostProcessing();
+  ASSERT_EQ(expected, out);
+}
+
+TEST(ermilova_d_shell_sort_batcher_even_odd_merger_omp, test_sort_all_equal_elements) {
+  // Create data
+  std::vector<int> in = {7, 7, 7, 7, 7};
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+
+  // Create task_data
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask sut(task_data);
+  sut.Validation();
+  sut.PreProcessing();
+  sut.Run();
+  sut.PostProcessing();
+  ASSERT_EQ(expected, out);
+}
+
+TEST(ermilova_d_shell_sort_batcher_even_odd_merger_omp, test_sort_duplicates_elements) {
+  // Create data
+  std::vector<int> in = {7, 7, 7, 7, 7};
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+
+  // Create task_data
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask sut(task_data);
+  sut.Validation();
+  sut.PreProcessing();
+  sut.Run();
+  sut.PostProcessing();
+  ASSERT_EQ(expected, out);
+}
+
+TEST(ermilova_d_shell_sort_batcher_even_odd_merger_omp, test_sort_100_random_elements) {
+  // Create data
+  std::vector<int> in = GenerateRandomVector(100);
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+
+  // Create task_data
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask sut(task_data);
+  sut.Validation();
+  sut.PreProcessing();
+  sut.Run();
+  sut.PostProcessing();
+  ASSERT_EQ(expected, out);
+}
+
+TEST(ermilova_d_shell_sort_batcher_even_odd_merger_omp, test_sort_1000_random_elements) {
+  // Create data
+  std::vector<int> in = GenerateRandomVector(1000);
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+
+  // Create task_data
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask sut(task_data);
+  sut.Validation();
+  sut.PreProcessing();
+  sut.Run();
+  sut.PostProcessing();
+  ASSERT_EQ(expected, out);
+}
+
+TEST(ermilova_d_shell_sort_batcher_even_odd_merger_omp, test_sort_347_random_elements) {
+  // Create data
+  std::vector<int> in = GenerateRandomVector(347);
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+
+  // Create task_data
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask sut(task_data);
+  sut.Validation();
+  sut.PreProcessing();
+  sut.Run();
+  sut.PostProcessing();
+  ASSERT_EQ(expected, out);
+}
+
+TEST(ermilova_d_shell_sort_batcher_even_odd_merger_omp, test_sort_with_boundary_sedgwick_gap_109) {
+  // Create data
+  std::vector<int> in = GenerateRandomVector(109);
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+
+  // Create task_data
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask sut(task_data);
+  sut.Validation();
+  sut.PreProcessing();
+  sut.Run();
+  sut.PostProcessing();
+  ASSERT_EQ(expected, out);
+}
+
+TEST(ermilova_d_shell_sort_batcher_even_odd_merger_omp, test_sort_128_random_elements) {
+  // Create data
+  std::vector<int> in = GenerateRandomVector(128);
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+
+  // Create task_data
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask sut(task_data);
+  sut.Validation();
+  sut.PreProcessing();
+  sut.Run();
+  sut.PostProcessing();
+  ASSERT_EQ(expected, out);
+}
+
+TEST(ermilova_d_shell_sort_batcher_even_odd_merger_omp, test_sort_27_random_elements) {
+  // Create data
+  std::vector<int> in = GenerateRandomVector(27);
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+
+  // Create task_data
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask sut(task_data);
+  sut.Validation();
+  sut.PreProcessing();
+  sut.Run();
+  sut.PostProcessing();
+  ASSERT_EQ(expected, out);
+}
+
+TEST(ermilova_d_shell_sort_batcher_even_odd_merger_omp, test_sort_809_random_elements) {
+  // Create data
+  std::vector<int> in = GenerateRandomVector(809);
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+
+  // Create task_data
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask sut(task_data);
+  sut.Validation();
+  sut.PreProcessing();
+  sut.Run();
+  sut.PostProcessing();
+  ASSERT_EQ(expected, out);
+}
+
+TEST(ermilova_d_shell_sort_batcher_even_odd_merger_omp, test_sort_500_random_elements) {
+  // Create data
+  std::vector<int> in = GenerateRandomVector(500);
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+
+  // Create task_data
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask sut(task_data);
+  sut.Validation();
+  sut.PreProcessing();
+  sut.Run();
+  sut.PostProcessing();
+  ASSERT_EQ(expected, out);
+}
+
+TEST(ermilova_d_shell_sort_batcher_even_odd_merger_omp, test_sort_with_boundary_sedgwick_gap_729) {
+  // Create data
+  std::vector<int> in = GenerateRandomVector(729);
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+
+  // Create task_data
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask sut(task_data);
+  sut.Validation();
+  sut.PreProcessing();
+  sut.Run();
+  sut.PostProcessing();
+  ASSERT_EQ(expected, out);
+}
+
+TEST(ermilova_d_shell_sort_batcher_even_odd_merger_omp, test_sort_with_boundary_sedgwick_gap_457) {
+  // Create data
+  std::vector<int> in = GenerateRandomVector(457);
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> expected = in;
+  std::ranges::sort(expected);
+
+  // Create task_data
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask sut(task_data);
+  sut.Validation();
+  sut.PreProcessing();
+  sut.Run();
+  sut.PostProcessing();
+  ASSERT_EQ(expected, out);
+}
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, vec_negative_values) {
+//   // Create data
+//
+//   bool is_resersed = false;
+//
+//   std::vector<int> in = {-578, -23546, -1231, -6, -18247, -789, -2348, -3, -213980, -123345};
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref);
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, vec_repeating_value) {
+//   // Create data
+//
+//   bool is_resersed = false;
+//
+//   std::vector<int> in = {10, 10, 8, 9399, 10, 10, 546, 2387, 3728};
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref);
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, sorted_vec) {
+//   // Create data
+//
+//   bool is_resersed = false;
+//
+//   std::vector<int> in = {13, 56, 90, 123, 345, 567, 1000, 1230, 12340};
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref);
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, reverse_sorted_vec) {
+//   // Create data
+//
+//   bool is_resersed = true;
+//
+//   std::vector<int> in = {12340, 9999, 5678, 800, 567, 340, 230, 10, 8, 3, 1};
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref, std::greater<>());
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, vec_1) {
+//   // Create data
+//   const int upper_border_test = 1000;
+//   const int lower_border_test = -1000;
+//   const int size = 1;
+//
+//   bool is_resersed = false;
+//
+//   std::vector<int> in = GetRandomVector(size, upper_border_test, lower_border_test);
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref);
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, vec_10) {
+//   // Create data
+//   const int upper_border_test = 1000;
+//   const int lower_border_test = -1000;
+//   const int size = 10;
+//
+//   bool is_resersed = false;
+//
+//   std::vector<int> in = GetRandomVector(size, upper_border_test, lower_border_test);
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref);
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, vec_100) {
+//   // Create data
+//   const int upper_border_test = 1000;
+//   const int lower_border_test = -1000;
+//   const int size = 100;
+//
+//   bool is_resersed = false;
+//
+//   std::vector<int> in = GetRandomVector(size, upper_border_test, lower_border_test);
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref);
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, vec_1000) {
+//   // Create data
+//   const int upper_border_test = 1000;
+//   const int lower_border_test = -1000;
+//   const int size = 1000;
+//
+//   bool is_resersed = false;
+//
+//   std::vector<int> in = GetRandomVector(size, upper_border_test, lower_border_test);
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref);
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, vec_10000) {
+//   // Create data
+//   const int upper_border_test = 1000;
+//   const int lower_border_test = -1000;
+//   const int size = 10000;
+//
+//   bool is_resersed = false;
+//
+//   std::vector<int> in = GetRandomVector(size, upper_border_test, lower_border_test);
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref);
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, vec_8) {
+//   // Create data
+//   const int upper_border_test = 1000;
+//   const int lower_border_test = -1000;
+//   const int size = 8;
+//
+//   bool is_resersed = false;
+//
+//   std::vector<int> in = GetRandomVector(size, upper_border_test, lower_border_test);
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref);
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, vec_128) {
+//   // Create data
+//   const int upper_border_test = 1000;
+//   const int lower_border_test = -1000;
+//   const int size = 128;
+//
+//   bool is_resersed = false;
+//
+//   std::vector<int> in = GetRandomVector(size, upper_border_test, lower_border_test);
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref);
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, vec_27) {
+//   // Create data
+//   const int upper_border_test = 1000;
+//   const int lower_border_test = -1000;
+//   const int size = 27;
+//
+//   bool is_resersed = false;
+//
+//   std::vector<int> in = GetRandomVector(size, upper_border_test, lower_border_test);
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref);
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, vec_729) {
+//   // Create data
+//   const int upper_border_test = 1000;
+//   const int lower_border_test = -1000;
+//   const int size = 729;
+//
+//   bool is_resersed = false;
+//
+//   std::vector<int> in = GetRandomVector(size, upper_border_test, lower_border_test);
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref);
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, vec_457) {
+//   // Create data
+//   const int upper_border_test = 1000;
+//   const int lower_border_test = -1000;
+//   const int size = 457;
+//
+//   bool is_resersed = false;
+//
+//   std::vector<int> in = GetRandomVector(size, upper_border_test, lower_border_test);
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref);
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, vec_809) {
+//   // Create data
+//   const int upper_border_test = 1000;
+//   const int lower_border_test = -1000;
+//   const int size = 809;
+//
+//   bool is_resersed = false;
+//
+//   std::vector<int> in = GetRandomVector(size, upper_border_test, lower_border_test);
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref);
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, reverse_sort_vec_500) {
+//   // Create data
+//   const int upper_border_test = 1000;
+//   const int lower_border_test = -1000;
+//   const int size = 500;
+//
+//   bool is_resersed = true;
+//
+//   std::vector<int> in = GetRandomVector(size, upper_border_test, lower_border_test);
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref, std::greater<>());
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, reverse_sort_vec_347) {
+//   // Create data
+//   const int upper_border_test = 1000;
+//   const int lower_border_test = -1000;
+//   const int size = 809;
+//
+//   bool is_resersed = true;
+//
+//   std::vector<int> in = GetRandomVector(size, upper_border_test, lower_border_test);
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref, std::greater<>());
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, reverse_sort_vec_1000) {
+//   // Create data
+//   const int upper_border_test = 1000;
+//   const int lower_border_test = -1000;
+//   const int size = 1000;
+//
+//   bool is_resersed = true;
+//
+//   std::vector<int> in = GetRandomVector(size, upper_border_test, lower_border_test);
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref, std::greater<>());
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, reverse_sort_vec_10000) {
+//   // Create data
+//   const int upper_border_test = 1000;
+//   const int lower_border_test = -1000;
+//   const int size = 10000;
+//
+//   bool is_resersed = true;
+//
+//   std::vector<int> in = GetRandomVector(size, upper_border_test, lower_border_test);
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref, std::greater<>());
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, reverse_duplicates_vec) {
+//   // Create data
+//
+//   bool is_resersed = false;
+//
+//   std::vector<int> in = {5, 4, 3, 2, 1, 5, 4, 3, 2, 1};
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref);
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, reverse_duplicates_vec_reverse_sort) {
+//   // Create data
+//
+//   bool is_resersed = true;
+//
+//   std::vector<int> in = {5, 4, 3, 2, 1, 5, 4, 3, 2, 1};
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref, std::greater<>());
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, duplicates_vec) {
+//   // Create data
+//
+//   bool is_resersed = false;
+//
+//   std::vector<int> in = {1, 2, 3, 4, 5, 1, 2, 3, 4, 5};
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref);
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }
+//
+// TEST(ermilova_d_shell_sort_batcher_even_odd_merger_seq, duplicates_vec_reverse_sort) {
+//   // Create data
+//
+//   bool is_resersed = true;
+//
+//   std::vector<int> in = {1, 2, 3, 4, 5, 1, 2, 3, 4, 5};
+//   std::vector<int> out(in.size(), 0);
+//
+//   std::vector<int> ref = in;
+//   std::ranges::sort(ref, std::greater<>());
+//
+//   // Create task_data
+//   auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+//   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(&is_resersed));
+//   task_data_seq->inputs_count.emplace_back(in.size());
+//   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+//   task_data_seq->outputs_count.emplace_back(out.size());
+//
+//   // Create Task
+//   ermilova_d_shell_sort_batcher_even_odd_merger_seq::TestTaskSequential test_task_sequential(task_data_seq);
+//   ASSERT_EQ(test_task_sequential.Validation(), true);
+//   test_task_sequential.PreProcessing();
+//   test_task_sequential.Run();
+//   test_task_sequential.PostProcessing();
+//   EXPECT_EQ(ref, out);
+// }

--- a/tasks/omp/ermilova_d_shell_sort_batcher_even-odd_merger/include/ops_omp.hpp
+++ b/tasks/omp/ermilova_d_shell_sort_batcher_even-odd_merger/include/ops_omp.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace ermilova_d_shell_sort_batcher_even_odd_merger_omp {
+
+class OmpTask : public ppc::core::Task {
+ public:
+  explicit OmpTask(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> data_;
+};
+
+}  // namespace ermilova_d_shell_sort_batcher_even_odd_merger_omp

--- a/tasks/omp/ermilova_d_shell_sort_batcher_even-odd_merger/perf_tests/main.cpp
+++ b/tasks/omp/ermilova_d_shell_sort_batcher_even-odd_merger/perf_tests/main.cpp
@@ -1,0 +1,102 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "omp/ermilova_d_shell_sort_batcher_even-odd_merger/include/ops_omp.hpp"
+
+namespace {
+std::vector<int> GenerateRandomVector(size_t size, int lower_bound = -1000, int upper_bound = 1000) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  std::vector<int> vec(size);
+  for (size_t i = 0; i < size; i++) {
+    vec[i] = static_cast<int>(lower_bound + (gen() % (upper_bound - lower_bound + 1)));
+  }
+  return vec;
+}
+}  // namespace
+
+TEST(ermilova_d_shell_sort_batcher_even_odd_merger_omp, test_pipeline_run) {
+  // Create data
+  std::vector<int> in = GenerateRandomVector(10000);
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> ref = in;
+  std::ranges::sort(ref);
+
+  // Create task_data
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto task = std::make_shared<ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask>(task_data);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(task);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(ref, out);
+}
+
+TEST(ermilova_d_shell_sort_batcher_even_odd_merger_omp, test_task_run) {
+  // Create data
+  std::vector<int> in = GenerateRandomVector(10000);
+  std::vector<int> out(in.size(), 0);
+
+  std::vector<int> ref = in;
+  std::ranges::sort(ref);
+
+  // Create task_data
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto task = std::make_shared<ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask>(task_data);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(task);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(ref, out);
+}

--- a/tasks/omp/ermilova_d_shell_sort_batcher_even-odd_merger/src/ops_omp.cpp
+++ b/tasks/omp/ermilova_d_shell_sort_batcher_even-odd_merger/src/ops_omp.cpp
@@ -1,0 +1,143 @@
+#include "omp/ermilova_d_shell_sort_batcher_even-odd_merger/include/ops_omp.hpp"
+
+#include <omp.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <vector>
+
+namespace {
+
+std::vector<int> CreateSedgwickSequence(int n) {
+  std::vector<int> gaps;
+  int k = 0;
+  while (true) {
+    int gap =
+        (k % 2 == 0) ? (9 * (1 << (2 * k))) - (9 * (1 << k)) + 1 : (8 * (1 << k)) - (6 * (1 << ((k + 1) / 2))) + 1;
+
+    if (gap > n / 2) {
+      break;
+    }
+
+    gaps.push_back(gap);
+    k++;
+  }
+
+  if (gaps.empty() || gaps.back() != 1) {
+    gaps.push_back(1);
+  }
+
+  std::ranges::reverse(gaps);
+  return gaps;
+}
+
+void ShellSort(std::vector<int> &data, size_t start, size_t end) {
+  auto partition_size = static_cast<int>(end - start + 1);
+  auto gaps = CreateSedgwickSequence(partition_size);
+
+  for (int gap : gaps) {
+    for (size_t i = start + gap; i <= end; i++) {
+      int temp = data[i];
+      size_t j = i;
+      while (j >= start + gap && data[j - gap] > temp) {
+        data[j] = data[j - gap];
+        j -= gap;
+      }
+      data[j] = temp;
+    }
+  }
+}
+
+void BatcherMerge(std::vector<int> &data, size_t start, size_t mid, size_t end) {
+  size_t elements_count = end - start;
+  std::vector<int> left(data.begin() + static_cast<std::ptrdiff_t>(start),
+                        data.begin() + static_cast<std::ptrdiff_t>(mid));
+
+  std::vector<int> right(data.begin() + static_cast<std::ptrdiff_t>(mid),
+                         data.begin() + static_cast<std::ptrdiff_t>(end));
+  size_t left_index = 0;
+  size_t right_index = 0;
+  size_t data_offset = start;
+#pragma omp parallel
+  {
+    int threads_count = omp_get_num_threads();
+    int thread_number = omp_get_thread_num();
+    size_t block_size = (elements_count + threads_count - 1) / threads_count;
+    size_t block_start = std::min(thread_number * block_size, elements_count);
+    size_t block_end = std::min((thread_number + 1) * block_size, elements_count);
+
+    size_t left_size = mid - start;
+    size_t right_size = end - mid;
+
+    for (size_t i = block_start; i < block_end; ++i) {
+      if (i % 2 == 0) {
+        if (left_index < left_size && (right_index >= right_size || left[left_index] <= right[right_index])) {
+          data[data_offset++] = left[left_index++];
+        } else {
+          data[data_offset++] = right[right_index++];
+        }
+      } else {
+        if (right_index < right_size && (left_index >= left_size || right[right_index] <= left[left_index])) {
+          data[data_offset++] = right[right_index++];
+        } else {
+          data[data_offset++] = left[left_index++];
+        }
+      }
+    }
+  }
+}
+
+void ParallelShellSortWithBatcherMerge(std::vector<int> &data) {
+  size_t elements_count = data.size();
+  if (elements_count <= 1) {
+    return;
+  }
+
+  int threads_count = omp_get_num_threads();
+  size_t block_size = (elements_count + threads_count - 1) / threads_count;
+
+#pragma omp parallel
+  {
+    int thread_number = omp_get_thread_num();
+
+    size_t start_block_index = static_cast<size_t>(thread_number) * block_size;
+    size_t end_block_index = std::min(start_block_index + block_size, elements_count) - 1;
+    if (start_block_index < elements_count) {
+      ShellSort(data, start_block_index, end_block_index);
+    }
+  }
+
+  for (size_t merge_size = block_size; merge_size < elements_count; merge_size *= 2) {
+#pragma omp parallel for schedule(static)
+    for (int i = 0; i < static_cast<int>(elements_count); i += static_cast<int>(2 * merge_size)) {
+      size_t mid = std::min(i + merge_size, elements_count);
+      size_t end = std::min(i + (2 * merge_size), elements_count);
+      if (mid < end) {
+        BatcherMerge(data, i, mid, end);
+      }
+    }
+  }
+}
+}  // namespace
+bool ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask::PreProcessingImpl() {
+  auto input_task_size = task_data->inputs_count[0];
+  auto *input_task_data = reinterpret_cast<int *>(task_data->inputs[0]);
+  data_ = std::vector(input_task_data, input_task_data + input_task_size);
+
+  return true;
+}
+
+bool ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask::ValidationImpl() {
+  return task_data->inputs_count[0] > 0 && task_data->inputs_count[0] == task_data->outputs_count[0];
+}
+
+bool ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask::RunImpl() {
+  ParallelShellSortWithBatcherMerge(data_);
+  return true;
+}
+
+bool ermilova_d_shell_sort_batcher_even_odd_merger_omp::OmpTask::PostProcessingImpl() {
+  auto *output_task_data = reinterpret_cast<int *>(task_data->outputs[0]);
+  std::ranges::copy(data_, output_task_data);
+  return true;
+}


### PR DESCRIPTION
Задача состоит в том, чтобы частично отсортировать данные, используя сортировку Шелла, а затем используя чётно-нечётное слияние Бэтчера произвести компановку отсортированных данных.

Для сортировки Шелла использовалась последовательность Седжвика, которая даёт среднюю оценку сложности сортировки O(n^7/6), после частино отсортированные данные сливаются в один набор согласно алгоритму чётно-нечётного слияния Бэтчера

**Параллельная схема**:

1. Данные разбиваются на подмассивы между потоками
2. Каждый поток сортирует свой набор данных сортировкой Шелла
3. Отсортированные данные распределяются между потоками
4. Распределённые данные объединяются слиянием Бэтчера