### PR TITLE
Ополин Дмитрий. Вариант 18. Технология OMP. Поразрядная сортировка для целых чисел с четно-нечетным слиянием Бэтчера.

### DIFF
--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/func_tests/main.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/func_tests/main.cpp
@@ -8,7 +8,6 @@
 #include <vector>
 
 #include "core/task/include/task.hpp"
-#include "core/util/include/util.hpp"
 #include "omp/opolin_d_radix_sort_betcher_merge/include/ops_omp.hpp"
 
 namespace opolin_d_radix_batcher_sort_omp {

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/func_tests/main.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/func_tests/main.cpp
@@ -29,7 +29,6 @@ void GenDataRadixSort(size_t size, std::vector<int> &vec, std::vector<int> &expe
 }  // namespace
 }  // namespace opolin_d_radix_batcher_sort_omp
 
-
 TEST(opolin_d_radix_batcher_sort_omp, test_size_3) {
   int size = 3;
   std::vector<int> expected;
@@ -44,8 +43,7 @@ TEST(opolin_d_radix_batcher_sort_omp, test_size_3) {
   task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_omp->outputs_count.emplace_back(out.size());
 
-  auto test_task_omp =
-      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  auto test_task_omp = std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
   ASSERT_EQ(test_task_omp->Validation(), true);
   test_task_omp->PreProcessing();
   test_task_omp->Run();
@@ -66,8 +64,7 @@ TEST(opolin_d_radix_batcher_sort_omp, test_size_6) {
   task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_omp->outputs_count.emplace_back(out.size());
 
-  auto test_task_omp =
-      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  auto test_task_omp = std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
   ASSERT_EQ(test_task_omp->Validation(), true);
   test_task_omp->PreProcessing();
   test_task_omp->Run();
@@ -86,8 +83,7 @@ TEST(opolin_d_radix_batcher_sort_omp, test_empty) {
   task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_omp->outputs_count.emplace_back(size);
 
-  auto test_task_omp =
-      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  auto test_task_omp = std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
   ASSERT_EQ(test_task_omp->Validation(), false);
 }
 
@@ -104,8 +100,7 @@ TEST(opolin_d_radix_batcher_sort_omp, test_one_element) {
   task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_omp->outputs_count.emplace_back(out.size());
 
-  auto test_task_omp =
-      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  auto test_task_omp = std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
   ASSERT_EQ(test_task_omp->Validation(), true);
   test_task_omp->PreProcessing();
   test_task_omp->Run();
@@ -126,8 +121,7 @@ TEST(opolin_d_radix_batcher_sort_omp, test_negative_values) {
   task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_omp->outputs_count.emplace_back(out.size());
 
-  auto test_task_omp =
-      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  auto test_task_omp = std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
   ASSERT_EQ(test_task_omp->Validation(), true);
   test_task_omp->PreProcessing();
   test_task_omp->Run();
@@ -149,8 +143,7 @@ TEST(opolin_d_radix_batcher_sort_omp, test_sorted) {
   task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_omp->outputs_count.emplace_back(out.size());
 
-  auto test_task_omp =
-      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  auto test_task_omp = std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
   ASSERT_EQ(test_task_omp->Validation(), true);
   test_task_omp->PreProcessing();
   test_task_omp->Run();
@@ -171,8 +164,7 @@ TEST(opolin_d_radix_batcher_sort_omp, test_equal_values) {
   task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_omp->outputs_count.emplace_back(out.size());
 
-  auto test_task_omp =
-      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  auto test_task_omp = std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
   ASSERT_EQ(test_task_omp->Validation(), true);
   test_task_omp->PreProcessing();
   test_task_omp->Run();
@@ -193,8 +185,7 @@ TEST(opolin_d_radix_batcher_sort_omp, test_reversed) {
   task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_omp->outputs_count.emplace_back(out.size());
 
-  auto test_task_omp =
-      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  auto test_task_omp = std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
   ASSERT_EQ(test_task_omp->Validation(), true);
   test_task_omp->PreProcessing();
   test_task_omp->Run();
@@ -215,8 +206,7 @@ TEST(opolin_d_radix_batcher_sort_omp, test_varying_digit_counts) {
   task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_omp->outputs_count.emplace_back(out.size());
 
-  auto test_task_omp =
-      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  auto test_task_omp = std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
   ASSERT_EQ(test_task_omp->Validation(), true);
   test_task_omp->PreProcessing();
   test_task_omp->Run();
@@ -235,8 +225,7 @@ TEST(opolin_d_radix_batcher_sort_omp, test_negative_size) {
   task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_omp->outputs_count.emplace_back(size);
 
-  auto test_task_omp =
-      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  auto test_task_omp = std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
   ASSERT_EQ(test_task_omp->Validation(), false);
 }
 
@@ -253,8 +242,7 @@ TEST(opolin_d_radix_batcher_sort_omp, test_size_100) {
   task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_omp->outputs_count.emplace_back(out.size());
 
-  auto test_task_omp =
-      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  auto test_task_omp = std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
   ASSERT_EQ(test_task_omp->Validation(), true);
   test_task_omp->PreProcessing();
   test_task_omp->Run();
@@ -275,8 +263,7 @@ TEST(opolin_d_radix_batcher_sort_omp, test_size_prime_7) {
   task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_omp->outputs_count.emplace_back(out.size());
 
-  auto test_task_omp =
-      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  auto test_task_omp = std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
   ASSERT_EQ(test_task_omp->Validation(), true);
   test_task_omp->PreProcessing();
   test_task_omp->Run();
@@ -297,8 +284,7 @@ TEST(opolin_d_radix_batcher_sort_omp, test_size_prime_13) {
   task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_omp->outputs_count.emplace_back(out.size());
 
-  auto test_task_omp =
-      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  auto test_task_omp = std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
   ASSERT_EQ(test_task_omp->Validation(), true);
   test_task_omp->PreProcessing();
   test_task_omp->Run();
@@ -320,8 +306,7 @@ TEST(opolin_d_radix_batcher_sort_omp, test_double_reversed_order) {
   task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_omp->outputs_count.emplace_back(out.size());
 
-  auto test_task_omp =
-      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  auto test_task_omp = std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
   ASSERT_EQ(test_task_omp->Validation(), true);
   test_task_omp->PreProcessing();
   test_task_omp->Run();

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/func_tests/main.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/func_tests/main.cpp
@@ -1,0 +1,330 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "core/util/include/util.hpp"
+#include "omp/opolin_d_radix_sort_betcher_merge/include/ops_omp.hpp"
+
+namespace opolin_d_radix_batcher_sort_omp {
+namespace {
+void GenDataRadixSort(size_t size, std::vector<int> &vec, std::vector<int> &expected) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> dis(-1000, 1000);
+  vec.clear();
+  expected.clear();
+  vec.reserve(size);
+  for (size_t i = 0; i < size; ++i) {
+    vec.push_back(dis(gen));
+  }
+  expected = vec;
+  std::ranges::sort(expected);
+}
+}  // namespace
+}  // namespace opolin_d_radix_batcher_sort_omp
+
+
+TEST(opolin_d_radix_batcher_sort_omp, test_size_3) {
+  int size = 3;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {2, 1, 10};
+  expected = {1, 2, 10};
+
+  std::vector<int> out(size, 0);
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(out.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  auto test_task_omp =
+      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  ASSERT_EQ(test_task_omp->Validation(), true);
+  test_task_omp->PreProcessing();
+  test_task_omp->Run();
+  test_task_omp->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_omp, test_size_6) {
+  int size = 6;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {3, 1, 7, 0, 12, 2};
+  expected = {0, 1, 2, 3, 7, 12};
+  std::vector<int> out(size, 0);
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(out.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  auto test_task_omp =
+      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  ASSERT_EQ(test_task_omp->Validation(), true);
+  test_task_omp->PreProcessing();
+  test_task_omp->Run();
+  test_task_omp->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_omp, test_empty) {
+  int size = 0;
+  std::vector<int> expected;
+  std::vector<int> input;
+  std::vector<int> out;
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(size);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(size);
+
+  auto test_task_omp =
+      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  ASSERT_EQ(test_task_omp->Validation(), false);
+}
+
+TEST(opolin_d_radix_batcher_sort_omp, test_one_element) {
+  int size = 1;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {31};
+  expected = {31};
+  std::vector<int> out(size, 0);
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(out.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  auto test_task_omp =
+      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  ASSERT_EQ(test_task_omp->Validation(), true);
+  test_task_omp->PreProcessing();
+  test_task_omp->Run();
+  test_task_omp->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_omp, test_negative_values) {
+  int size = 5;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {-12, -4, -7, -2, -34};
+  expected = {-34, -12, -7, -4, -2};
+  std::vector<int> out(size, 0);
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(out.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  auto test_task_omp =
+      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  ASSERT_EQ(test_task_omp->Validation(), true);
+  test_task_omp->PreProcessing();
+  test_task_omp->Run();
+  test_task_omp->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_omp, test_sorted) {
+  int size = 5;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {0, 1, 2, 6, 7};
+  expected = {0, 1, 2, 6, 7};
+
+  std::vector<int> out(size, 0);
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(out.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  auto test_task_omp =
+      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  ASSERT_EQ(test_task_omp->Validation(), true);
+  test_task_omp->PreProcessing();
+  test_task_omp->Run();
+  test_task_omp->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_omp, test_equal_values) {
+  int size = 3;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {2, 2, 2};
+  expected = {2, 2, 2};
+  std::vector<int> out(size, 0);
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(out.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  auto test_task_omp =
+      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  ASSERT_EQ(test_task_omp->Validation(), true);
+  test_task_omp->PreProcessing();
+  test_task_omp->Run();
+  test_task_omp->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_omp, test_reversed) {
+  int size = 10;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {12, 8, 6, 3, 2, 0, -4, -6, -7, -10};
+  expected = {-10, -7, -6, -4, 0, 2, 3, 6, 8, 12};
+  std::vector<int> out(size, 0);
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(out.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  auto test_task_omp =
+      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  ASSERT_EQ(test_task_omp->Validation(), true);
+  test_task_omp->PreProcessing();
+  test_task_omp->Run();
+  test_task_omp->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_omp, test_varying_digit_counts) {
+  int size = 6;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {123456, 12, 123, 1, 12345, 1234};
+  expected = {1, 12, 123, 1234, 12345, 123456};
+  std::vector<int> out(size, 0);
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(out.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  auto test_task_omp =
+      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  ASSERT_EQ(test_task_omp->Validation(), true);
+  test_task_omp->PreProcessing();
+  test_task_omp->Run();
+  test_task_omp->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_omp, test_negative_size) {
+  int size = -1;
+  std::vector<int> expected;
+  std::vector<int> input;
+  std::vector<int> out;
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(size);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(size);
+
+  auto test_task_omp =
+      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  ASSERT_EQ(test_task_omp->Validation(), false);
+}
+
+TEST(opolin_d_radix_batcher_sort_omp, test_size_100) {
+  int size = 100;
+  std::vector<int> expected;
+  std::vector<int> input;
+  opolin_d_radix_batcher_sort_omp::GenDataRadixSort(size, input, expected);
+
+  std::vector<int> out(size, 0);
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(out.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  auto test_task_omp =
+      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  ASSERT_EQ(test_task_omp->Validation(), true);
+  test_task_omp->PreProcessing();
+  test_task_omp->Run();
+  test_task_omp->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_omp, test_size_prime_7) {
+  int size = 7;
+  std::vector<int> expected;
+  std::vector<int> input;
+  opolin_d_radix_batcher_sort_omp::GenDataRadixSort(size, input, expected);
+
+  std::vector<int> out(size, 0);
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(out.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  auto test_task_omp =
+      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  ASSERT_EQ(test_task_omp->Validation(), true);
+  test_task_omp->PreProcessing();
+  test_task_omp->Run();
+  test_task_omp->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_omp, test_size_prime_13) {
+  int size = 13;
+  std::vector<int> expected;
+  std::vector<int> input;
+  opolin_d_radix_batcher_sort_omp::GenDataRadixSort(size, input, expected);
+
+  std::vector<int> out(size, 0);
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(out.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  auto test_task_omp =
+      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  ASSERT_EQ(test_task_omp->Validation(), true);
+  test_task_omp->PreProcessing();
+  test_task_omp->Run();
+  test_task_omp->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_omp, test_double_reversed_order) {
+  int size = 10;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {5, 4, 3, 2, 1, 10, 9, 8, 7, 6};
+  expected = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+
+  std::vector<int> out(size, 0);
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(out.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  auto test_task_omp =
+      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  ASSERT_EQ(test_task_omp->Validation(), true);
+  test_task_omp->PreProcessing();
+  test_task_omp->Run();
+  test_task_omp->PostProcessing();
+  ASSERT_EQ(out, expected);
+}

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/include/ops_omp.hpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/include/ops_omp.hpp
@@ -7,7 +7,7 @@
 
 namespace opolin_d_radix_batcher_sort_omp {
 void SortByDigit(std::vector<int>& array, int digit_place);
-void BatcherOddEvenMerge(std::vector<int>& array, int start, int n);
+void BatcherOddEvenMerge(std::vector<int>& array, int start, int mid, int end);
 
 class RadixBatcherSortTaskOpenMP : public ppc::core::Task {
  public:

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/include/ops_omp.hpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/include/ops_omp.hpp
@@ -6,9 +6,8 @@
 #include "core/task/include/task.hpp"
 
 namespace opolin_d_radix_batcher_sort_omp {
-void SortByDigit(std::vector<int> &array, int digit_place);
-void BatcherOddEvenMerge(std::vector<int> &array, int start, int n, int step);
-void CompEx(std::vector<int> &array, int i, int j);
+void SortByDigit(std::vector<int>& array, int digit_place);
+void BatcherOddEvenMerge(std::vector<int>& array, int start, int mid, int end);
 
 class RadixBatcherSortTaskOpenMP : public ppc::core::Task {
  public:

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/include/ops_omp.hpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/include/ops_omp.hpp
@@ -6,20 +6,20 @@
 #include "core/task/include/task.hpp"
 
 namespace opolin_d_radix_batcher_sort_omp {
-  void SortByDigit(std::vector<int>& array, int digit_place);
-  void BatcherOddEvenMerge(std::vector<int>& array, int start, int n);
-  
-  class RadixBatcherSortTaskOpenMP : public ppc::core::Task {
-   public:
-    explicit RadixBatcherSortTaskOpenMP(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
-    bool PreProcessingImpl() override;
-    bool ValidationImpl() override;
-    bool RunImpl() override;
-    bool PostProcessingImpl() override;
-  
-   private:
-    std::vector<int> input_;
-    std::vector<int> output_;
-    int size_;
-  };
+void SortByDigit(std::vector<int>& array, int digit_place);
+void BatcherOddEvenMerge(std::vector<int>& array, int start, int n);
+
+class RadixBatcherSortTaskOpenMP : public ppc::core::Task {
+ public:
+  explicit RadixBatcherSortTaskOpenMP(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> input_;
+  std::vector<int> output_;
+  int size_;
+};
 }  // namespace opolin_d_radix_batcher_sort_omp

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/include/ops_omp.hpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/include/ops_omp.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace opolin_d_radix_batcher_sort_omp {
+  void SortByDigit(std::vector<int>& array, int digit_place);
+  void BatcherOddEvenMerge(std::vector<int>& array, int start, int n);
+  
+  class RadixBatcherSortTaskOpenMP : public ppc::core::Task {
+   public:
+    explicit RadixBatcherSortTaskOpenMP(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+    bool PreProcessingImpl() override;
+    bool ValidationImpl() override;
+    bool RunImpl() override;
+    bool PostProcessingImpl() override;
+  
+   private:
+    std::vector<int> input_;
+    std::vector<int> output_;
+    int size_;
+  };
+}  // namespace opolin_d_radix_batcher_sort_omp

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/include/ops_omp.hpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/include/ops_omp.hpp
@@ -6,7 +6,7 @@
 #include "core/task/include/task.hpp"
 
 namespace opolin_d_radix_batcher_sort_omp {
-void SortByDigit(std::vector<int>& array, int digit_place);
+void SortByDigit(std::vector<int> &array, int digit_place);
 void BatcherOddEvenMerge(std::vector<int> &array, int start, int n, int step);
 void CompEx(std::vector<int> &array, int i, int j);
 

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/include/ops_omp.hpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/include/ops_omp.hpp
@@ -7,7 +7,7 @@
 
 namespace opolin_d_radix_batcher_sort_omp {
 void SortByDigit(std::vector<int>& array, int digit_place);
-void BatcherOddEvenMerge(std::vector<int>& array, int start, int end);
+void BatcherOddEvenMerge(std::vector<int>& array, int start, int mid, int end);
 
 class RadixBatcherSortTaskOpenMP : public ppc::core::Task {
  public:

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/include/ops_omp.hpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/include/ops_omp.hpp
@@ -8,6 +8,7 @@
 namespace opolin_d_radix_batcher_sort_omp {
 void SortByDigit(std::vector<int>& array, int digit_place);
 void BatcherOddEvenMerge(std::vector<int>& array, int start, int mid, int end);
+void RadixSort(std::vector<int>& input, int start, int end);
 
 class RadixBatcherSortTaskOpenMP : public ppc::core::Task {
  public:

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/include/ops_omp.hpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/include/ops_omp.hpp
@@ -7,7 +7,7 @@
 
 namespace opolin_d_radix_batcher_sort_omp {
 void SortByDigit(std::vector<int>& array, int digit_place);
-void BatcherOddEvenMerge(std::vector<int>& array, int start, int mid, int end);
+void BatcherOddEvenMerge(std::vector<int>& array, int start, int end);
 
 class RadixBatcherSortTaskOpenMP : public ppc::core::Task {
  public:

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/include/ops_omp.hpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/include/ops_omp.hpp
@@ -7,7 +7,8 @@
 
 namespace opolin_d_radix_batcher_sort_omp {
 void SortByDigit(std::vector<int>& array, int digit_place);
-void BatcherOddEvenMerge(std::vector<int>& array, int start, int mid, int end);
+void BatcherOddEvenMerge(std::vector<int> &array, int start, int n, int step);
+void CompEx(std::vector<int> &array, int i, int j);
 
 class RadixBatcherSortTaskOpenMP : public ppc::core::Task {
  public:

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/perf_tests/main.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/perf_tests/main.cpp
@@ -66,6 +66,7 @@ TEST(opolin_d_radix_batcher_sort_omp, test_pipeline_run) {
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(expected, out);
 }
 
 TEST(opolin_d_radix_batcher_sort_omp, test_task_run) {
@@ -102,4 +103,5 @@ TEST(opolin_d_radix_batcher_sort_omp, test_task_run) {
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(expected, out);
 }

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/perf_tests/main.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/perf_tests/main.cpp
@@ -81,7 +81,6 @@ TEST(opolin_d_radix_batcher_sort_omp, test_task_run) {
   task_data_omp->inputs_count.emplace_back(out.size());
   task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_omp->outputs_count.emplace_back(out.size());
-
   // Create Task
   auto test_task_omp = std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
   ASSERT_EQ(test_task_omp->Validation(), true);

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/perf_tests/main.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/perf_tests/main.cpp
@@ -1,0 +1,109 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "omp/opolin_d_radix_sort_betcher_merge/include/ops_omp.hpp"
+
+namespace opolin_d_radix_batcher_sort_omp {
+namespace {
+void GenDataRadixSort(size_t size, std::vector<int> &vec, std::vector<int> &expected) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> dis(-1000, 1000);
+  vec.clear();
+  expected.clear();
+  vec.reserve(size);
+  for (size_t i = 0; i < size; ++i) {
+    vec.push_back(dis(gen));
+  }
+  expected = vec;
+  std::ranges::sort(expected);
+}
+}  // namespace
+}  // namespace opolin_d_radix_batcher_sort_omp
+
+TEST(opolin_d_radix_batcher_sort_omp, test_pipeline_run) {
+  int size = 500000;
+  std::vector<int> input;
+  std::vector<int> expected;
+  opolin_d_radix_batcher_sort_omp::GenDataRadixSort(size, input, expected);
+  std::vector<int> out(size, 0);
+  // Create TaskData
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(out.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_omp =
+      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  ASSERT_EQ(test_task_omp->Validation(), true);
+  test_task_omp->PreProcessing();
+  test_task_omp->Run();
+  test_task_omp->PostProcessing();
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}
+
+TEST(opolin_d_radix_batcher_sort_omp, test_task_run) {
+  int size = 500000;
+  std::vector<int> input;
+  std::vector<int> expected;
+  opolin_d_radix_batcher_sort_omp::GenDataRadixSort(size, input, expected);
+  std::vector<int> out(size, 0);
+  // Create TaskData
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(out.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_omp =
+      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  ASSERT_EQ(test_task_omp->Validation(), true);
+  test_task_omp->PreProcessing();
+  test_task_omp->Run();
+  test_task_omp->PostProcessing();
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/perf_tests/main.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/perf_tests/main.cpp
@@ -43,6 +43,7 @@ TEST(opolin_d_radix_batcher_sort_omp, test_pipeline_run) {
   task_data_omp->inputs_count.emplace_back(out.size());
   task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_omp->outputs_count.emplace_back(out.size());
+
   // Create Task
   auto test_task_omp = std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
   ASSERT_EQ(test_task_omp->Validation(), true);

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/perf_tests/main.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/perf_tests/main.cpp
@@ -43,7 +43,6 @@ TEST(opolin_d_radix_batcher_sort_omp, test_pipeline_run) {
   task_data_omp->inputs_count.emplace_back(out.size());
   task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_omp->outputs_count.emplace_back(out.size());
-
   // Create Task
   auto test_task_omp = std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
   ASSERT_EQ(test_task_omp->Validation(), true);

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/perf_tests/main.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/perf_tests/main.cpp
@@ -45,8 +45,7 @@ TEST(opolin_d_radix_batcher_sort_omp, test_pipeline_run) {
   task_data_omp->outputs_count.emplace_back(out.size());
 
   // Create Task
-  auto test_task_omp =
-      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  auto test_task_omp = std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
   ASSERT_EQ(test_task_omp->Validation(), true);
   test_task_omp->PreProcessing();
   test_task_omp->Run();
@@ -84,8 +83,7 @@ TEST(opolin_d_radix_batcher_sort_omp, test_task_run) {
   task_data_omp->outputs_count.emplace_back(out.size());
 
   // Create Task
-  auto test_task_omp =
-      std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
+  auto test_task_omp = std::make_shared<opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP>(task_data_omp);
   ASSERT_EQ(test_task_omp->Validation(), true);
   test_task_omp->PreProcessing();
   test_task_omp->Run();

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
@@ -74,7 +74,7 @@ bool opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP::PostProcessing
   return true;
 }
 
-void opolin_d_radix_batcher_sort_omp::RadixSort(std::vector<int>& input, int start, int end) {
+void opolin_d_radix_batcher_sort_omp::RadixSort(std::vector<int> &input, int start, int end) {
   std::vector<int> local_input(input.begin() + start, input.begin() + end);
   std::vector<int> positives;
   std::vector<int> negatives;

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
@@ -152,7 +152,7 @@ void opolin_d_radix_batcher_sort_omp::BatcherOddEvenMerge(std::vector<int> &arra
 }
 
 void opolin_d_radix_batcher_sort_omp::CompEx(std::vector<int> &array, int i, int j) {
-  if (i < array.size() && j < array.size() && array[i] > array[j]) {
+  if (static_cast<size_t>(i) < array.size() && static_cast<size_t>(j) < array.size() && array[i] > array[j]) {
     std::swap(array[i], array[j]);
   }
 }

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
@@ -50,8 +50,7 @@ bool opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP::RunImpl() {
     for (int val : local_input) {
       if (val >= 0) {
         positives.push_back(val);
-      }
-      else {
+      } else {
         negatives.push_back(-val);
       }
     }

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
@@ -139,10 +139,11 @@ void opolin_d_radix_batcher_sort_omp::SortByDigit(std::vector<int> &array, int d
 void opolin_d_radix_batcher_sort_omp::BatcherOddEvenMerge(std::vector<int> &array, int start, int mid, int end) {
   int n = end - start;
   for (int phase = 0; phase < n; phase++) {
-#pragma omp parallel for
-    for (int i = start + (phase % 2); i < end - 1; i += 2) {
-      if (array[i] > array[i + 1]) {
-        std::swap(array[i], array[i + 1]);
+    for (int i = start; i < end - 1; i++) {
+      if ((phase % 2 == 0 && i % 2 == 0) || (phase % 2 == 1 && i % 2 == 1)) {
+        if (array[i] > array[i + 1]) {
+          std::swap(array[i], array[i + 1]);
+        }
       }
     }
   }

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
@@ -178,7 +178,7 @@ void opolin_d_radix_batcher_sort_omp::SortByDigit(std::vector<int> &array, int d
   array = result;
 }
 
-void polin_d_radix_batcher_sort_omp::BatcherOddEvenMerge(std::vector<int> &array, int start, int n) {
+void opolin_d_radix_batcher_sort_omp::BatcherOddEvenMerge(std::vector<int> &array, int start, int n) {
   if (n <= 1) return;
 
   int m = n / 2;

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <utility>
 #include <vector>
 
 bool opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP::PreProcessingImpl() {

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
@@ -48,11 +48,17 @@ bool opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP::RunImpl() {
     std::vector<int> negatives;
 
     for (int val : local_input) {
-      if (val >= 0) positives.push_back(val);
-      else negatives.push_back(-val);
+      if (val >= 0) {
+        positives.push_back(val);
+      }
+      else {
+        negatives.push_back(-val);
+      }
     }
     int max_abs = 0;
-    for (int val : local_input) max_abs = std::max(max_abs, std::abs(val));
+    for (int val : local_input) {
+      max_abs = std::max(max_abs, std::abs(val));
+    }
     int digit_count = (max_abs == 0) ? 1 : 0;
     while (max_abs > 0) {
       max_abs /= 10;
@@ -60,13 +66,19 @@ bool opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP::RunImpl() {
     }
 
     for (int place = 1; digit_count > 0; place *= 10, digit_count--) {
-      if (!positives.empty()) SortByDigit(positives, place);
-      if (!negatives.empty()) SortByDigit(negatives, place);
+      if (!positives.empty()) {
+        SortByDigit(positives, place);
+      }
+      if (!negatives.empty()) {
+        SortByDigit(negatives, place);
+      }
     }
 
     if (!negatives.empty()) {
       std::reverse(negatives.begin(), negatives.end());
-      for (size_t j = 0; j < negatives.size(); j++) negatives[j] = -negatives[j];
+      for (size_t j = 0; j < negatives.size(); j++) {
+        negatives[j] = -negatives[j];
+      }
     }
 
     std::vector<int> sorted_local;

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
@@ -1,0 +1,196 @@
+#include "omp/opolin_d_radix_sort_betcher_merge/include/ops_omp.hpp"
+
+#include <omp.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+bool opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP::PreProcessingImpl() {
+  auto *in_ptr = reinterpret_cast<int *>(task_data->inputs[0]);
+  input_ = std::vector<int>(in_ptr, in_ptr + size_);
+  unsigned int output_size = task_data->outputs_count[0];
+  output_ = std::vector<int>(output_size, 0);
+  return true;
+}
+
+bool opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP::ValidationImpl() {
+  // Check equality of counts elements
+  size_ = static_cast<int>(task_data->inputs_count[0]);
+  if (size_ <= 0 || task_data->inputs.empty()) {
+    return false;
+  }
+  return task_data->inputs_count[0] == task_data->outputs_count[0];
+}
+
+bool opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP::RunImpl() {
+  std::vector<int> positives;
+  std::vector<int> negatives;
+  int pos_count = 0;
+  int neg_count = 0;
+#pragma omp parallel
+  {
+    int local_pos_count = 0;
+    int local_neg_count = 0;
+#pragma omp for nowait
+    for (int i = 0; i < size_; i++) {
+      if (input_[i] >= 0) {
+        local_pos_count++;
+      } else {
+        local_neg_count++;
+      }
+    }
+#pragma omp critical
+    {
+      pos_count += local_pos_count;
+      neg_count += local_neg_count;
+    }
+  }
+
+  positives.resize(pos_count);
+  negatives.resize(neg_count);
+
+  int pos_index = 0;
+  int neg_index = 0;
+#pragma omp parallel
+  {
+    std::vector<int> local_pos;
+    std::vector<int> local_neg;
+#pragma omp for nowait
+    for (int i = 0; i < size_; i++) {
+      if (input_[i] >= 0) {
+        local_pos.push_back(input_[i]);
+      } else {
+        local_neg.push_back(-input_[i]);
+      }
+    }
+#pragma omp critical
+    {
+      int start_pos = pos_index;
+      pos_index += local_pos.size();
+      for (size_t j = 0; j < local_pos.size(); j++) {
+        positives[start_pos + j] = local_pos[j];
+      }
+      int start_neg = neg_index;
+      neg_index += local_neg.size();
+      for (size_t j = 0; j < local_neg.size(); j++) {
+        negatives[start_neg + j] = local_neg[j];
+      }
+    }
+  }
+  int max_abs = 0;
+#pragma omp parallel
+  {
+    int local_max = 0;
+#pragma omp for nowait
+    for (int i = 0; i < size_; i++) {
+      int abs_val = std::abs(input_[i]);
+      if (abs_val > local_max) {
+        local_max = abs_val;
+      }
+    }
+#pragma omp critical
+    {
+      if (local_max > max_abs) {
+        max_abs = local_max;
+      }
+    }
+  }
+
+  int digit_count = 0;
+  if (max_abs == 0) {
+    digit_count = 1;
+  } else {
+    while (max_abs > 0) {
+      max_abs /= 10;
+      digit_count++;
+    }
+  }
+#pragma omp parallel sections
+  {
+#pragma omp section
+    {
+      for (int place = 1; digit_count > 0; place *= 10, digit_count--) {
+        if (!positives.empty()) {
+          SortByDigit(positives, place);
+        }
+      }
+    }
+#pragma omp section
+    {
+      for (int place = 1; digit_count > 0; place *= 10, digit_count--) {
+        if (!negatives.empty()) {
+          SortByDigit(negatives, place);
+        }
+      }
+    }
+  }
+
+  if (!negatives.empty()) {
+    std::reverse(negatives.begin(), negatives.end());
+    for (size_t i = 0; i < negatives.size(); i++) {
+      negatives[i] = -negatives[i];
+    }
+  }
+
+  output_.resize(size_);
+  int neg_size = negatives.size();
+  int pos_size = positives.size();
+#pragma omp parallel
+  {
+#pragma omp for nowait
+    for (int i = 0; i < neg_size; i++) {
+      output_[i] = negatives[i];
+    }
+#pragma omp for nowait
+    for (int i = 0; i < pos_size; i++) {
+      output_[neg_size + i] = positives[i];
+    }
+  }
+  BatcherOddEvenMerge(output_, 0, size_);
+  return true;
+}
+
+bool opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP::PostProcessingImpl() {
+  for (size_t i = 0; i < output_.size(); i++) {
+    reinterpret_cast<int *>(task_data->outputs[0])[i] = output_[i];
+  }
+  return true;
+}
+
+void opolin_d_radix_batcher_sort_omp::SortByDigit(std::vector<int> &array, int digit_place) {
+  const int base = 10;
+  std::vector<int> result(array.size());
+  std::vector<int> buckets(base, 0);
+
+  for (int value : array) {
+    int digit = (value / digit_place) % base;
+    buckets[digit]++;
+  }
+  for (int i = 1; i < base; i++) {
+    buckets[i] += buckets[i - 1];
+  }
+  for (int i = static_cast<int>(array.size() - 1); i >= 0; i--) {
+    int digit = (array[i] / digit_place) % base;
+    result[--buckets[digit]] = array[i];
+  }
+  array = result;
+}
+
+void polin_d_radix_batcher_sort_omp::BatcherOddEvenMerge(std::vector<int>& array, int start, int n) {
+  if (n <= 1) return;
+
+  int m = n / 2;
+  BatcherOddEvenMerge(array, start, m);
+  BatcherOddEvenMerge(array, start + m, n - m);
+
+#pragma omp parallel for
+  for (int i = start; i < start + m; i++) {
+    if (i + m < start + n) {
+      if (array[i] > array[i + m]) {
+        std::swap(array[i], array[i + m]);
+      }
+    }
+  }
+}

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
@@ -80,7 +80,7 @@ bool opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP::RunImpl() {
     std::vector<int> sorted_local;
     sorted_local.insert(sorted_local.end(), negatives.begin(), negatives.end());
     sorted_local.insert(sorted_local.end(), positives.begin(), positives.end());
-    std::copy(sorted_local.begin(), sorted_local.end(), temp.begin() + start);
+    std::copy(sorted_local.begin(), sorted_local.end(), input_.begin() + start);
   }
   while (starts.size() > 1) {
     std::vector<int> new_starts;
@@ -92,7 +92,7 @@ bool opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP::RunImpl() {
       int start = starts[idx];
       int mid = ends[idx];
       int end = ends[idx + 1];
-      OddEvenMergeBlocks(input_, start, mid, end);
+      BatcherOddEvenMerge(input_, start, mid, end);
 #pragma omp critical
       {
         new_starts.push_back(start);
@@ -106,7 +106,7 @@ bool opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP::RunImpl() {
     starts = new_starts;
     ends = new_ends;
   }
-  output_ = result;
+  output_ = input_;
   return true;
 }
 

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
@@ -178,7 +178,7 @@ void opolin_d_radix_batcher_sort_omp::SortByDigit(std::vector<int> &array, int d
   array = result;
 }
 
-void polin_d_radix_batcher_sort_omp::BatcherOddEvenMerge(std::vector<int>& array, int start, int n) {
+void polin_d_radix_batcher_sort_omp::BatcherOddEvenMerge(std::vector<int> &array, int start, int n) {
   if (n <= 1) return;
 
   int m = n / 2;

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
@@ -90,9 +90,8 @@ bool opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP::RunImpl() {
     for (int i = 0; i < merge_pairs; i++) {
       int idx = i * 2;
       int start = starts[idx];
-      int mid = ends[idx];
       int end = ends[idx + 1];
-      BatcherOddEvenMerge(input_, start, mid, end);
+      BatcherOddEvenMerge(input_, start, end);
       new_starts[i] = start;
       new_ends[i] = end;
     }
@@ -118,7 +117,6 @@ void opolin_d_radix_batcher_sort_omp::SortByDigit(std::vector<int> &array, int d
   const int base = 10;
   std::vector<int> result(array.size());
   std::vector<int> buckets(base, 0);
-
   for (int value : array) {
     int digit = (value / digit_place) % base;
     buckets[digit]++;
@@ -133,13 +131,21 @@ void opolin_d_radix_batcher_sort_omp::SortByDigit(std::vector<int> &array, int d
   array = result;
 }
 
-void opolin_d_radix_batcher_sort_omp::BatcherOddEvenMerge(std::vector<int> &array, int start, int mid, int end) {
+void opolin_d_radix_batcher_sort_omp::BatcherOddEvenMerge(std::vector<int> &array, int start, int end) {
   int n = end - start;
-  for (int phase = 0; phase < n; phase++) {
-    for (int i = start + (phase % 2); i < end - 1; i += 2) {
-      if (array[i] > array[i + 1]) {
-        std::swap(array[i], array[i + 1]);
+  if (n <= 1) {
+    return;
+  }
+  int mid = start + n / 2;
+  BatcherOddEvenMerge(array, start, mid);
+  BatcherOddEvenMerge(array, mid, end);
+  int k = n / 2;
+  while (k >= 1) {
+    for (int i = start; i + k < end; i++) {
+      if (i < mid && i + k >= mid && array[i] > array[i + k]) {
+        std::swap(array[i], array[i + k]);
       }
     }
+    k /= 2;
   }
 }

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
@@ -136,15 +136,15 @@ void opolin_d_radix_batcher_sort_omp::BatcherOddEvenMerge(std::vector<int> &arra
   if (n <= 1) return;
   int mid = start + n / 2;
   if (n > 2) {
-    BatcherOddEvenMerge(arr, start, mid);
-    BatcherOddEvenMerge(arr, mid, end);
+    BatcherOddEvenMerge(array, start, mid);
+    BatcherOddEvenMerge(array, mid, end);
   }
   for (int step = 1; step < n; step *= 2) {
     for (int i = start; i + step < end; i += 2 * step) {
       int left = i;
       int right = i + step;
-      if (right < end && arr[left] > arr[right]) {
-        std::swap(arr[left], arr[right]);
+      if (right < end && array[left] > array[right]) {
+        std::swap(array[left], array[right]);
       }
     }
   }

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
@@ -46,22 +46,18 @@ bool opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP::RunImpl() {
     std::vector<int> positives;
     std::vector<int> negatives;
 
-    for (size_t i = 0; i < local_input.size(); i++) {
-      if (local_input[i] >= 0) {
-        positives.push_back(local_input[i]);
+    for (size_t j = 0; j < local_input.size(); j++) {
+      if (local_input[j] >= 0) {
+        positives.push_back(local_input[j]);
       } else {
-        negatives.push_back(-local_input[i]);
+        negatives.push_back(-local_input[j]);
       }
     }
     int max_abs = 0;
-    for (size_t i = 0; i < local_input.size(); i++) {
-      max_abs = std::max(max_abs, std::abs(local_input[i]));
+    for (size_t j = 0; j < local_input.size(); j++) {
+      max_abs = std::max(max_abs, std::abs(local_input[j]));
     }
-    int digit_count = (max_abs == 0) ? 1 : 0;
-    while (max_abs > 0) {
-      max_abs /= 10;
-      digit_count++;
-    }
+    int digit_count = (max_abs == 0) ? 1 : static_cast<int>(std::log10(max_abs)) + 1;
     for (int place = 1; digit_count > 0; place *= 10, digit_count--) {
       if (!positives.empty()) {
         SortByDigit(positives, place);
@@ -80,7 +76,7 @@ bool opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP::RunImpl() {
     std::vector<int> sorted_local;
     sorted_local.insert(sorted_local.end(), negatives.begin(), negatives.end());
     sorted_local.insert(sorted_local.end(), positives.begin(), positives.end());
-    std::copy(sorted_local.begin(), sorted_local.end(), input_.begin() + start);
+    std::ranges::copy(sorted_local, input_.begin() + start);
   }
   while (starts.size() > 1) {
     int merge_pairs = static_cast<int>(starts.size()) / 2;

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
@@ -18,7 +18,10 @@ bool opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP::PreProcessingI
 bool opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP::ValidationImpl() {
   // Check equality of counts elements
   size_ = static_cast<int>(task_data->inputs_count[0]);
-  if (size_ <= 0 || task_data->inputs.empty()) {
+  if (size_ <= 0 || task_data->inputs.empty() || task_data->outputs.empty()) {
+    return false;
+  }
+  if (task_data->inputs[0] == nullptr || task_data->outputs[0] == nullptr) {
     return false;
   }
   return task_data->inputs_count[0] == task_data->outputs_count[0];
@@ -60,8 +63,8 @@ bool opolin_d_radix_batcher_sort_omp::RadixBatcherSortTaskOpenMP::RunImpl() {
       new_starts.push_back(starts.back());
       new_ends.push_back(ends.back());
     }
-    starts = new_starts;
-    ends = new_ends;
+    starts = std::move(new_starts);
+    ends = std::move(new_ends);
   }
   output_ = input_;
   return true;

--- a/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
+++ b/tasks/omp/opolin_d_radix_sort_betcher_merge/src/ops_omp.cpp
@@ -146,7 +146,7 @@ void opolin_d_radix_batcher_sort_omp::BatcherOddEvenMerge(std::vector<int> &arra
   }
   while (p > 0) {
 #pragma omp parallel for
-    for (int i = start; i + p < end; i++) {
+    for (int i = start; i < end - p; i++) {
       if (array[i] > array[i + p]) {
         std::swap(array[i], array[i + p]);
       }


### PR DESCRIPTION
1. Делим исходный массив на блоки для параллельной обработки.
2. Применяем алгоритм поразрядной сортировки(LSD) для блоков:
2.1. Создается 10 корзин (от 0 до 9) для распределения элементов по
текущему разряду.
2.2. Переупорядочиваем элементы на основе распределения по корзинам,
сохраняя относительный порядок при равенстве разрядов.
2.3. Для вектора отрицательных чисел порядок элементов реверсируется.
2.4. Вставляем отсортированные блоки в основной массив.
3. Применяем четно-нечетное слияние Бэтчера.
3.1. Слияние участков от start до mid с mid до end, путем сравнения и обмена элементами на расстоянии p(степень 2).