### PR TITLE
Белов Артём. Вариант 18. Технология OMP. Поразрядная сортировка для целых чисел с четно-нечетным слиянием Бэтчера.

### DIFF
--- a/tasks/omp/belov_a_radix_sort_with_batcher_mergesort/func_tests/main.cpp
+++ b/tasks/omp/belov_a_radix_sort_with_batcher_mergesort/func_tests/main.cpp
@@ -1,0 +1,382 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "omp/belov_a_radix_sort_with_batcher_mergesort/include/ops_omp.hpp"
+
+using namespace belov_a_radix_batcher_mergesort_omp;
+
+namespace {
+vector<Bigint> GenerateMixedValuesArray(int n) {
+  random_device rd;
+  mt19937 gen(rd());
+
+  uniform_int_distribution<Bigint> small_range(-999LL, 999LL);
+  uniform_int_distribution<Bigint> medium_range(-10000LL, 10000LL);
+  uniform_int_distribution<Bigint> large_range(-10000000000LL, 10000000000LL);
+  uniform_int_distribution<int> choice(0, 2);
+
+  vector<Bigint> arr;
+  arr.reserve(n);
+
+  for (int i = 0; i < n; ++i) {
+    if (choice(gen) == 0) {
+      arr.push_back(small_range(gen));
+    } else if (choice(gen) == 1) {
+      arr.push_back(medium_range(gen));
+    } else {
+      arr.push_back(large_range(gen));
+    }
+  }
+  return arr;
+}
+
+vector<Bigint> GenerateIntArray(int n) {
+  random_device rd;
+  mt19937 gen(rd());
+  uniform_int_distribution<int> dist(numeric_limits<int>::min(), numeric_limits<int>::max());
+
+  vector<Bigint> arr;
+  arr.reserve(n);
+
+  for (int i = 0; i < n; ++i) {
+    arr.push_back(dist(gen));
+  }
+  return arr;
+}
+
+vector<Bigint> GenerateBigintArray(int n) {
+  random_device rd;
+  mt19937 gen(rd());
+  uniform_int_distribution<Bigint> dist(numeric_limits<Bigint>::min() / 2, numeric_limits<Bigint>::max() / 2);
+
+  vector<Bigint> arr;
+  arr.reserve(n);
+
+  for (int i = 0; i < n; ++i) {
+    arr.push_back(dist(gen));
+  }
+  return arr;
+}
+}  // namespace
+
+TEST(belov_a_radix_batcher_mergesort_omp, test_random_small_BigintV_vector) {
+  int n = 1024;
+  vector<Bigint> arr = GenerateBigintArray(n);
+
+  vector<Bigint> expected_solution = arr;
+  std::ranges::sort(expected_solution);
+
+  shared_ptr<ppc::core::TaskData> task_data_omp = make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->inputs_count.emplace_back(arr.size());
+  task_data_omp->inputs_count.emplace_back(n);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortParallel tesk_task_omp(task_data_omp);
+  ASSERT_EQ(tesk_task_omp.Validation(), true);
+  tesk_task_omp.PreProcessing();
+  tesk_task_omp.Run();
+  tesk_task_omp.PostProcessing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_omp, test_random_medium_BigintV_vector) {
+  int n = 8192;
+  vector<Bigint> arr = GenerateBigintArray(n);
+
+  vector<Bigint> expected_solution = arr;
+  std::ranges::sort(expected_solution);
+
+  shared_ptr<ppc::core::TaskData> task_data_omp = make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->inputs_count.emplace_back(arr.size());
+  task_data_omp->inputs_count.emplace_back(n);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortParallel tesk_task_omp(task_data_omp);
+  ASSERT_EQ(tesk_task_omp.Validation(), true);
+  tesk_task_omp.PreProcessing();
+  tesk_task_omp.Run();
+  tesk_task_omp.PostProcessing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_omp, test_random_large_BigintV_vector) {
+  int n = 65536;
+  vector<Bigint> arr = GenerateBigintArray(n);
+
+  vector<Bigint> expected_solution = arr;
+  std::ranges::sort(expected_solution);
+
+  shared_ptr<ppc::core::TaskData> task_data_omp = make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->inputs_count.emplace_back(arr.size());
+  task_data_omp->inputs_count.emplace_back(n);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortParallel tesk_task_omp(task_data_omp);
+  ASSERT_EQ(tesk_task_omp.Validation(), true);
+  tesk_task_omp.PreProcessing();
+  tesk_task_omp.Run();
+  tesk_task_omp.PostProcessing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_omp, test_random_small_intV_vector) {
+  int n = 4096;
+  vector<Bigint> arr = GenerateIntArray(n);
+
+  vector<Bigint> expected_solution = arr;
+  std::ranges::sort(expected_solution);
+
+  shared_ptr<ppc::core::TaskData> task_data_omp = make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->inputs_count.emplace_back(arr.size());
+  task_data_omp->inputs_count.emplace_back(n);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortParallel tesk_task_omp(task_data_omp);
+  ASSERT_EQ(tesk_task_omp.Validation(), true);
+  tesk_task_omp.PreProcessing();
+  tesk_task_omp.Run();
+  tesk_task_omp.PostProcessing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_omp, test_random_medium_intV_vector) {
+  int n = 16384;
+  vector<Bigint> arr = GenerateIntArray(n);
+
+  vector<Bigint> expected_solution = arr;
+  std::ranges::sort(expected_solution);
+
+  shared_ptr<ppc::core::TaskData> task_data_omp = make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->inputs_count.emplace_back(arr.size());
+  task_data_omp->inputs_count.emplace_back(n);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortParallel tesk_task_omp(task_data_omp);
+  ASSERT_EQ(tesk_task_omp.Validation(), true);
+  tesk_task_omp.PreProcessing();
+  tesk_task_omp.Run();
+  tesk_task_omp.PostProcessing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_omp, test_random_large_intV_vector) {
+  int n = 65536;
+  vector<Bigint> arr = GenerateIntArray(n);
+
+  vector<Bigint> expected_solution = arr;
+  std::ranges::sort(expected_solution);
+
+  shared_ptr<ppc::core::TaskData> task_data_omp = make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->inputs_count.emplace_back(arr.size());
+  task_data_omp->inputs_count.emplace_back(n);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortParallel tesk_task_omp(task_data_omp);
+  ASSERT_EQ(tesk_task_omp.Validation(), true);
+  tesk_task_omp.PreProcessing();
+  tesk_task_omp.Run();
+  tesk_task_omp.PostProcessing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_omp, test_random_small_mixedV_vector) {
+  int n = 2048;
+  vector<Bigint> arr = GenerateMixedValuesArray(n);
+
+  vector<Bigint> expected_solution = arr;
+  std::ranges::sort(expected_solution);
+
+  shared_ptr<ppc::core::TaskData> task_data_omp = make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->inputs_count.emplace_back(arr.size());
+  task_data_omp->inputs_count.emplace_back(n);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortParallel tesk_task_omp(task_data_omp);
+  ASSERT_EQ(tesk_task_omp.Validation(), true);
+  tesk_task_omp.PreProcessing();
+  tesk_task_omp.Run();
+  tesk_task_omp.PostProcessing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_omp, test_random_medium_mixedV_vector) {
+  int n = 16384;
+  vector<Bigint> arr = GenerateMixedValuesArray(n);
+
+  vector<Bigint> expected_solution = arr;
+  std::ranges::sort(expected_solution);
+
+  shared_ptr<ppc::core::TaskData> task_data_omp = make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->inputs_count.emplace_back(arr.size());
+  task_data_omp->inputs_count.emplace_back(n);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortParallel tesk_task_omp(task_data_omp);
+  ASSERT_EQ(tesk_task_omp.Validation(), true);
+  tesk_task_omp.PreProcessing();
+  tesk_task_omp.Run();
+  tesk_task_omp.PostProcessing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_omp, test_random_large_mixedV_vector) {
+  int n = 65536;
+  vector<Bigint> arr = GenerateMixedValuesArray(n);
+
+  vector<Bigint> expected_solution = arr;
+  std::ranges::sort(expected_solution);
+
+  shared_ptr<ppc::core::TaskData> task_data_omp = make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->inputs_count.emplace_back(arr.size());
+  task_data_omp->inputs_count.emplace_back(n);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortParallel tesk_task_omp(task_data_omp);
+  ASSERT_EQ(tesk_task_omp.Validation(), true);
+  tesk_task_omp.PreProcessing();
+  tesk_task_omp.Run();
+  tesk_task_omp.PostProcessing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_omp, test_predefined_intV_vector) {
+  int n = 16;
+  vector<Bigint> arr = {74685421,  -53749, 2147483647, -1000, -2147483648, 1001, 0,       124,
+                        315986930, -123,   42,         -43,   2,           -1,   -999999, 999998};
+
+  vector<Bigint> expected_solution = arr;
+  std::ranges::sort(expected_solution);
+
+  shared_ptr<ppc::core::TaskData> task_data_omp = make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->inputs_count.emplace_back(arr.size());
+  task_data_omp->inputs_count.emplace_back(n);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortParallel tesk_task_omp(task_data_omp);
+  ASSERT_EQ(tesk_task_omp.Validation(), true);
+  tesk_task_omp.PreProcessing();
+  tesk_task_omp.Run();
+  tesk_task_omp.PostProcessing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_omp, test_one_element_input_Bigint) {
+  int n = 1;
+  vector<Bigint> arr = {8888};
+
+  vector<Bigint> expected_solution = arr;
+
+  shared_ptr<ppc::core::TaskData> task_data_omp = make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->inputs_count.emplace_back(arr.size());
+  task_data_omp->inputs_count.emplace_back(n);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortParallel tesk_task_omp(task_data_omp);
+  ASSERT_EQ(tesk_task_omp.Validation(), true);
+  tesk_task_omp.PreProcessing();
+  tesk_task_omp.Run();
+  tesk_task_omp.PostProcessing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_omp, test_array_size_missmatch) {
+  int n = 3;
+  vector<Bigint> arr = {-53742329, -2147483648, 123265244, 0, 315986930, 42, 2147483647, -853960, 472691};
+
+  shared_ptr<ppc::core::TaskData> task_data_omp = make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->inputs_count.emplace_back(arr.size());
+  task_data_omp->inputs_count.emplace_back(n);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortParallel tesk_task_omp(task_data_omp);
+
+  EXPECT_FALSE(tesk_task_omp.Validation());
+}
+
+TEST(belov_a_radix_batcher_mergesort_omp, test_invalid_inputs_count) {
+  int n = 3;
+  vector<Bigint> arr = {-53742329, -2147483648, 123265244, 0, 315986930, 42, 2147483647, -853960, 472691};
+
+  shared_ptr<ppc::core::TaskData> task_data_omp = make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->inputs_count.emplace_back(n);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortParallel tesk_task_omp(task_data_omp);
+
+  EXPECT_FALSE(tesk_task_omp.Validation());
+}
+
+TEST(belov_a_radix_batcher_mergesort_omp, test_empty_input_Validation) {
+  int n = 0;
+  vector<Bigint> arr = {};
+
+  shared_ptr<ppc::core::TaskData> task_data_omp = make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->inputs_count.emplace_back(arr.size());
+  task_data_omp->inputs_count.emplace_back(n);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortParallel tesk_task_omp(task_data_omp);
+
+  EXPECT_FALSE(tesk_task_omp.Validation());
+}
+
+TEST(belov_a_radix_batcher_mergesort_omp, test_empty_output_Validation) {
+  int n = 3;
+  vector<Bigint> arr = {789, 654, 231, 0, 123456789, 792012345678, -22475942, -853960, 59227648};
+
+  shared_ptr<ppc::core::TaskData> task_data_omp = make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->inputs_count.emplace_back(arr.size());
+  task_data_omp->inputs_count.emplace_back(n);
+  // task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_omp->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortParallel tesk_task_omp(task_data_omp);
+
+  EXPECT_FALSE(tesk_task_omp.Validation());
+}

