### PR TITLE
Лопатин Илья. Вариант 12. Технология MPI+OMP. Вычисление многомерных интегралов методом Монте-Карло.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,6 +11,7 @@ Checks: >
   portability-*,
   readability-*,
   -bugprone-casting-through-void,
+  -bugprone-easily-swappable-parameters,
   -bugprone-exception-escape,
   -bugprone-implicit-widening-of-multiplication-result,
   -misc-const-correctness,

--- a/tasks/all/lopatin_i_monte_carlo/func_tests/lopatinMonteCarloFuncALL.cpp
+++ b/tasks/all/lopatin_i_monte_carlo/func_tests/lopatinMonteCarloFuncALL.cpp
@@ -1,0 +1,442 @@
+#include <gtest/gtest.h>
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <numbers>
+#include <vector>
+
+#include "all/lopatin_i_monte_carlo/include/lopatinMonteCarloALL.hpp"
+#include "core/task/include/task.hpp"
+
+namespace lopatin_i_monte_carlo_all {
+
+std::vector<double> GenerateBounds(double min_val, double max_val, int dimensions) {
+  std::vector<double> bounds;
+  for (int i = 0; i < dimensions; ++i) {
+    bounds.push_back(min_val);
+    bounds.push_back(max_val);
+  }
+  return bounds;
+}
+}  // namespace lopatin_i_monte_carlo_all
+
+TEST(lopatin_i_monte_carlo_all, validationInvalidInputOddBoundsCount) {
+  boost::mpi::communicator world;
+
+  std::vector<double> bounds = {0.0, 1.0, 2.0};  // even num of bounds
+  const int iterations = 10;
+  double result = 0.0;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(bounds.data()));
+    task_data->inputs_count.push_back(bounds.size());  // incorrect num of inputs
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<int*>(&iterations)));
+    task_data->inputs_count.push_back(1);
+
+    task_data->outputs.push_back(reinterpret_cast<uint8_t*>(&result));
+    task_data->outputs_count.push_back(1);
+  }
+
+  lopatin_i_monte_carlo_all::TestTaskAll task(task_data, [](const std::vector<double>&) { return 1.0; });
+  if (world.rank() == 0) {
+    ASSERT_FALSE(task.Validation());
+  }
+}
+
+TEST(lopatin_i_monte_carlo_all, validationMissingOutputData) {
+  boost::mpi::communicator world;
+
+  std::vector<double> bounds = lopatin_i_monte_carlo_all::GenerateBounds(0.0, 1.0, 2);
+  const int iterations = 10;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(bounds.data()));
+    task_data->inputs_count.push_back(4);
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<int*>(&iterations)));
+    task_data->inputs_count.push_back(1);
+  }
+
+  lopatin_i_monte_carlo_all::TestTaskAll task(task_data, [](const std::vector<double>&) { return 1.0; });
+  if (world.rank() == 0) {
+    ASSERT_FALSE(task.Validation());
+  }
+}
+
+TEST(lopatin_i_monte_carlo_all, validationZeroIterations) {
+  boost::mpi::communicator world;
+
+  std::vector<double> bounds = lopatin_i_monte_carlo_all::GenerateBounds(0.0, 1.0, 2);
+  const int iterations = 0;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(bounds.data()));
+    task_data->inputs_count.push_back(4);
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<int*>(&iterations)));
+    task_data->inputs_count.push_back(1);
+  }
+
+  lopatin_i_monte_carlo_all::TestTaskAll task(task_data, [](const std::vector<double>&) { return 1.0; });
+  if (world.rank() == 0) {
+    ASSERT_FALSE(task.Validation());
+  }
+}
+
+TEST(lopatin_i_monte_carlo_all, highDimensionalIntegration) {
+  boost::mpi::communicator world;
+
+  const int dimensions = 7;
+  const int iterations = 40000;
+  std::vector<double> bounds = lopatin_i_monte_carlo_all::GenerateBounds(-1.0, 1.0, dimensions);
+  double result = 0.0;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(bounds.data()));
+    task_data->inputs_count.push_back(bounds.size());
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<int*>(&iterations)));
+    task_data->inputs_count.push_back(1);
+
+    task_data->outputs.push_back(reinterpret_cast<uint8_t*>(&result));
+    task_data->outputs_count.push_back(1);
+  }
+
+  lopatin_i_monte_carlo_all::TestTaskAll task(task_data, [](const std::vector<double>&) {
+    return 1.0;  // const
+  });
+
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+
+  if (world.rank() == 0) {
+    const double expected = std::pow(2.0, dimensions);  // hypercube
+    const double tolerance = 0.05 * expected;
+    EXPECT_NEAR(result, expected, tolerance);  // error 5%
+  }
+}
+
+TEST(lopatin_i_monte_carlo_all, 1DConstantFunction) {
+  boost::mpi::communicator world;
+
+  const int dimensions = 1;
+  const int iterations = 100000;
+  std::vector<double> bounds = lopatin_i_monte_carlo_all::GenerateBounds(2.0, 5.0, dimensions);  // [2, 5]
+  double result = 0.0;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(bounds.data()));
+    task_data->inputs_count.push_back(bounds.size());
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<int*>(&iterations)));
+    task_data->inputs_count.push_back(1);
+
+    task_data->outputs.push_back(reinterpret_cast<uint8_t*>(&result));
+    task_data->outputs_count.push_back(1);
+  }
+
+  lopatin_i_monte_carlo_all::TestTaskAll task(task_data, [](const std::vector<double>& x) {
+    return 1.0;  // f(x) = 1
+  });
+
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+
+  if (world.rank() == 0) {
+    const double expected = 3.0;
+    const double tolerance = 0.05 * expected;
+    EXPECT_NEAR(result, expected, tolerance);  // error 5%
+  }
+}
+
+TEST(lopatin_i_monte_carlo_all, 3DExponentialFunction) {
+  boost::mpi::communicator world;
+
+  const int dimensions = 3;
+  const int iterations = 70000;
+  std::vector<double> bounds = lopatin_i_monte_carlo_all::GenerateBounds(0.0, 1.0, dimensions);  // [0,1]^3
+  double result = 0.0;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(bounds.data()));
+    task_data->inputs_count.push_back(bounds.size());
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<int*>(&iterations)));
+    task_data->inputs_count.push_back(1);
+
+    task_data->outputs.push_back(reinterpret_cast<uint8_t*>(&result));
+    task_data->outputs_count.push_back(1);
+  }
+  lopatin_i_monte_carlo_all::TestTaskAll task(
+      task_data, [](const std::vector<double>& x) { return std::pow(std::numbers::e, x[0] + x[1] + x[2]); });
+
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+
+  if (world.rank() == 0) {
+    const double expected = std::pow(std::numbers::e - 1, 3);  // = 5.073
+    const double tolerance = 0.05 * expected;
+    EXPECT_NEAR(result, expected, tolerance);  // error 5%
+  }
+}
+
+TEST(lopatin_i_monte_carlo_all, 2DLinearFunction) {
+  boost::mpi::communicator world;
+
+  const int dimensions = 2;
+  const int iterations = 70000;
+  std::vector<double> bounds = lopatin_i_monte_carlo_all::GenerateBounds(0.0, 1.0, dimensions);
+  double result = 0.0;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(bounds.data()));
+    task_data->inputs_count.push_back(bounds.size());
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<int*>(&iterations)));
+    task_data->inputs_count.push_back(1);
+
+    task_data->outputs.push_back(reinterpret_cast<uint8_t*>(&result));
+    task_data->outputs_count.push_back(1);
+  }
+
+  auto function = [](const std::vector<double>& x) {
+    assert(x.size() == 2);
+    return x[0] + x[1];
+  };
+
+  lopatin_i_monte_carlo_all::TestTaskAll task(task_data, function);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+
+  if (world.rank() == 0) {
+    const double expected = 1.0;
+    const double tolerance = 0.05 * expected;
+    EXPECT_NEAR(result, expected, tolerance);  // error 5%
+  }
+}
+
+TEST(lopatin_i_monte_carlo_all, 3DProductFunction) {
+  boost::mpi::communicator world;
+
+  const int dimensions = 3;
+  const int iterations = 50000;
+  std::vector<double> bounds = lopatin_i_monte_carlo_all::GenerateBounds(0.0, 1.0, dimensions);
+  double result = 0.0;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(bounds.data()));
+    task_data->inputs_count.push_back(bounds.size());
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<int*>(&iterations)));
+    task_data->inputs_count.push_back(1);
+
+    task_data->outputs.push_back(reinterpret_cast<uint8_t*>(&result));
+    task_data->outputs_count.push_back(1);
+  }
+
+  lopatin_i_monte_carlo_all::TestTaskAll task(task_data,
+                                              [](const std::vector<double>& x) { return x[0] * x[1] * x[2]; });
+
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+
+  if (world.rank() == 0) {
+    const double expected = 0.125;
+    const double tolerance = 0.05 * expected;
+    EXPECT_NEAR(result, expected, tolerance);  // error 5%
+  }
+}
+
+TEST(lopatin_i_monte_carlo_all, 4DQuadraticFunction) {
+  boost::mpi::communicator world;
+
+  const int dimensions = 4;
+  const int iterations = 70000;  // increase for 4D
+  std::vector<double> bounds = lopatin_i_monte_carlo_all::GenerateBounds(0.0, 1.0, dimensions);
+  double result = 0.0;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(bounds.data()));
+    task_data->inputs_count.push_back(bounds.size());
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<int*>(&iterations)));
+    task_data->inputs_count.push_back(1);
+
+    task_data->outputs.push_back(reinterpret_cast<uint8_t*>(&result));
+    task_data->outputs_count.push_back(1);
+  }
+
+  // (x1 + x2 + x3 + x4)^2
+  auto function = [](const std::vector<double>& x) {
+    double sum = x[0] + x[1] + x[2] + x[3];
+    return sum * sum;
+  };
+
+  lopatin_i_monte_carlo_all::TestTaskAll task(task_data, function);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+
+  if (world.rank() == 0) {
+    // anal 13/3 = 4.33333
+    const double expected = 13.0 / 3.0;
+    const double tolerance = 0.05 * expected;
+    EXPECT_NEAR(result, expected, tolerance);  // error 5%
+  }
+}
+
+TEST(lopatin_i_monte_carlo_all, 2DCosineFunction) {
+  boost::mpi::communicator world;
+
+  const int dimensions = 2;
+  const int iterations = 100000;
+  std::vector<double> bounds = lopatin_i_monte_carlo_all::GenerateBounds(0.0, std::numbers::pi / 2, dimensions);
+  double result = 0.0;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(bounds.data()));
+    task_data->inputs_count.push_back(bounds.size());
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<int*>(&iterations)));
+    task_data->inputs_count.push_back(1);
+
+    task_data->outputs.push_back(reinterpret_cast<uint8_t*>(&result));
+    task_data->outputs_count.push_back(1);
+  }
+
+  // cos(x + y)
+  auto function = [](const std::vector<double>& x) { return std::cos(x[0] + x[1]); };
+
+  lopatin_i_monte_carlo_all::TestTaskAll task(task_data, function);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+
+  if (world.rank() == 0) {
+    // analytical = 0
+    const double expected = 0.0;
+    const double tolerance = 0.05;
+    EXPECT_NEAR(result, expected, tolerance);  // error 5%
+  }
+}
+
+TEST(lopatin_i_monte_carlo_all, 2DSqrtFunction) {
+  boost::mpi::communicator world;
+
+  const int dimensions = 2;
+  const int iterations = 40000;
+  std::vector<double> bounds = lopatin_i_monte_carlo_all::GenerateBounds(0.0, 1.0, dimensions);
+  double result = 0.0;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(bounds.data()));
+    task_data->inputs_count.push_back(bounds.size());
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<int*>(&iterations)));
+    task_data->inputs_count.push_back(1);
+
+    task_data->outputs.push_back(reinterpret_cast<uint8_t*>(&result));
+    task_data->outputs_count.push_back(1);
+  }
+
+  // sqrt(x + y)
+  auto function = [](const std::vector<double>& x) { return std::sqrt(x[0] + x[1]); };
+
+  lopatin_i_monte_carlo_all::TestTaskAll task(task_data, function);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+
+  if (world.rank() == 0) {
+    // analytical = 0.975
+    const double expected = 0.975;
+    const double tolerance = 0.05 * expected;
+    EXPECT_NEAR(result, expected, tolerance);  // error 5%
+  }
+}
+
+TEST(lopatin_i_monte_carlo_all, 3DSinFunction) {
+  boost::mpi::communicator world;
+
+  const int dimensions = 3;
+  const int iterations = 40000;
+  std::vector<double> bounds = lopatin_i_monte_carlo_all::GenerateBounds(0.0, std::numbers::pi / 6, dimensions);
+  double result = 0.0;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(bounds.data()));
+    task_data->inputs_count.push_back(bounds.size());
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<int*>(&iterations)));
+    task_data->inputs_count.push_back(1);
+
+    task_data->outputs.push_back(reinterpret_cast<uint8_t*>(&result));
+    task_data->outputs_count.push_back(1);
+  }
+  // sin(x + y + z)
+  auto function = [](const std::vector<double>& x) { return std::sin(x[0] + x[1] + x[2]); };
+
+  lopatin_i_monte_carlo_all::TestTaskAll task(task_data, function);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+
+  if (world.rank() == 0) {
+    // analytical = 0.098
+    const double expected = 0.098;
+    const double tolerance = 0.05 * expected;
+    EXPECT_NEAR(result, expected, tolerance);  // error 5%
+  }
+}
+
+TEST(lopatin_i_monte_carlo_all, 4DLogFunction) {
+  boost::mpi::communicator world;
+
+  const int dimensions = 4;
+  const int iterations = 70000;
+  std::vector<double> bounds = lopatin_i_monte_carlo_all::GenerateBounds(1.0, std::numbers::e, dimensions);
+  double result = 0.0;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(bounds.data()));
+    task_data->inputs_count.push_back(bounds.size());
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<int*>(&iterations)));
+    task_data->inputs_count.push_back(1);
+
+    task_data->outputs.push_back(reinterpret_cast<uint8_t*>(&result));
+    task_data->outputs_count.push_back(1);
+  }
+  // ln(x1 + x2 + x3 + x4)
+  auto function = [](const std::vector<double>& x) { return std::log(x[0] + x[1] + x[2] + x[3]); };
+
+  lopatin_i_monte_carlo_all::TestTaskAll task(task_data, function);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+
+  if (world.rank() == 0) {
+    // analytical = 17.4108
+    const double expected = 17.4108;
+    const double tolerance = 0.05 * expected;
+    EXPECT_NEAR(result, expected, tolerance);  // error 5%
+  }
+}

--- a/tasks/all/lopatin_i_monte_carlo/func_tests/lopatinMonteCarloFuncALL.cpp
+++ b/tasks/all/lopatin_i_monte_carlo/func_tests/lopatinMonteCarloFuncALL.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <boost/mpi/communicator.hpp>
 #include <cassert>
 #include <cmath>
 #include <cstdint>

--- a/tasks/all/lopatin_i_monte_carlo/include/lopatinMonteCarloALL.hpp
+++ b/tasks/all/lopatin_i_monte_carlo/include/lopatinMonteCarloALL.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <boost/mpi/communicator.hpp>
+#include <functional>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace lopatin_i_monte_carlo_all {
+
+std::vector<double> GenerateBounds(double min_val, double max_val, int dimensions);
+
+class TestTaskAll : public ppc::core::Task {
+ public:
+  using IntegrandFunction = double(const std::vector<double>&);
+  explicit TestTaskAll(ppc::core::TaskDataPtr task_data, std::function<IntegrandFunction> func)
+      : Task(std::move(task_data)), integrand_(std::move(func)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<double> integrationBounds_;
+  std::function<IntegrandFunction> integrand_;
+  double result_{};
+  int iterations_;
+
+  boost::mpi::communicator world_;
+};
+
+}  // namespace lopatin_i_monte_carlo_all