--- a/tasks/omp/belov_a_radix_sort_with_batcher_mergesort/func_tests/main.cpp
+++ b/tasks/omp/belov_a_radix_sort_with_batcher_mergesort/func_tests/main.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <random>
 #include <vector>

--- a/tasks/omp/belov_a_radix_sort_with_batcher_mergesort/include/ops_omp.hpp
+++ b/tasks/omp/belov_a_radix_sort_with_batcher_mergesort/include/ops_omp.hpp
@@ -4,6 +4,7 @@
 #include <omp.h>
 
 #include <cmath>
+#include <cstddef>
 #include <memory>
 #include <span>
 #include <utility>

--- a/tasks/omp/belov_a_radix_sort_with_batcher_mergesort/include/ops_omp.hpp
+++ b/tasks/omp/belov_a_radix_sort_with_batcher_mergesort/include/ops_omp.hpp
@@ -1,0 +1,45 @@
+#ifndef OPS_OMP_HPP
+#define OPS_OMP_HPP
+
+#include <omp.h>
+
+#include <cmath>
+#include <memory>
+#include <span>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+using Bigint = long long;
+using namespace std;
+
+namespace belov_a_radix_batcher_mergesort_omp {
+
+class RadixBatcherMergesortParallel : public ppc::core::Task {
+ public:
+  explicit RadixBatcherMergesortParallel(std::shared_ptr<ppc::core::TaskData> task_data) : Task(std::move(task_data)) {}
+
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+  static void Sort(std::span<Bigint> arr);
+
+ private:
+  vector<Bigint> array_;  // input unsorted numbers array
+  size_t n_ = 0;          // array size
+
+  static void RadixSort(vector<Bigint>& arr, bool invert);
+  static void CountingSort(vector<Bigint>& arr, Bigint digit_place);
+  static int GetNumberDigitCapacity(Bigint num);
+
+  static void SortParallel(vector<Bigint>& arr);
+  static void BatcherMergeParallel(vector<Bigint>& arr, int num_threads);
+  static vector<Bigint> OddEvenMerge(const vector<Bigint>& left, const vector<Bigint>& right);
+};
+
+}  // namespace belov_a_radix_batcher_mergesort_omp
+
+#endif  // OPS_OMP_HPP