--- a/tasks/all/lopatin_i_monte_carlo/perf_tests/lopatinMonteCarloPerfALL.cpp
+++ b/tasks/all/lopatin_i_monte_carlo/perf_tests/lopatinMonteCarloPerfALL.cpp
@@ -64,6 +64,10 @@ TEST(lopatin_i_monte_carlo_all, test_pipeline_run) {
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   if (world.rank() == 0) {
     ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+    const double expected = std::pow(std::exp(3.0) - std::exp(-3.0), 5);  // = 3.219e6
+    const double tolerance = 0.05 * expected;                             // 5% error
+    EXPECT_NEAR(result, expected, tolerance);
   }
 }
 
@@ -109,5 +113,9 @@ TEST(lopatin_i_monte_carlo_all, test_task_run) {
   perf_analyzer->TaskRun(perf_attr, perf_results);
   if (world.rank() == 0) {
     ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+    const double expected = std::pow(std::exp(3.0) - std::exp(-3.0), 5);  // = 3.219e6
+    const double tolerance = 0.05 * expected;                             // 5% error
+    EXPECT_NEAR(result, expected, tolerance);
   }
 }

--- a/tasks/all/lopatin_i_monte_carlo/perf_tests/lopatinMonteCarloPerfALL.cpp
+++ b/tasks/all/lopatin_i_monte_carlo/perf_tests/lopatinMonteCarloPerfALL.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <boost/mpi/communicator.hpp>
 #include <chrono>
 #include <cmath>
 #include <cstdint>

--- a/tasks/all/lopatin_i_monte_carlo/perf_tests/lopatinMonteCarloPerfALL.cpp
+++ b/tasks/all/lopatin_i_monte_carlo/perf_tests/lopatinMonteCarloPerfALL.cpp
@@ -1,0 +1,113 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "all/lopatin_i_monte_carlo/include/lopatinMonteCarloALL.hpp"
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+
+namespace lopatin_i_monte_carlo_all {
+
+std::vector<double> GenerateBounds(double min_val, double max_val, int dimensions) {
+  std::vector<double> bounds;
+  for (int i = 0; i < dimensions; ++i) {
+    bounds.push_back(min_val);
+    bounds.push_back(max_val);
+  }
+  return bounds;
+}
+}  // namespace lopatin_i_monte_carlo_all
+
+TEST(lopatin_i_monte_carlo_all, test_pipeline_run) {
+  boost::mpi::communicator world;
+
+  const int dimensions = 5;
+  const int iterations = 10000000;
+
+  std::vector<double> bounds = lopatin_i_monte_carlo_all::GenerateBounds(-3.0, 3.0, dimensions);
+  double result = 0.0;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(bounds.data()));
+    task_data->inputs_count.push_back(bounds.size());
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<int*>(&iterations)));
+    task_data->inputs_count.push_back(1);
+
+    task_data->outputs.push_back(reinterpret_cast<uint8_t*>(&result));
+    task_data->outputs_count.push_back(1);
+  }
+  // exp(x1 + x2 + x3 + x4 + x5)
+  std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
+    return std::exp(x[0] + x[1] + x[2] + x[3] + x[4]);
+  };
+
+  auto test_task = std::make_shared<lopatin_i_monte_carlo_all::TestTaskAll>(task_data, function);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 5;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  if (world.rank() == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
+  }
+}
+
+TEST(lopatin_i_monte_carlo_all, test_task_run) {
+  boost::mpi::communicator world;
+
+  const int dimensions = 5;
+  const int iterations = 10000000;
+
+  std::vector<double> bounds = lopatin_i_monte_carlo_all::GenerateBounds(-3.0, 3.0, dimensions);
+  double result = 0.0;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(bounds.data()));
+    task_data->inputs_count.push_back(bounds.size());
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<int*>(&iterations)));
+    task_data->inputs_count.push_back(1);
+
+    task_data->outputs.push_back(reinterpret_cast<uint8_t*>(&result));
+    task_data->outputs_count.push_back(1);
+  }
+
+  // exp(x1 + x2 + x3 + x4 + x5)
+  std::function<double(const std::vector<double>&)> function = [](const std::vector<double>& x) {
+    return std::exp(x[0] + x[1] + x[2] + x[3] + x[4]);
+  };
+
+  auto test_task = std::make_shared<lopatin_i_monte_carlo_all::TestTaskAll>(task_data, function);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 5;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  if (world.rank() == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
+  }
+}