--- a/tasks/omp/belov_a_radix_sort_with_batcher_mergesort/perf_tests/main.cpp
+++ b/tasks/omp/belov_a_radix_sort_with_batcher_mergesort/perf_tests/main.cpp
@@ -1,0 +1,123 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "omp/belov_a_radix_sort_with_batcher_mergesort/include/ops_omp.hpp"
+
+using namespace belov_a_radix_batcher_mergesort_omp;
+
+namespace {
+vector<Bigint> GenerateMixedValuesArray(int n) {
+  random_device rd;
+  mt19937 gen(rd());
+
+  uniform_int_distribution<Bigint> small_range(-999LL, 999LL);
+  uniform_int_distribution<Bigint> medium_range(-10000LL, 10000LL);
+  uniform_int_distribution<Bigint> large_range(-10000000000LL, 10000000000LL);
+  uniform_int_distribution<int> choice(0, 2);
+
+  vector<Bigint> arr;
+  arr.reserve(n);
+
+  for (int i = 0; i < n; ++i) {
+    if (choice(gen) == 0) {
+      arr.push_back(small_range(gen));
+    } else if (choice(gen) == 1) {
+      arr.push_back(medium_range(gen));
+    } else {
+      arr.push_back(large_range(gen));
+    }
+  }
+  return arr;
+}
+}  // namespace
+
+TEST(belov_a_radix_batcher_mergesort_omp, test_pipeline_run) {
+  // Create data
+  int n = 4194304;
+  vector<Bigint> arr = GenerateMixedValuesArray(n);
+
+  // Create TaskData
+  shared_ptr<ppc::core::TaskData> task_data_omp = make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+  task_data_omp->inputs_count.emplace_back(arr.size());
+  task_data_omp->inputs_count.emplace_back(n);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+  task_data_omp->outputs_count.emplace_back(arr.size());
+
+  // Create Task
+  auto tesk_task_omp =
+      std::make_shared<belov_a_radix_batcher_mergesort_omp::RadixBatcherMergesortParallel>(task_data_omp);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(tesk_task_omp);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+
+  ASSERT_TRUE(tesk_task_omp->Validation());
+  tesk_task_omp->PreProcessing();
+  tesk_task_omp->Run();
+  tesk_task_omp->PostProcessing();
+
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}
+
+TEST(belov_a_radix_batcher_mergesort_omp, test_task_run) {
+  // Create data
+  int n = 4194304;
+  vector<Bigint> arr = GenerateMixedValuesArray(n);
+
+  // Create TaskData
+  shared_ptr<ppc::core::TaskData> task_data_omp = make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+  task_data_omp->inputs_count.emplace_back(arr.size());
+  task_data_omp->inputs_count.emplace_back(n);
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+  task_data_omp->outputs_count.emplace_back(arr.size());
+
+  // Create Task
+  auto tesk_task_omp =
+      std::make_shared<belov_a_radix_batcher_mergesort_omp::RadixBatcherMergesortParallel>(task_data_omp);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(tesk_task_omp);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+
+  ASSERT_TRUE(tesk_task_omp->Validation());
+  tesk_task_omp->PreProcessing();
+  tesk_task_omp->Run();
+  tesk_task_omp->PostProcessing();
+
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}

--- a/tasks/omp/belov_a_radix_sort_with_batcher_mergesort/src/ops_omp.cpp
+++ b/tasks/omp/belov_a_radix_sort_with_batcher_mergesort/src/ops_omp.cpp
@@ -1,0 +1,159 @@
+#include "omp/belov_a_radix_sort_with_batcher_mergesort/include/ops_omp.hpp"
+
+#include <cmath>
+
+#include "core/util/include/util.hpp"
+
+using namespace std;
+
+namespace belov_a_radix_batcher_mergesort_omp {
+
+int RadixBatcherMergesortParallel::GetNumberDigitCapacity(Bigint num) {
+  return (num == 0 ? 1 : static_cast<int>(log10(abs(num))) + 1);
+}
+
+void RadixBatcherMergesortParallel::Sort(std::span<Bigint> arr) {
+  vector<Bigint> pos;
+  vector<Bigint> neg;
+
+  for (const auto& num : arr) {
+    (num >= 0 ? pos : neg).push_back(abs(num));
+  }
+
+  RadixSort(pos, false);
+  RadixSort(neg, true);
+
+  size_t index = 0;
+
+  for (const auto& num : neg) {
+    arr[index++] = -num;
+  }
+
+  for (const auto& num : pos) {
+    arr[index++] = num;
+  }
+}
+
+void RadixBatcherMergesortParallel::RadixSort(vector<Bigint>& arr, bool invert) {
+  if (arr.empty()) {
+    return;
+  }
+
+  Bigint max_val = *std::max_element(arr.begin(), arr.end());
+  int max_val_digit_capacity = GetNumberDigitCapacity(max_val);
+  int iter = 1;
+
+  for (Bigint digit_place = 1; iter <= max_val_digit_capacity; digit_place *= 10, ++iter) {
+    CountingSort(arr, digit_place);
+  }
+
+  if (invert) {
+    std::reverse(arr.begin(), arr.end());
+  }
+}
+
+void RadixBatcherMergesortParallel::CountingSort(vector<Bigint>& arr, Bigint digit_place) {
+  vector<Bigint> output(arr.size());
+  int count[10] = {};
+
+  for (const auto& num : arr) {
+    Bigint index = (num / digit_place) % 10;
+    count[index]++;
+  }
+
+  for (int i = 1; i < 10; i++) {
+    count[i] += count[i - 1];
+  }
+
+  for (size_t i = arr.size() - 1; i < arr.size(); i--) {
+    Bigint num = arr[i];
+    Bigint index = (num / digit_place) % 10;
+    output[--count[index]] = num;
+  }
+
+  std::copy(output.begin(), output.end(), arr.begin());
+}
+
+void RadixBatcherMergesortParallel::SortParallel(vector<Bigint>& arr) {
+  if (arr.empty()) {
+    return;
+  }
+
+  int num_threads = ppc::util::GetPPCNumThreads();
+  size_t chunk_size = arr.size() / num_threads;
+
+#pragma omp parallel num_threads(num_threads)
+  {
+    int thread_id = omp_get_thread_num();
+    size_t start = thread_id * chunk_size;
+    size_t end = (thread_id == num_threads - 1) ? arr.size() : start + chunk_size;
+
+    std::span<Bigint> local_span(arr.data() + start, end - start);
+    Sort(local_span);
+  }
+}
+
+void RadixBatcherMergesortParallel::BatcherMergeParallel(vector<Bigint>& arr, int num_threads) {
+  size_t n = arr.size();
+
+  if (n == 0) {
+    return;
+  }
+
+  num_threads = std::max(1, num_threads);
+
+  size_t chunk_size = n / num_threads;            // if n < num_threads, chunk_size = 0
+  size_t step = std::max<size_t>(chunk_size, 1);  // guarantee that step >= 1 (to avoid division by zero)
+
+  for (; step < n; step *= 2) {
+#pragma omp parallel for
+    for (size_t i = 0; i < n - step; i += 2 * step) {
+      size_t left = i;
+      size_t right = i + step;
+      size_t end = std::min(i + 2 * step, n);
+
+      std::inplace_merge(arr.begin() + static_cast<int64_t>(left), arr.begin() + static_cast<int64_t>(right),
+                         arr.begin() + static_cast<int64_t>(end));
+    }
+  }
+}
+
+vector<Bigint> RadixBatcherMergesortParallel::OddEvenMerge(const vector<Bigint>& left, const vector<Bigint>& right) {
+  vector<Bigint> merged(left.size() + right.size());
+  std::merge(left.begin(), left.end(), right.begin(), right.end(), merged.begin());
+
+  for (size_t i = 1; i < merged.size(); i += 2) {
+    if (i + 1 < merged.size() && merged[i] > merged[i + 1]) {
+      std::swap(merged[i], merged[i + 1]);
+    }
+  }
+  return merged;
+}
+
+bool RadixBatcherMergesortParallel::PreProcessingImpl() {
+  n_ = task_data->inputs_count[0];
+  auto* input_array_data = reinterpret_cast<Bigint*>(task_data->inputs[0]);
+  array_.assign(input_array_data, input_array_data + n_);
+
+  return true;
+}
+
+bool RadixBatcherMergesortParallel::ValidationImpl() {
+  return (task_data->inputs.size() == 1 && !(task_data->inputs_count.size() < 2) && task_data->inputs_count[0] != 0 &&
+          (task_data->inputs_count[0] == task_data->inputs_count[1]) && !task_data->outputs.empty());
+}
+
+bool RadixBatcherMergesortParallel::RunImpl() {
+  int num_threads = ppc::util::GetPPCNumThreads();
+  SortParallel(array_);
+  BatcherMergeParallel(array_, num_threads);
+
+  return true;
+}
+
+bool RadixBatcherMergesortParallel::PostProcessingImpl() {
+  copy(array_.begin(), array_.end(), reinterpret_cast<Bigint*>(task_data->outputs[0]));
+  return true;
+}
+
+}  // namespace belov_a_radix_batcher_mergesort_omp