--- a/tasks/all/lopatin_i_monte_carlo/src/lopatinMonteCarloALL.cpp
+++ b/tasks/all/lopatin_i_monte_carlo/src/lopatinMonteCarloALL.cpp
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <cstddef>
 #include <ctime>
+#include <functional>
 #include <random>
 #include <vector>
 
@@ -57,7 +58,7 @@ bool TestTaskAll::RunImpl() {
   // distributing iterations
   const int world_size = world_.size();
   const int world_rank = world_.rank();
-  const int local_iterations = iterations_ / world_size + (world_rank < (iterations_ % world_size) ? 1 : 0);
+  const int local_iterations = (iterations_ / world_size) + (world_rank < (iterations_ % world_size) ? 1 : 0);
 
   double local_sum = 0.0;
 #pragma omp parallel reduction(+ : local_sum)

--- a/tasks/all/lopatin_i_monte_carlo/src/lopatinMonteCarloALL.cpp
+++ b/tasks/all/lopatin_i_monte_carlo/src/lopatinMonteCarloALL.cpp
@@ -5,7 +5,7 @@
 #include <algorithm>
 #include <boost/mpi/collectives/broadcast.hpp>
 #include <boost/mpi/collectives/reduce.hpp>
-#include <boost/serialization/vector.hpp>   // NOLINT(*-include-cleaner)
+#include <boost/serialization/vector.hpp>  // NOLINT(*-include-cleaner)
 #include <cmath>
 #include <cstddef>
 #include <ctime>

--- a/tasks/all/lopatin_i_monte_carlo/src/lopatinMonteCarloALL.cpp
+++ b/tasks/all/lopatin_i_monte_carlo/src/lopatinMonteCarloALL.cpp
@@ -1,0 +1,102 @@
+#include "all/lopatin_i_monte_carlo/include/lopatinMonteCarloALL.hpp"
+
+#include <omp.h>
+
+#include <algorithm>
+#include <boost/mpi/collectives/broadcast.hpp>
+#include <boost/mpi/collectives/reduce.hpp>
+#include <boost/serialization/vector.hpp>   // NOLINT(*-include-cleaner)
+#include <cmath>
+#include <cstddef>
+#include <ctime>
+#include <random>
+#include <vector>
+
+namespace lopatin_i_monte_carlo_all {
+
+bool TestTaskAll::ValidationImpl() {
+  if (world_.rank() == 0) {
+    const bool outputs_valid = !task_data->outputs_count.empty() && task_data->outputs_count[0] == 1;
+    const bool inputs_valid = task_data->inputs_count.size() == 2 &&
+                              (task_data->inputs_count[0] % 2 == 0) &&  // odd num of bounds
+                              task_data->inputs_count[1] == 1;          // iterations num
+
+    auto* iter_ptr = reinterpret_cast<int*>(task_data->inputs[1]);
+    const int iterations = *iter_ptr;
+    const bool iter_valid = iterations > 0;
+    return outputs_valid && inputs_valid && iter_valid;
+  }
+  return true;
+}
+
+bool TestTaskAll::PreProcessingImpl() {
+  if (world_.rank() == 0) {
+    auto* bounds_ptr = reinterpret_cast<double*>(task_data->inputs[0]);
+    size_t bounds_size = task_data->inputs_count[0];
+    integrationBounds_.resize(bounds_size);
+    std::copy(bounds_ptr, bounds_ptr + bounds_size, integrationBounds_.begin());
+
+    auto* iter_ptr = reinterpret_cast<int*>(task_data->inputs[1]);
+    iterations_ = *iter_ptr;
+  }
+  return true;
+}
+
+bool TestTaskAll::RunImpl() {
+  boost::mpi::broadcast(world_, integrationBounds_, 0);
+  boost::mpi::broadcast(world_, iterations_, 0);
+
+  const size_t d = integrationBounds_.size() / 2;  // dimensions
+
+  // integration volume
+  double volume = 1.0;
+  for (size_t j = 0; j < d; ++j) {
+    volume *= (integrationBounds_[(2 * j) + 1] - integrationBounds_[2 * j]);
+  }
+
+  // distributing iterations
+  const int world_size = world_.size();
+  const int world_rank = world_.rank();
+  const int local_iterations = iterations_ / world_size + (world_rank < (iterations_ % world_size) ? 1 : 0);
+
+  double local_sum = 0.0;
+#pragma omp parallel reduction(+ : local_sum)
+  {
+    // init random numbers generator
+    std::random_device rd;
+    std::seed_seq seed{rd(), static_cast<unsigned>(std::time(nullptr)), static_cast<unsigned>(world_rank),
+                       static_cast<unsigned>(omp_get_thread_num())};
+    std::mt19937 local_rnd(seed);
+    std::uniform_real_distribution<> dis(0.0, 1.0);
+
+#pragma omp for
+    for (int i = 0; i < local_iterations; ++i) {
+      std::vector<double> point(d);
+      for (size_t j = 0; j < d; ++j) {
+        const double min = integrationBounds_[2 * j];
+        const double max = integrationBounds_[(2 * j) + 1];
+        point[j] = min + (max - min) * dis(local_rnd);
+      }
+      local_sum += integrand_(point);
+    }
+  }
+
+  double global_sum = 0.0;
+  boost::mpi::reduce(world_, local_sum, global_sum, std::plus<>(), 0);
+
+  if (world_rank == 0) {
+    result_ = (global_sum / iterations_) * volume;
+  }
+
+  return true;
+}
+
+bool TestTaskAll::PostProcessingImpl() {
+  if (world_.rank() == 0) {
+    auto* output_ptr = reinterpret_cast<double*>(task_data->outputs[0]);
+    *output_ptr = result_;
+  }
+  return true;
+}
+
+}  // namespace lopatin_i_monte_carlo_all


### PR DESCRIPTION
## Problem Statement
This task implements a parallel version of Monte Carlo integration using a combination of MPI and OpenMP. The algorithm computes multi-dimensional integrals through parallel random sampling across multiple processes and threads. Key enhancements over the OpenMP-only version:

- Distributed computation across multiple MPI processes, enabling scalability to cluster environments
- Parallel point generation and function evaluation within each MPI process using OpenMP
- Efficient data distribution and result aggregation using MPI collective operations
- Improved performance for large-scale computations by leveraging both inter-process and intra-process parallelism
## Algorithm Stages
### PreProcessingImpl()
- Root process (rank 0):
Read integration bounds (min/max pairs for each dimension) from the input buffer
Store the number of iterations for sampling
- All processes:
Prepare to receive broadcasted data (handled in RunImpl)
### ValidationImpl()
- Root process (rank 0):
Verify output buffer exists and can store 1 value
Ensure inputs contain:
Even number of bounds (pairs of min/max for each dimension)
Single integer for iteration count
Iteration count is positive
- Other processes:
No validation needed, as data consistency is ensured by broadcast from the root process
### RunImpl()
- Data Distribution:
Broadcast integration bounds and iteration count from the root process (rank 0) to all MPI processes using `boost::mpi::broadcast`
- Volume Calculation:
Each process calculates the integration region volume independently: 
$V = \prod (max_i - min_i)$ for all dimensions
- Iteration Distribution:
Distribute the total iterations across MPI processes:
Each process computes its local number of iterations based on its rank and the total number of processes
Ensures even workload distribution with slight adjustments for remainder iterations
- Parallel Sampling with OpenMP:
Within each MPI process, use OpenMP to parallelize the sampling:
Initialize thread-local random number generators with unique seeds based on process rank, thread ID, and system time
Generate random points within the multi-dimensional bounds
Evaluate the integrand function at these points
Accumulate partial sums using OpenMP’s `reduction(+ : local_sum)` clause
- Result Aggregation:
Each MPI process computes its local sum from the OpenMP parallel region
Use `boost::mpi::reduce` to aggregate all local sums into a global sum on the root process
- Final Calculation (root process):
Compute the integral result: $\text{Result} = V \times \left( \frac{\text{globalSum}}{\text{iterations}} \right)$
### PostProcessingImpl()
- Root process (rank 0):
Write the computed integral value to the output buffer
- Other processes:
No action needed, as only the root process handles output