--- a/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/func_tests/main.cpp
+++ b/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/func_tests/main.cpp
@@ -1,0 +1,384 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "seq/belov_a_radix_sort_with_batcher_mergesort/include/ops_seq.hpp"
+
+using namespace belov_a_radix_batcher_mergesort_seq;
+
+namespace {
+vector<Bigint> GenerateMixedValuesArray(int n) {
+  random_device rd;
+  mt19937 gen(rd());
+
+  uniform_int_distribution<Bigint> small_range(-999LL, 999LL);
+  uniform_int_distribution<Bigint> medium_range(-10000LL, 10000LL);
+  uniform_int_distribution<Bigint> large_range(-10000000000LL, 10000000000LL);
+  uniform_int_distribution<int> choice(0, 2);
+
+  vector<Bigint> arr;
+  arr.reserve(n);
+
+  for (int i = 0; i < n; ++i) {
+    if (choice(gen) == 0) {
+      arr.push_back(small_range(gen));
+    } else if (choice(gen) == 1) {
+      arr.push_back(medium_range(gen));
+    } else {
+      arr.push_back(large_range(gen));
+    }
+  }
+  return arr;
+}
+
+vector<Bigint> GenerateIntArray(int n) {
+  random_device rd;
+  mt19937 gen(rd());
+  uniform_int_distribution<int> dist(numeric_limits<int>::min(), numeric_limits<int>::max());
+
+  vector<Bigint> arr;
+  arr.reserve(n);
+
+  for (int i = 0; i < n; ++i) {
+    arr.push_back(dist(gen));
+  }
+  return arr;
+}
+
+vector<Bigint> GenerateBigintArray(int n) {
+  random_device rd;
+  mt19937 gen(rd());
+  uniform_int_distribution<Bigint> dist(numeric_limits<Bigint>::min() / 2, numeric_limits<Bigint>::max() / 2);
+
+  vector<Bigint> arr;
+  arr.reserve(n);
+
+  for (int i = 0; i < n; ++i) {
+    arr.push_back(dist(gen));
+  }
+  return arr;
+}
+}  // namespace
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_random_small_BigintV_vector) {
+  int n = 1024;
+  vector<Bigint> arr = GenerateBigintArray(n);
+
+  vector<Bigint> expected_solution = arr;
+  std::ranges::sort(expected_solution);
+
+  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->inputs_count.emplace_back(arr.size());
+  task_data_seq->inputs_count.emplace_back(n);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_random_medium_BigintV_vector) {
+  int n = 8192;
+  vector<Bigint> arr = GenerateBigintArray(n);
+
+  vector<Bigint> expected_solution = arr;
+  std::ranges::sort(expected_solution);
+
+  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->inputs_count.emplace_back(arr.size());
+  task_data_seq->inputs_count.emplace_back(n);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_random_large_BigintV_vector) {
+  int n = 65536;
+  vector<Bigint> arr = GenerateBigintArray(n);
+
+  vector<Bigint> expected_solution = arr;
+  std::ranges::sort(expected_solution);
+
+  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->inputs_count.emplace_back(arr.size());
+  task_data_seq->inputs_count.emplace_back(n);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_random_small_intV_vector) {
+  int n = 4096;
+  vector<Bigint> arr = GenerateIntArray(n);
+
+  vector<Bigint> expected_solution = arr;
+  std::ranges::sort(expected_solution);
+
+  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->inputs_count.emplace_back(arr.size());
+  task_data_seq->inputs_count.emplace_back(n);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_random_medium_intV_vector) {
+  int n = 16384;
+  vector<Bigint> arr = GenerateIntArray(n);
+
+  vector<Bigint> expected_solution = arr;
+  std::ranges::sort(expected_solution);
+
+  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->inputs_count.emplace_back(arr.size());
+  task_data_seq->inputs_count.emplace_back(n);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_random_large_intV_vector) {
+  int n = 65536;
+  vector<Bigint> arr = GenerateIntArray(n);
+
+  vector<Bigint> expected_solution = arr;
+  std::ranges::sort(expected_solution);
+
+  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->inputs_count.emplace_back(arr.size());
+  task_data_seq->inputs_count.emplace_back(n);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_random_small_mixedV_vector) {
+  int n = 2048;
+  vector<Bigint> arr = GenerateMixedValuesArray(n);
+
+  vector<Bigint> expected_solution = arr;
+  std::ranges::sort(expected_solution);
+
+  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->inputs_count.emplace_back(arr.size());
+  task_data_seq->inputs_count.emplace_back(n);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_random_medium_mixedV_vector) {
+  int n = 16384;
+  vector<Bigint> arr = GenerateMixedValuesArray(n);
+
+  vector<Bigint> expected_solution = arr;
+  std::ranges::sort(expected_solution);
+
+  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->inputs_count.emplace_back(arr.size());
+  task_data_seq->inputs_count.emplace_back(n);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_random_large_mixedV_vector) {
+  int n = 65536;
+  vector<Bigint> arr = GenerateMixedValuesArray(n);
+
+  vector<Bigint> expected_solution = arr;
+  std::ranges::sort(expected_solution);
+
+  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->inputs_count.emplace_back(arr.size());
+  task_data_seq->inputs_count.emplace_back(n);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_predefined_intV_vector) {
+  int n = 16;
+  vector<Bigint> arr = {74685421,  -53749, 2147483647, -1000, -2147483648, 1001, 0,       124,
+                        315986930, -123,   42,         -43,   2,           -1,   -999999, 999998};
+
+  vector<Bigint> expected_solution = arr;
+  std::ranges::sort(expected_solution);
+
+  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->inputs_count.emplace_back(arr.size());
+  task_data_seq->inputs_count.emplace_back(n);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_one_element_input_Bigint) {
+  int n = 1;
+  vector<Bigint> arr = {8888};
+
+  vector<Bigint> expected_solution = arr;
+
+  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->inputs_count.emplace_back(arr.size());
+  task_data_seq->inputs_count.emplace_back(n);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+
+  EXPECT_EQ(arr, expected_solution);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_array_size_missmatch) {
+  int n = 3;
+  vector<Bigint> arr = {-53742329, -2147483648, 123265244, 0, 315986930, 42, 2147483647, -853960, 472691};
+
+  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->inputs_count.emplace_back(arr.size());
+  task_data_seq->inputs_count.emplace_back(n);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential test_task_sequential(task_data_seq);
+
+  EXPECT_FALSE(test_task_sequential.Validation());
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_invalid_inputs_count) {
+  int n = 3;
+  vector<Bigint> arr = {-53742329, -2147483648, 123265244, 0, 315986930, 42, 2147483647, -853960, 472691};
+
+  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  // task_data_seq->inputs_count.emplace_back(arr.size());
+  task_data_seq->inputs_count.emplace_back(n);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential test_task_sequential(task_data_seq);
+
+  EXPECT_FALSE(test_task_sequential.Validation());
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_empty_input_Validation) {
+  int n = 0;
+  vector<Bigint> arr = {};
+
+  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->inputs_count.emplace_back(arr.size());
+  task_data_seq->inputs_count.emplace_back(n);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential test_task_sequential(task_data_seq);
+
+  EXPECT_FALSE(test_task_sequential.Validation());
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_empty_output_Validation) {
+  int n = 3;
+  vector<Bigint> arr = {789, 654, 231, 0, 123456789, 792012345678, -22475942, -853960, 59227648};
+
+  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->inputs_count.emplace_back(arr.size());
+  task_data_seq->inputs_count.emplace_back(n);
+  // task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
+  task_data_seq->outputs_count.emplace_back(arr.size());
+
+  RadixBatcherMergesortSequential test_task_sequential(task_data_seq);
+
+  EXPECT_FALSE(test_task_sequential.Validation());
+}

--- a/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/func_tests/main.cpp
+++ b/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/func_tests/main.cpp
@@ -13,16 +13,16 @@
 using namespace belov_a_radix_batcher_mergesort_seq;
 
 namespace {
-vector<Bigint> GenerateMixedValuesArray(int n) {
-  random_device rd;
-  mt19937 gen(rd());
+std::vector<Bigint> GenerateMixedValuesArray(int n) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
 
-  uniform_int_distribution<Bigint> small_range(-999LL, 999LL);
-  uniform_int_distribution<Bigint> medium_range(-10000LL, 10000LL);
-  uniform_int_distribution<Bigint> large_range(-10000000000LL, 10000000000LL);
-  uniform_int_distribution<int> choice(0, 2);
+  std::uniform_int_distribution<Bigint> small_range(-999LL, 999LL);
+  std::uniform_int_distribution<Bigint> medium_range(-10000LL, 10000LL);
+  std::uniform_int_distribution<Bigint> large_range(-10000000000LL, 10000000000LL);
+  std::uniform_int_distribution<int> choice(0, 2);
 
-  vector<Bigint> arr;
+  std::vector<Bigint> arr;
   arr.reserve(n);
 
   for (int i = 0; i < n; ++i) {
@@ -37,12 +37,12 @@ vector<Bigint> GenerateMixedValuesArray(int n) {
   return arr;
 }
 
-vector<Bigint> GenerateIntArray(int n) {
-  random_device rd;
-  mt19937 gen(rd());
-  uniform_int_distribution<int> dist(numeric_limits<int>::min(), numeric_limits<int>::max());
+std::vector<Bigint> GenerateIntArray(int n) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> dist(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
 
-  vector<Bigint> arr;
+  std::vector<Bigint> arr;
   arr.reserve(n);
 
   for (int i = 0; i < n; ++i) {
@@ -51,12 +51,13 @@ vector<Bigint> GenerateIntArray(int n) {
   return arr;
 }
 
-vector<Bigint> GenerateBigintArray(int n) {
-  random_device rd;
-  mt19937 gen(rd());
-  uniform_int_distribution<Bigint> dist(numeric_limits<Bigint>::min() / 2, numeric_limits<Bigint>::max() / 2);
+std::vector<Bigint> GenerateBigintArray(int n) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<Bigint> dist(std::numeric_limits<Bigint>::min() / 2,
+                                             std::numeric_limits<Bigint>::max() / 2);
 
-  vector<Bigint> arr;
+  std::vector<Bigint> arr;
   arr.reserve(n);
 
   for (int i = 0; i < n; ++i) {
@@ -68,12 +69,12 @@ vector<Bigint> GenerateBigintArray(int n) {
 
 TEST(belov_a_radix_batcher_mergesort_seq, test_random_small_BigintV_vector) {
   int n = 1024;
-  vector<Bigint> arr = GenerateBigintArray(n);
+  std::vector<Bigint> arr = GenerateBigintArray(n);
 
-  vector<Bigint> expected_solution = arr;
+  std::vector<Bigint> expected_solution = arr;
   std::ranges::sort(expected_solution);
 
-  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
   task_data_seq->inputs_count.emplace_back(arr.size());
   task_data_seq->inputs_count.emplace_back(n);
@@ -91,12 +92,12 @@ TEST(belov_a_radix_batcher_mergesort_seq, test_random_small_BigintV_vector) {
 
 TEST(belov_a_radix_batcher_mergesort_seq, test_random_medium_BigintV_vector) {
   int n = 8192;
-  vector<Bigint> arr = GenerateBigintArray(n);
+  std::vector<Bigint> arr = GenerateBigintArray(n);
 
-  vector<Bigint> expected_solution = arr;
+  std::vector<Bigint> expected_solution = arr;
   std::ranges::sort(expected_solution);
 
-  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
   task_data_seq->inputs_count.emplace_back(arr.size());
   task_data_seq->inputs_count.emplace_back(n);
@@ -114,12 +115,12 @@ TEST(belov_a_radix_batcher_mergesort_seq, test_random_medium_BigintV_vector) {
 
 TEST(belov_a_radix_batcher_mergesort_seq, test_random_large_BigintV_vector) {
   int n = 65536;
-  vector<Bigint> arr = GenerateBigintArray(n);
+  std::vector<Bigint> arr = GenerateBigintArray(n);
 
-  vector<Bigint> expected_solution = arr;
+  std::vector<Bigint> expected_solution = arr;
   std::ranges::sort(expected_solution);
 
-  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
   task_data_seq->inputs_count.emplace_back(arr.size());
   task_data_seq->inputs_count.emplace_back(n);
@@ -137,12 +138,12 @@ TEST(belov_a_radix_batcher_mergesort_seq, test_random_large_BigintV_vector) {
 
 TEST(belov_a_radix_batcher_mergesort_seq, test_random_small_intV_vector) {
   int n = 4096;
-  vector<Bigint> arr = GenerateIntArray(n);
+  std::vector<Bigint> arr = GenerateIntArray(n);
 
-  vector<Bigint> expected_solution = arr;
+  std::vector<Bigint> expected_solution = arr;
   std::ranges::sort(expected_solution);
 
-  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
   task_data_seq->inputs_count.emplace_back(arr.size());
   task_data_seq->inputs_count.emplace_back(n);
@@ -160,12 +161,12 @@ TEST(belov_a_radix_batcher_mergesort_seq, test_random_small_intV_vector) {
 
 TEST(belov_a_radix_batcher_mergesort_seq, test_random_medium_intV_vector) {
   int n = 16384;
-  vector<Bigint> arr = GenerateIntArray(n);
+  std::vector<Bigint> arr = GenerateIntArray(n);
 
-  vector<Bigint> expected_solution = arr;
+  std::vector<Bigint> expected_solution = arr;
   std::ranges::sort(expected_solution);
 
-  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
   task_data_seq->inputs_count.emplace_back(arr.size());
   task_data_seq->inputs_count.emplace_back(n);
@@ -183,12 +184,12 @@ TEST(belov_a_radix_batcher_mergesort_seq, test_random_medium_intV_vector) {
 
 TEST(belov_a_radix_batcher_mergesort_seq, test_random_large_intV_vector) {
   int n = 65536;
-  vector<Bigint> arr = GenerateIntArray(n);
+  std::vector<Bigint> arr = GenerateIntArray(n);
 
-  vector<Bigint> expected_solution = arr;
+  std::vector<Bigint> expected_solution = arr;
   std::ranges::sort(expected_solution);
 
-  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
   task_data_seq->inputs_count.emplace_back(arr.size());
   task_data_seq->inputs_count.emplace_back(n);
@@ -206,12 +207,12 @@ TEST(belov_a_radix_batcher_mergesort_seq, test_random_large_intV_vector) {
 
 TEST(belov_a_radix_batcher_mergesort_seq, test_random_small_mixedV_vector) {
   int n = 2048;
-  vector<Bigint> arr = GenerateMixedValuesArray(n);
+  std::vector<Bigint> arr = GenerateMixedValuesArray(n);
 
-  vector<Bigint> expected_solution = arr;
+  std::vector<Bigint> expected_solution = arr;
   std::ranges::sort(expected_solution);
 
-  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
   task_data_seq->inputs_count.emplace_back(arr.size());
   task_data_seq->inputs_count.emplace_back(n);
@@ -229,12 +230,12 @@ TEST(belov_a_radix_batcher_mergesort_seq, test_random_small_mixedV_vector) {
 
 TEST(belov_a_radix_batcher_mergesort_seq, test_random_medium_mixedV_vector) {
   int n = 16384;
-  vector<Bigint> arr = GenerateMixedValuesArray(n);
+  std::vector<Bigint> arr = GenerateMixedValuesArray(n);
 
-  vector<Bigint> expected_solution = arr;
+  std::vector<Bigint> expected_solution = arr;
   std::ranges::sort(expected_solution);
 
-  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
   task_data_seq->inputs_count.emplace_back(arr.size());
   task_data_seq->inputs_count.emplace_back(n);
@@ -252,12 +253,12 @@ TEST(belov_a_radix_batcher_mergesort_seq, test_random_medium_mixedV_vector) {
 
 TEST(belov_a_radix_batcher_mergesort_seq, test_random_large_mixedV_vector) {
   int n = 65536;
-  vector<Bigint> arr = GenerateMixedValuesArray(n);
+  std::vector<Bigint> arr = GenerateMixedValuesArray(n);
 
-  vector<Bigint> expected_solution = arr;
+  std::vector<Bigint> expected_solution = arr;
   std::ranges::sort(expected_solution);
 
-  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
   task_data_seq->inputs_count.emplace_back(arr.size());
   task_data_seq->inputs_count.emplace_back(n);
@@ -275,13 +276,13 @@ TEST(belov_a_radix_batcher_mergesort_seq, test_random_large_mixedV_vector) {
 
 TEST(belov_a_radix_batcher_mergesort_seq, test_predefined_intV_vector) {
   int n = 16;
-  vector<Bigint> arr = {74685421,  -53749, 2147483647, -1000, -2147483648, 1001, 0,       124,
-                        315986930, -123,   42,         -43,   2,           -1,   -999999, 999998};
+  std::vector<Bigint> arr = {74685421,  -53749, 2147483647, -1000, -2147483648, 1001, 0,       124,
+                             315986930, -123,   42,         -43,   2,           -1,   -999999, 999998};
 
-  vector<Bigint> expected_solution = arr;
+  std::vector<Bigint> expected_solution = arr;
   std::ranges::sort(expected_solution);
 
-  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
   task_data_seq->inputs_count.emplace_back(arr.size());
   task_data_seq->inputs_count.emplace_back(n);
@@ -299,11 +300,11 @@ TEST(belov_a_radix_batcher_mergesort_seq, test_predefined_intV_vector) {
 
 TEST(belov_a_radix_batcher_mergesort_seq, test_one_element_input_Bigint) {
   int n = 1;
-  vector<Bigint> arr = {8888};
+  std::vector<Bigint> arr = {8888};
 
-  vector<Bigint> expected_solution = arr;
+  std::vector<Bigint> expected_solution = arr;
 
-  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
   task_data_seq->inputs_count.emplace_back(arr.size());
   task_data_seq->inputs_count.emplace_back(n);
@@ -321,9 +322,9 @@ TEST(belov_a_radix_batcher_mergesort_seq, test_one_element_input_Bigint) {
 
 TEST(belov_a_radix_batcher_mergesort_seq, test_array_size_missmatch) {
   int n = 3;
-  vector<Bigint> arr = {-53742329, -2147483648, 123265244, 0, 315986930, 42, 2147483647, -853960, 472691};
+  std::vector<Bigint> arr = {-53742329, -2147483648, 123265244, 0, 315986930, 42, 2147483647, -853960, 472691};
 
-  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
   task_data_seq->inputs_count.emplace_back(arr.size());
   task_data_seq->inputs_count.emplace_back(n);
@@ -337,11 +338,10 @@ TEST(belov_a_radix_batcher_mergesort_seq, test_array_size_missmatch) {
 
 TEST(belov_a_radix_batcher_mergesort_seq, test_invalid_inputs_count) {
   int n = 3;
-  vector<Bigint> arr = {-53742329, -2147483648, 123265244, 0, 315986930, 42, 2147483647, -853960, 472691};
+  std::vector<Bigint> arr = {-53742329, -2147483648, 123265244, 0, 315986930, 42, 2147483647, -853960, 472691};
 
-  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
-  // task_data_seq->inputs_count.emplace_back(arr.size());
   task_data_seq->inputs_count.emplace_back(n);
   task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
   task_data_seq->outputs_count.emplace_back(arr.size());
@@ -353,9 +353,9 @@ TEST(belov_a_radix_batcher_mergesort_seq, test_invalid_inputs_count) {
 
 TEST(belov_a_radix_batcher_mergesort_seq, test_empty_input_Validation) {
   int n = 0;
-  vector<Bigint> arr = {};
+  std::vector<Bigint> arr = {};
 
-  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
   task_data_seq->inputs_count.emplace_back(arr.size());
   task_data_seq->inputs_count.emplace_back(n);
@@ -369,13 +369,12 @@ TEST(belov_a_radix_batcher_mergesort_seq, test_empty_input_Validation) {
 
 TEST(belov_a_radix_batcher_mergesort_seq, test_empty_output_Validation) {
   int n = 3;
-  vector<Bigint> arr = {789, 654, 231, 0, 123456789, 792012345678, -22475942, -853960, 59227648};
+  std::vector<Bigint> arr = {789, 654, 231, 0, 123456789, 792012345678, -22475942, -853960, 59227648};
 
-  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
   task_data_seq->inputs_count.emplace_back(arr.size());
   task_data_seq->inputs_count.emplace_back(n);
-  // task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(arr.data()));
   task_data_seq->outputs_count.emplace_back(arr.size());
 
   RadixBatcherMergesortSequential test_task_sequential(task_data_seq);

--- a/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/include/ops_seq.hpp
+++ b/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/include/ops_seq.hpp
@@ -2,6 +2,7 @@
 #define OPS_SEQ_HPP
 
 #include <cmath>
+#include <cstddef>
 #include <memory>
 #include <utility>
 #include <vector>

--- a/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/include/ops_seq.hpp
+++ b/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/include/ops_seq.hpp
@@ -1,0 +1,43 @@
+#ifndef OPS_SEQ_HPP
+#define OPS_SEQ_HPP
+
+#include <cmath>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+using Bigint = long long;
+using namespace std;
+
+namespace belov_a_radix_batcher_mergesort_seq {
+
+class RadixBatcherMergesortSequential : public ppc::core::Task {
+ public:
+  explicit RadixBatcherMergesortSequential(std::shared_ptr<ppc::core::TaskData> task_data)
+      : Task(std::move(task_data)) {}
+
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+  static void Sort(vector<Bigint>& arr);
+
+  std::vector<Bigint> GenerateMixedValuesArray(int n);
+  vector<Bigint> GenerateIntArray(int n);
+  vector<Bigint> GenerateBigintArray(int n);
+
+ private:
+  vector<Bigint> array_;  // input unsorted numbers array
+  size_t n_ = 0;          // array size
+
+  void static RadixSort(vector<Bigint>& arr, bool invert);
+  static void CountingSort(vector<Bigint>& arr, Bigint digit_place);
+  static int GetNumberDigitCapacity(Bigint num);
+};
+
+}  // namespace belov_a_radix_batcher_mergesort_seq
+
+#endif  // OPS_SEQ_HPP

--- a/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/include/ops_seq.hpp
+++ b/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/include/ops_seq.hpp
@@ -10,8 +10,6 @@
 #include "core/task/include/task.hpp"
 
 using Bigint = long long;
-using namespace std;
-
 namespace belov_a_radix_batcher_mergesort_seq {
 
 class RadixBatcherMergesortSequential : public ppc::core::Task {
@@ -24,18 +22,18 @@ class RadixBatcherMergesortSequential : public ppc::core::Task {
   bool RunImpl() override;
   bool PostProcessingImpl() override;
 
-  static void Sort(vector<Bigint>& arr);
+  static void Sort(std::vector<Bigint>& arr);
 
   std::vector<Bigint> GenerateMixedValuesArray(int n);
-  vector<Bigint> GenerateIntArray(int n);
-  vector<Bigint> GenerateBigintArray(int n);
+  std::vector<Bigint> GenerateIntArray(int n);
+  std::vector<Bigint> GenerateBigintArray(int n);
 
  private:
-  vector<Bigint> array_;  // input unsorted numbers array
-  size_t n_ = 0;          // array size
+  std::vector<Bigint> array_;  // input unsorted numbers array
+  size_t n_ = 0;               // array size
 
-  void static RadixSort(vector<Bigint>& arr, bool invert);
-  static void CountingSort(vector<Bigint>& arr, Bigint digit_place);
+  void static RadixSort(std::vector<Bigint>& arr, bool invert);
+  static void CountingSort(std::vector<Bigint>& arr, Bigint digit_place);
   static int GetNumberDigitCapacity(Bigint num);
 };
 

--- a/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/perf_tests/main.cpp
+++ b/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/perf_tests/main.cpp
@@ -1,0 +1,123 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "seq/belov_a_radix_sort_with_batcher_mergesort/include/ops_seq.hpp"
+
+using namespace belov_a_radix_batcher_mergesort_seq;
+
+namespace {
+vector<Bigint> GenerateMixedValuesArray(int n) {
+  random_device rd;
+  mt19937 gen(rd());
+
+  uniform_int_distribution<Bigint> small_range(-999LL, 999LL);
+  uniform_int_distribution<Bigint> medium_range(-10000LL, 10000LL);
+  uniform_int_distribution<Bigint> large_range(-10000000000LL, 10000000000LL);
+  uniform_int_distribution<int> choice(0, 2);
+
+  vector<Bigint> arr;
+  arr.reserve(n);
+
+  for (int i = 0; i < n; ++i) {
+    if (choice(gen) == 0) {
+      arr.push_back(small_range(gen));
+    } else if (choice(gen) == 1) {
+      arr.push_back(medium_range(gen));
+    } else {
+      arr.push_back(large_range(gen));
+    }
+  }
+  return arr;
+}
+}  // namespace
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_pipeline_run) {
+  // Create data
+  int n = 4194304;
+  vector<Bigint> arr = GenerateMixedValuesArray(n);
+
+  // Create TaskData
+  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+  task_data_seq->inputs_count.emplace_back(arr.size());
+  task_data_seq->inputs_count.emplace_back(n);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+  task_data_seq->outputs_count.emplace_back(arr.size());
+
+  // Create Task
+  auto test_task_sequential =
+      std::make_shared<belov_a_radix_batcher_mergesort_seq::RadixBatcherMergesortSequential>(task_data_seq);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+
+  ASSERT_TRUE(test_task_sequential->Validation());
+  test_task_sequential->PreProcessing();
+  test_task_sequential->Run();
+  test_task_sequential->PostProcessing();
+
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}
+
+TEST(belov_a_radix_batcher_mergesort_seq, test_task_run) {
+  // Create data
+  int n = 4194304;
+  vector<Bigint> arr = GenerateMixedValuesArray(n);
+
+  // Create TaskData
+  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+  task_data_seq->inputs_count.emplace_back(arr.size());
+  task_data_seq->inputs_count.emplace_back(n);
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
+  task_data_seq->outputs_count.emplace_back(arr.size());
+
+  // Create Task
+  auto test_task_sequential =
+      std::make_shared<belov_a_radix_batcher_mergesort_seq::RadixBatcherMergesortSequential>(task_data_seq);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+
+  ASSERT_TRUE(test_task_sequential->Validation());
+  test_task_sequential->PreProcessing();
+  test_task_sequential->Run();
+  test_task_sequential->PostProcessing();
+
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}

--- a/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/perf_tests/main.cpp
+++ b/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/perf_tests/main.cpp
@@ -13,16 +13,16 @@
 using namespace belov_a_radix_batcher_mergesort_seq;
 
 namespace {
-vector<Bigint> GenerateMixedValuesArray(int n) {
-  random_device rd;
-  mt19937 gen(rd());
+std::vector<Bigint> GenerateMixedValuesArray(int n) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
 
-  uniform_int_distribution<Bigint> small_range(-999LL, 999LL);
-  uniform_int_distribution<Bigint> medium_range(-10000LL, 10000LL);
-  uniform_int_distribution<Bigint> large_range(-10000000000LL, 10000000000LL);
-  uniform_int_distribution<int> choice(0, 2);
+  std::uniform_int_distribution<Bigint> small_range(-999LL, 999LL);
+  std::uniform_int_distribution<Bigint> medium_range(-10000LL, 10000LL);
+  std::uniform_int_distribution<Bigint> large_range(-10000000000LL, 10000000000LL);
+  std::uniform_int_distribution<int> choice(0, 2);
 
-  vector<Bigint> arr;
+  std::vector<Bigint> arr;
   arr.reserve(n);
 
   for (int i = 0; i < n; ++i) {
@@ -41,10 +41,10 @@ vector<Bigint> GenerateMixedValuesArray(int n) {
 TEST(belov_a_radix_batcher_mergesort_seq, test_pipeline_run) {
   // Create data
   int n = 4194304;
-  vector<Bigint> arr = GenerateMixedValuesArray(n);
+  std::vector<Bigint> arr = GenerateMixedValuesArray(n);
 
   // Create TaskData
-  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
   task_data_seq->inputs_count.emplace_back(arr.size());
   task_data_seq->inputs_count.emplace_back(n);
@@ -83,10 +83,10 @@ TEST(belov_a_radix_batcher_mergesort_seq, test_pipeline_run) {
 TEST(belov_a_radix_batcher_mergesort_seq, test_task_run) {
   // Create data
   int n = 4194304;
-  vector<Bigint> arr = GenerateMixedValuesArray(n);
+  std::vector<Bigint> arr = GenerateMixedValuesArray(n);
 
   // Create TaskData
-  shared_ptr<ppc::core::TaskData> task_data_seq = make_shared<ppc::core::TaskData>();
+  std::shared_ptr<ppc::core::TaskData> task_data_seq = std::make_shared<ppc::core::TaskData>();
   task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(arr.data()));
   task_data_seq->inputs_count.emplace_back(arr.size());
   task_data_seq->inputs_count.emplace_back(n);

--- a/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/perf_tests/main.cpp
+++ b/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/perf_tests/main.cpp
@@ -27,11 +27,11 @@ std::vector<Bigint> GenerateMixedValuesArray(int n) {
 
   for (int i = 0; i < n; ++i) {
     if (choice(gen) == 0) {
-      arr.push_back(small_range(gen));
+      arr.push_back(large_range(gen));
     } else if (choice(gen) == 1) {
       arr.push_back(medium_range(gen));
     } else {
-      arr.push_back(large_range(gen));
+      arr.push_back(small_range(gen));
     }
   }
   return arr;

--- a/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/src/ops_seq.cpp
+++ b/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/src/ops_seq.cpp
@@ -6,19 +6,17 @@
 #include <cstdlib>
 #include <vector>
 
-using namespace std;
-
 namespace belov_a_radix_batcher_mergesort_seq {
 int RadixBatcherMergesortSequential::GetNumberDigitCapacity(Bigint num) {
-  return (num == 0 ? 1 : static_cast<int>(log10(abs(num))) + 1);
+  return (num == 0 ? 1 : static_cast<int>(log10(std::fabs(num))) + 1);
 }
 
-void RadixBatcherMergesortSequential::Sort(vector<Bigint>& arr) {
-  vector<Bigint> pos;
-  vector<Bigint> neg;
+void RadixBatcherMergesortSequential::Sort(std::vector<Bigint>& arr) {
+  std::vector<Bigint> pos;
+  std::vector<Bigint> neg;
 
   for (const auto& num : arr) {
-    (num >= 0 ? pos : neg).push_back(abs(num));
+    (num >= 0 ? pos : neg).push_back(std::abs(num));
   }
 
   RadixSort(pos, false);
@@ -32,7 +30,7 @@ void RadixBatcherMergesortSequential::Sort(vector<Bigint>& arr) {
   arr.insert(arr.end(), pos.begin(), pos.end());
 }
 
-void RadixBatcherMergesortSequential::RadixSort(vector<Bigint>& arr, bool invert) {
+void RadixBatcherMergesortSequential::RadixSort(std::vector<Bigint>& arr, bool invert) {
   if (arr.empty()) {
     return;
   }
@@ -50,8 +48,8 @@ void RadixBatcherMergesortSequential::RadixSort(vector<Bigint>& arr, bool invert
   }
 }
 
-void RadixBatcherMergesortSequential::CountingSort(vector<Bigint>& arr, Bigint digit_place) {
-  vector<Bigint> output(arr.size());
+void RadixBatcherMergesortSequential::CountingSort(std::vector<Bigint>& arr, Bigint digit_place) {
+  std::vector<Bigint> output(arr.size());
   int count[10] = {};
 
   for (const auto& num : arr) {

--- a/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/src/ops_seq.cpp
+++ b/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/src/ops_seq.cpp
@@ -1,0 +1,98 @@
+#include "seq/belov_a_radix_sort_with_batcher_mergesort/include/ops_seq.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdlib>
+#include <vector>
+
+using namespace std;
+
+namespace belov_a_radix_batcher_mergesort_seq {
+int RadixBatcherMergesortSequential::GetNumberDigitCapacity(Bigint num) {
+  return (num == 0 ? 1 : static_cast<int>(log10(abs(num))) + 1);
+}
+
+void RadixBatcherMergesortSequential::Sort(vector<Bigint>& arr) {
+  vector<Bigint> pos;
+  vector<Bigint> neg;
+
+  for (const auto& num : arr) {
+    (num >= 0 ? pos : neg).push_back(abs(num));
+  }
+
+  RadixSort(pos, false);
+  RadixSort(neg, true);
+
+  arr.clear();
+  arr.reserve(neg.size() + pos.size());
+  for (const auto& num : neg) {
+    arr.push_back(-num);
+  }
+  arr.insert(arr.end(), pos.begin(), pos.end());
+}
+
+void RadixBatcherMergesortSequential::RadixSort(vector<Bigint>& arr, bool invert) {
+  if (arr.empty()) {
+    return;
+  }
+
+  Bigint max_val = *std::ranges::max_element(arr);
+  int max_val_digit_capacity = GetNumberDigitCapacity(max_val);
+  int iter = 1;
+
+  for (Bigint digit_place = 1; iter <= max_val_digit_capacity; digit_place *= 10, ++iter) {
+    CountingSort(arr, digit_place);
+  }
+
+  if (invert) {
+    std::ranges::reverse(arr);
+  }
+}
+
+void RadixBatcherMergesortSequential::CountingSort(vector<Bigint>& arr, Bigint digit_place) {
+  vector<Bigint> output(arr.size());
+  int count[10] = {};
+
+  for (const auto& num : arr) {
+    Bigint index = (num / digit_place) % 10;
+    count[index]++;
+  }
+
+  for (int i = 1; i < 10; i++) {
+    count[i] += count[i - 1];
+  }
+
+  for (size_t i = arr.size() - 1; i < arr.size(); i--) {
+    Bigint num = arr[i];
+    Bigint index = (num / digit_place) % 10;
+    output[--count[index]] = num;
+  }
+
+  std::ranges::copy(output, arr.begin());
+}
+
+bool RadixBatcherMergesortSequential::PreProcessingImpl() {
+  n_ = task_data->inputs_count[0];
+  auto* input_array_data = reinterpret_cast<Bigint*>(task_data->inputs[0]);
+  array_.assign(input_array_data, input_array_data + n_);
+
+  return true;
+}
+
+bool RadixBatcherMergesortSequential::ValidationImpl() {
+  return (task_data->inputs.size() == 1 && !(task_data->inputs_count.size() < 2) && task_data->inputs_count[0] != 0 &&
+          (task_data->inputs_count[0] == task_data->inputs_count[1]) && !task_data->outputs.empty());
+}
+
+bool RadixBatcherMergesortSequential::RunImpl() {
+  Sort(array_);
+  return true;
+}
+
+bool RadixBatcherMergesortSequential::PostProcessingImpl() {
+  std::ranges::copy(array_, reinterpret_cast<Bigint*>(task_data->outputs[0]));
+  return true;
+}
+
+}  // namespace belov_a_radix_batcher_mergesort_seq

--- a/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/src/ops_seq.cpp
+++ b/tasks/seq/belov_a_radix_sort_with_batcher_mergesort/src/ops_seq.cpp
@@ -22,12 +22,15 @@ void RadixBatcherMergesortSequential::Sort(std::vector<Bigint>& arr) {
   RadixSort(pos, false);
   RadixSort(neg, true);
 
-  arr.clear();
-  arr.reserve(neg.size() + pos.size());
+  size_t index = 0;
+
   for (const auto& num : neg) {
-    arr.push_back(-num);
+    arr[index++] = -num;
   }
-  arr.insert(arr.end(), pos.begin(), pos.end());
+
+  for (const auto& num : pos) {
+    arr[index++] = num;
+  }
 }
 
 void RadixBatcherMergesortSequential::RadixSort(std::vector<Bigint>& arr, bool invert) {
@@ -62,7 +65,7 @@ void RadixBatcherMergesortSequential::CountingSort(std::vector<Bigint>& arr, Big
   }
 
   for (size_t i = arr.size() - 1; i < arr.size(); i--) {
-    Bigint num = arr[i];
+    const Bigint& num = arr[i];
     Bigint index = (num / digit_place) % 10;
     output[--count[index]] = num;
   }


### PR DESCRIPTION
## Постановка задачи
Разработать параллельную версию алгоритма поразрядной сортировки для целых чисел (Radix Sort) с использованием OpenMP и четно-нечетным слиянием Бэтчера. Реализация предназначена для сортировки массивов целых чисел (тип данных bigint выбран как наиболее вместительный и устойчивый к нежелательным переполнениям).

## Описание алгоритма
### Radix Sort
Алгоритм использует подход LSD (Least Significant Digit), сортируя числа по разрядам, начиная с младшего. Основной этап — подсчет частоты элементов (Counting Sort) для каждого разряда. Для корректной обработки отрицательных чисел массив разделяется на положительные и отрицательные элементы: отрицательные инвертируются, сортируются, а затем их порядок восстанавливается при объединении с положительными. Параллелизация с помощью OpenMP применяется к этапам подсчета частот и перераспределения элементов, что ускоряет обработку больших массивов.

### Odd-Even Batcher's Mergesort
Четно-нечетное слияние Бэтчера реализовано с использованием директив OpenMP для параллельного выполнения сравнений и обменов элементов. Это позволяет эффективно распараллеливать процесс слияния отсортированных подмассивов, усиливая общую производительность алгоритма.

## Интеграция с задачей
Класс __RadixBatcherMergesortSequential__ наследуется от класса `Task` и реализует методы `PreProcessingImpl`, `ValidationImpl`, `RunImpl` и `PostProcessingImpl` для работы с входными и выходными данными через структуру `TaskData`. Параллельные участки кода помечены директивами OpenMP для оптимального распределения задач между потоками.

Данная реализация расширяет последовательную версию, демонстрируя преимущества параллелизма с использованием OMP. Она послужит основой для сравнения производительности с другими параллельными реализациями (TBB, STL, MPI) и последовательным вариантом.