### PR TITLE
Ануфриев Даниил. Задача 1. Вариант 11. Технология TBB. Вычисление многомерных интегралов с использованием многошаговой схемы (метод Симпсона).

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,6 +11,7 @@ Checks: >
   portability-*,
   readability-*,
   -bugprone-casting-through-void,
+  -bugprone-easily-swappable-parameters,
   -bugprone-exception-escape,
   -bugprone-implicit-widening-of-multiplication-result,
   -misc-const-correctness,

--- a/tasks/tbb/anufriev_d_integrals_simpson/func_tests/main.cpp
+++ b/tasks/tbb/anufriev_d_integrals_simpson/func_tests/main.cpp
@@ -21,15 +21,6 @@ std::shared_ptr<ppc::core::TaskData> MakeTaskData(const std::vector<double>& ele
   task_data->inputs_count.push_back(static_cast<uint32_t>(elements.size() * sizeof(double)));
   task_data->outputs.push_back(output_ptr);
   task_data->outputs_count.push_back(static_cast<uint32_t>(out_buffer.size() * sizeof(double)));
-
-  if (!out_buffer.empty()) {
-    auto* output_ptr = reinterpret_cast<uint8_t*>(out_buffer.data());
-    task_data->outputs.push_back(output_ptr);
-    task_data->outputs_count.push_back(static_cast<uint32_t>(out_buffer.size() * sizeof(double)));
-  } else {
-    task_data->outputs.push_back(nullptr);
-    task_data->outputs_count.push_back(0);
-  }
   return task_data;
 }
 }  // namespace

--- a/tasks/tbb/anufriev_d_integrals_simpson/func_tests/main.cpp
+++ b/tasks/tbb/anufriev_d_integrals_simpson/func_tests/main.cpp
@@ -20,7 +20,7 @@ std::shared_ptr<ppc::core::TaskData> MakeTaskData(const std::vector<double>& ele
   task_data->inputs_count.push_back(static_cast<uint32_t>(elements.size() * sizeof(double)));
   task_data->outputs.push_back(output_ptr);
   task_data->outputs_count.push_back(static_cast<uint32_t>(out_buffer.size() * sizeof(double)));
-  
+
   if (!out_buffer.empty()) {
     auto* output_ptr = reinterpret_cast<uint8_t*>(out_buffer.data());
     task_data->outputs.push_back(output_ptr);
@@ -28,7 +28,7 @@ std::shared_ptr<ppc::core::TaskData> MakeTaskData(const std::vector<double>& ele
   } else {
     task_data->outputs.push_back(nullptr);
     task_data->outputs_count.push_back(0);
-  } 
+  }
   return task_data;
 }
 }  // namespace

--- a/tasks/tbb/anufriev_d_integrals_simpson/func_tests/main.cpp
+++ b/tasks/tbb/anufriev_d_integrals_simpson/func_tests/main.cpp
@@ -21,7 +21,7 @@ std::shared_ptr<ppc::core::TaskData> MakeTaskData(const std::vector<double>& ele
   task_data->outputs.push_back(output_ptr);
   task_data->outputs_count.push_back(static_cast<uint32_t>(out_buffer.size() * sizeof(double)));
   
-  if(!out_buffer.empty()) {
+  if (!out_buffer.empty()) {
     auto* output_ptr = reinterpret_cast<uint8_t*>(out_buffer.data());
     task_data->outputs.push_back(output_ptr);
     task_data->outputs_count.push_back(static_cast<uint32_t>(out_buffer.size() * sizeof(double)));

--- a/tasks/tbb/anufriev_d_integrals_simpson/func_tests/main.cpp
+++ b/tasks/tbb/anufriev_d_integrals_simpson/func_tests/main.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <numbers>
 #include <vector>

--- a/tasks/tbb/anufriev_d_integrals_simpson/func_tests/main.cpp
+++ b/tasks/tbb/anufriev_d_integrals_simpson/func_tests/main.cpp
@@ -6,48 +6,41 @@
 #include <vector>
 
 #include "core/task/include/task.hpp"
-// Include the TBB header instead of SEQ
 #include "tbb/anufriev_d_integrals_simpson/include/ops_tbb.hpp"
 
 namespace {
 const double kPi = std::numbers::pi;
 
-// MakeTaskData remains the same
 std::shared_ptr<ppc::core::TaskData> MakeTaskData(const std::vector<double>& elements,
                                                   std::vector<double>& out_buffer) {
   auto task_data = std::make_shared<ppc::core::TaskData>();
   auto* input_ptr = reinterpret_cast<uint8_t*>(const_cast<double*>(elements.data()));
   auto* output_ptr = reinterpret_cast<uint8_t*>(out_buffer.data());
-  // Ensure counts are correctly set in bytes
   task_data->inputs.push_back(input_ptr);
   task_data->inputs_count.push_back(static_cast<uint32_t>(elements.size() * sizeof(double)));
   task_data->outputs.push_back(output_ptr);
   task_data->outputs_count.push_back(static_cast<uint32_t>(out_buffer.size() * sizeof(double)));
   return task_data;
 }
-} // namespace
+}  // namespace
 
-// Rename test suite
 TEST(anufriev_d_integrals_simpson_tbb, test_1D_sin) {
   std::vector<double> in = {1, 0.0, kPi / 2.0, 100, 1};
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
-  // Use the TBB class
   anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(td);
   ASSERT_TRUE(task.Validation());
   ASSERT_TRUE(task.PreProcessing());
-  ASSERT_TRUE(task.Run()); // Check Run success
-  ASSERT_TRUE(task.PostProcessing()); // Check PostProcessing success
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
   double result = out_buffer[0];
   EXPECT_NEAR(result, 1.0, 1e-3);
 }
 
-// Rename test suite
 TEST(anufriev_d_integrals_simpson_tbb, test_2D_sum_of_squares) {
   std::vector<double> in = {2, 0.0, 1.0, 100, 0.0, 1.0, 100, 0};
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
-  // Use the TBB class
   anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(td);
   ASSERT_TRUE(task.Validation());
   ASSERT_TRUE(task.PreProcessing());
@@ -57,28 +50,23 @@ TEST(anufriev_d_integrals_simpson_tbb, test_2D_sum_of_squares) {
   EXPECT_NEAR(result, 2.0 / 3.0, 1e-3);
 }
 
-// Rename test suite
 TEST(anufriev_d_integrals_simpson_tbb, test_2D_sin_cos) {
-  // Increase N for better TBB utilization demonstration (optional)
   std::vector<double> in = {2, 0.0, kPi / 2.0, 200, 0.0, kPi / 2.0, 200, 1};
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
-  // Use the TBB class
   anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(td);
   ASSERT_TRUE(task.Validation());
   ASSERT_TRUE(task.PreProcessing());
   ASSERT_TRUE(task.Run());
   ASSERT_TRUE(task.PostProcessing());
   double result = out_buffer[0];
-  EXPECT_NEAR(result, 1.0, 1e-3); // Tolerance might need adjustment for large N
+  EXPECT_NEAR(result, 1.0, 1e-3);
 }
 
-// Rename test suite
 TEST(anufriev_d_integrals_simpson_tbb, test_unknown_func) {
   std::vector<double> in = {1, 0.0, 1.0, 2, 999};
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
-  // Use the TBB class
   anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(td);
   ASSERT_TRUE(task.Validation());
   ASSERT_TRUE(task.PreProcessing());
@@ -88,97 +76,75 @@ TEST(anufriev_d_integrals_simpson_tbb, test_unknown_func) {
   EXPECT_DOUBLE_EQ(result, 0.0);
 }
 
-
-// --- Negative Tests ---
-// Rename test suite
 TEST(anufriev_d_integrals_simpson_tbb, test_invalid_empty_input_ptr) {
-    auto task_data = std::make_shared<ppc::core::TaskData>();
-    // Provide nullptrs or empty vectors explicitly based on PreProcessing logic
-    task_data->inputs.push_back(nullptr);
-    task_data->inputs_count.push_back(0);
-    std::vector<double> out_buffer(1, 0.0); // Need a valid output buffer for Validation
-    task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_buffer.data()));
-    task_data->outputs_count.push_back(sizeof(double));
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(nullptr);
+  task_data->inputs_count.push_back(0);
+  std::vector<double> out_buffer(1, 0.0);
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_buffer.data()));
+  task_data->outputs_count.push_back(sizeof(double));
 
-    anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(task_data);
-    // PreProcessing should fail due to null input pointer
-    ASSERT_FALSE(task.PreProcessingImpl());
+  anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(task_data);
+  ASSERT_FALSE(task.PreProcessingImpl());
 }
 
 TEST(anufriev_d_integrals_simpson_tbb, test_invalid_output_buffer) {
-    auto task_data = std::make_shared<ppc::core::TaskData>();
-    std::vector<double> in = {1, 0.0, 1.0, 2, 0}; // Valid input
-    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in.data()));
-    task_data->inputs_count.push_back(in.size() * sizeof(double));
-    // Invalid output setup
-    task_data->outputs.push_back(nullptr);
-    task_data->outputs_count.push_back(0);
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  std::vector<double> in = {1, 0.0, 1.0, 2, 0};
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data->inputs_count.push_back(in.size() * sizeof(double));
+  task_data->outputs.push_back(nullptr);
+  task_data->outputs_count.push_back(0);
 
-    anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(task_data);
-    // Validation should fail due to invalid output setup
-    ASSERT_FALSE(task.ValidationImpl());
+  anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(task_data);
+  ASSERT_FALSE(task.ValidationImpl());
 }
 
-
-// Rename test suite
 TEST(anufriev_d_integrals_simpson_tbb, test_invalid_dimension_zero) {
-  std::vector<double> in = {0, 0.0, 1.0, 2, 999}; // Dimension 0
+  std::vector<double> in = {0, 0.0, 1.0, 2, 999};
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
   anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(td);
-  // PreProcessing should fail
   EXPECT_FALSE(task.PreProcessingImpl());
 }
 
-// Rename test suite
 TEST(anufriev_d_integrals_simpson_tbb, test_invalid_dimension_negative) {
-  std::vector<double> in = {-1, 0.0, 1.0, 2, 999}; // Dimension -1
+  std::vector<double> in = {-1, 0.0, 1.0, 2, 999};
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
   anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(td);
-   // PreProcessing should fail
   EXPECT_FALSE(task.PreProcessingImpl());
 }
 
-
-// Rename test suite
 TEST(anufriev_d_integrals_simpson_tbb, test_invalid_not_enough_data) {
-  std::vector<double> in = {2, 0.0, 1.0, 200}; // Missing data for second dimension
+  std::vector<double> in = {2, 0.0, 1.0, 200};
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
   anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(td);
-   // PreProcessing should fail
   EXPECT_FALSE(task.PreProcessingImpl());
 }
 
-// Rename test suite
 TEST(anufriev_d_integrals_simpson_tbb, test_invalid_odd_n) {
-  std::vector<double> in = {1, 0.0, 1.0, 3, 0}; // n=3 (odd)
+  std::vector<double> in = {1, 0.0, 1.0, 3, 0};
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
   anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(td);
-   // PreProcessing should fail
   EXPECT_FALSE(task.PreProcessingImpl());
 }
 
-// Rename test suite
 TEST(anufriev_d_integrals_simpson_tbb, test_invalid_negative_n) {
-  std::vector<double> in = {1, 0.0, 1.0, -2, 0}; // n=-2 (negative)
+  std::vector<double> in = {1, 0.0, 1.0, -2, 0};
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
   anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(td);
-   // PreProcessing should fail
   EXPECT_FALSE(task.PreProcessingImpl());
 }
 
-// Rename test suite
 TEST(anufriev_d_integrals_simpson_tbb, test_no_output_buffer_in_taskdata) {
   std::vector<double> in = {1, 0.0, 1.0, 2, 0};
   auto td = std::make_shared<ppc::core::TaskData>();
   td->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<double*>(in.data())));
   td->inputs_count.push_back(static_cast<std::uint32_t>(in.size() * sizeof(double)));
-  // td->outputs is empty
   anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(td);
-  // Validation should fail
   EXPECT_FALSE(task.Validation());
 }

--- a/tasks/tbb/anufriev_d_integrals_simpson/func_tests/main.cpp
+++ b/tasks/tbb/anufriev_d_integrals_simpson/func_tests/main.cpp
@@ -1,0 +1,184 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <numbers>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+// Include the TBB header instead of SEQ
+#include "tbb/anufriev_d_integrals_simpson/include/ops_tbb.hpp"
+
+namespace {
+const double kPi = std::numbers::pi;
+
+// MakeTaskData remains the same
+std::shared_ptr<ppc::core::TaskData> MakeTaskData(const std::vector<double>& elements,
+                                                  std::vector<double>& out_buffer) {
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  auto* input_ptr = reinterpret_cast<uint8_t*>(const_cast<double*>(elements.data()));
+  auto* output_ptr = reinterpret_cast<uint8_t*>(out_buffer.data());
+  // Ensure counts are correctly set in bytes
+  task_data->inputs.push_back(input_ptr);
+  task_data->inputs_count.push_back(static_cast<uint32_t>(elements.size() * sizeof(double)));
+  task_data->outputs.push_back(output_ptr);
+  task_data->outputs_count.push_back(static_cast<uint32_t>(out_buffer.size() * sizeof(double)));
+  return task_data;
+}
+} // namespace
+
+// Rename test suite
+TEST(anufriev_d_integrals_simpson_tbb, test_1D_sin) {
+  std::vector<double> in = {1, 0.0, kPi / 2.0, 100, 1};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  // Use the TBB class
+  anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(td);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run()); // Check Run success
+  ASSERT_TRUE(task.PostProcessing()); // Check PostProcessing success
+  double result = out_buffer[0];
+  EXPECT_NEAR(result, 1.0, 1e-3);
+}
+
+// Rename test suite
+TEST(anufriev_d_integrals_simpson_tbb, test_2D_sum_of_squares) {
+  std::vector<double> in = {2, 0.0, 1.0, 100, 0.0, 1.0, 100, 0};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  // Use the TBB class
+  anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(td);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+  double result = out_buffer[0];
+  EXPECT_NEAR(result, 2.0 / 3.0, 1e-3);
+}
+
+// Rename test suite
+TEST(anufriev_d_integrals_simpson_tbb, test_2D_sin_cos) {
+  // Increase N for better TBB utilization demonstration (optional)
+  std::vector<double> in = {2, 0.0, kPi / 2.0, 200, 0.0, kPi / 2.0, 200, 1};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  // Use the TBB class
+  anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(td);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+  double result = out_buffer[0];
+  EXPECT_NEAR(result, 1.0, 1e-3); // Tolerance might need adjustment for large N
+}
+
+// Rename test suite
+TEST(anufriev_d_integrals_simpson_tbb, test_unknown_func) {
+  std::vector<double> in = {1, 0.0, 1.0, 2, 999};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  // Use the TBB class
+  anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(td);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+  double result = out_buffer[0];
+  EXPECT_DOUBLE_EQ(result, 0.0);
+}
+
+
+// --- Negative Tests ---
+// Rename test suite
+TEST(anufriev_d_integrals_simpson_tbb, test_invalid_empty_input_ptr) {
+    auto task_data = std::make_shared<ppc::core::TaskData>();
+    // Provide nullptrs or empty vectors explicitly based on PreProcessing logic
+    task_data->inputs.push_back(nullptr);
+    task_data->inputs_count.push_back(0);
+    std::vector<double> out_buffer(1, 0.0); // Need a valid output buffer for Validation
+    task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_buffer.data()));
+    task_data->outputs_count.push_back(sizeof(double));
+
+    anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(task_data);
+    // PreProcessing should fail due to null input pointer
+    ASSERT_FALSE(task.PreProcessingImpl());
+}
+
+TEST(anufriev_d_integrals_simpson_tbb, test_invalid_output_buffer) {
+    auto task_data = std::make_shared<ppc::core::TaskData>();
+    std::vector<double> in = {1, 0.0, 1.0, 2, 0}; // Valid input
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in.data()));
+    task_data->inputs_count.push_back(in.size() * sizeof(double));
+    // Invalid output setup
+    task_data->outputs.push_back(nullptr);
+    task_data->outputs_count.push_back(0);
+
+    anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(task_data);
+    // Validation should fail due to invalid output setup
+    ASSERT_FALSE(task.ValidationImpl());
+}
+
+
+// Rename test suite
+TEST(anufriev_d_integrals_simpson_tbb, test_invalid_dimension_zero) {
+  std::vector<double> in = {0, 0.0, 1.0, 2, 999}; // Dimension 0
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(td);
+  // PreProcessing should fail
+  EXPECT_FALSE(task.PreProcessingImpl());
+}
+
+// Rename test suite
+TEST(anufriev_d_integrals_simpson_tbb, test_invalid_dimension_negative) {
+  std::vector<double> in = {-1, 0.0, 1.0, 2, 999}; // Dimension -1
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(td);
+   // PreProcessing should fail
+  EXPECT_FALSE(task.PreProcessingImpl());
+}
+
+
+// Rename test suite
+TEST(anufriev_d_integrals_simpson_tbb, test_invalid_not_enough_data) {
+  std::vector<double> in = {2, 0.0, 1.0, 200}; // Missing data for second dimension
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(td);
+   // PreProcessing should fail
+  EXPECT_FALSE(task.PreProcessingImpl());
+}
+
+// Rename test suite
+TEST(anufriev_d_integrals_simpson_tbb, test_invalid_odd_n) {
+  std::vector<double> in = {1, 0.0, 1.0, 3, 0}; // n=3 (odd)
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(td);
+   // PreProcessing should fail
+  EXPECT_FALSE(task.PreProcessingImpl());
+}
+
+// Rename test suite
+TEST(anufriev_d_integrals_simpson_tbb, test_invalid_negative_n) {
+  std::vector<double> in = {1, 0.0, 1.0, -2, 0}; // n=-2 (negative)
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(td);
+   // PreProcessing should fail
+  EXPECT_FALSE(task.PreProcessingImpl());
+}
+
+// Rename test suite
+TEST(anufriev_d_integrals_simpson_tbb, test_no_output_buffer_in_taskdata) {
+  std::vector<double> in = {1, 0.0, 1.0, 2, 0};
+  auto td = std::make_shared<ppc::core::TaskData>();
+  td->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<double*>(in.data())));
+  td->inputs_count.push_back(static_cast<std::uint32_t>(in.size() * sizeof(double)));
+  // td->outputs is empty
+  anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB task(td);
+  // Validation should fail
+  EXPECT_FALSE(task.Validation());
+}

--- a/tasks/tbb/anufriev_d_integrals_simpson/include/ops_tbb.hpp
+++ b/tasks/tbb/anufriev_d_integrals_simpson/include/ops_tbb.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace anufriev_d_integrals_simpson_tbb {
+
+class IntegralsSimpsonTBB : public ppc::core::Task {
+ public:
+  explicit IntegralsSimpsonTBB(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  int dimension_{};
+
+  std::vector<double> a_, b_;
+  std::vector<int> n_;
+  int func_code_{};
+  double result_{};
+
+  [[nodiscard]] double FunctionN(const std::vector<double>& coords) const;
+};
+
+}  // namespace anufriev_d_integrals_simpson_tbb

--- a/tasks/tbb/anufriev_d_integrals_simpson/perf_tests/main.cpp
+++ b/tasks/tbb/anufriev_d_integrals_simpson/perf_tests/main.cpp
@@ -7,12 +7,10 @@
 
 #include "core/perf/include/perf.hpp"
 #include "core/task/include/task.hpp"
-// Include the TBB header instead of SEQ
+
 #include "tbb/anufriev_d_integrals_simpson/include/ops_tbb.hpp"
 
-// Rename test suite
 TEST(anufriev_d_integrals_simpson_tbb, test_pipeline_run) {
-  // Using larger N values to see potential TBB benefit
   std::vector<double> in = {2, 0.0, 1.0, 2000, 0.0, 1.0, 2000, 0};
   std::vector<double> out(1, 0.0);
 
@@ -22,20 +20,17 @@ TEST(anufriev_d_integrals_simpson_tbb, test_pipeline_run) {
   task_data_tbb->outputs.push_back(reinterpret_cast<uint8_t*>(out.data()));
   task_data_tbb->outputs_count.push_back(static_cast<std::uint32_t>(out.size() * sizeof(double)));
 
-  // Use the TBB class
   auto task_tbb = std::make_shared<anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB>(task_data_tbb);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 10; // Adjust as needed
+  perf_attr->num_running = 10;
 
-  // --- Corrected Timer Definition ---
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&] {
     auto current_time_point = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
     return static_cast<double>(duration) * 1e-9;
   };
-  // --- End Corrected Timer Definition ---
 
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(task_tbb);
@@ -44,12 +39,10 @@ TEST(anufriev_d_integrals_simpson_tbb, test_pipeline_run) {
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
   double result = out[0];
-  EXPECT_NEAR(result, 2.0 / 3.0, 1e-3); // Check result consistency
+  EXPECT_NEAR(result, 2.0 / 3.0, 1e-3);
 }
 
-// Rename test suite
 TEST(anufriev_d_integrals_simpson_tbb, test_task_run) {
-  // Using larger N values
   std::vector<double> in = {2, 0.0, 1.0, 2000, 0.0, 1.0, 2000, 0};
   std::vector<double> out(1, 0.0);
 
@@ -59,20 +52,17 @@ TEST(anufriev_d_integrals_simpson_tbb, test_task_run) {
   task_data_tbb->outputs.push_back(reinterpret_cast<uint8_t*>(out.data()));
   task_data_tbb->outputs_count.push_back(static_cast<std::uint32_t>(out.size() * sizeof(double)));
 
-  // Use the TBB class
   auto task_tbb = std::make_shared<anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB>(task_data_tbb);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 10; // Adjust as needed
+  perf_attr->num_running = 10;
 
-  // --- Corrected Timer Definition ---
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&] {
     auto current_time_point = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
     return static_cast<double>(duration) * 1e-9;
   };
-  // --- End Corrected Timer Definition ---
 
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(task_tbb);
@@ -81,5 +71,5 @@ TEST(anufriev_d_integrals_simpson_tbb, test_task_run) {
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
   double result = out[0];
-  EXPECT_NEAR(result, 2.0 / 3.0, 1e-3); // Check result consistency
+  EXPECT_NEAR(result, 2.0 / 3.0, 1e-3);
 }

--- a/tasks/tbb/anufriev_d_integrals_simpson/perf_tests/main.cpp
+++ b/tasks/tbb/anufriev_d_integrals_simpson/perf_tests/main.cpp
@@ -7,7 +7,6 @@
 
 #include "core/perf/include/perf.hpp"
 #include "core/task/include/task.hpp"
-
 #include "tbb/anufriev_d_integrals_simpson/include/ops_tbb.hpp"
 
 TEST(anufriev_d_integrals_simpson_tbb, test_pipeline_run) {

--- a/tasks/tbb/anufriev_d_integrals_simpson/perf_tests/main.cpp
+++ b/tasks/tbb/anufriev_d_integrals_simpson/perf_tests/main.cpp
@@ -1,0 +1,85 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+// Include the TBB header instead of SEQ
+#include "tbb/anufriev_d_integrals_simpson/include/ops_tbb.hpp"
+
+// Rename test suite
+TEST(anufriev_d_integrals_simpson_tbb, test_pipeline_run) {
+  // Using larger N values to see potential TBB benefit
+  std::vector<double> in = {2, 0.0, 1.0, 2000, 0.0, 1.0, 2000, 0};
+  std::vector<double> out(1, 0.0);
+
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.push_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data_tbb->inputs_count.push_back(static_cast<std::uint32_t>(in.size() * sizeof(double)));
+  task_data_tbb->outputs.push_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_tbb->outputs_count.push_back(static_cast<std::uint32_t>(out.size() * sizeof(double)));
+
+  // Use the TBB class
+  auto task_tbb = std::make_shared<anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB>(task_data_tbb);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10; // Adjust as needed
+
+  // --- Corrected Timer Definition ---
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  // --- End Corrected Timer Definition ---
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(task_tbb);
+
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  double result = out[0];
+  EXPECT_NEAR(result, 2.0 / 3.0, 1e-3); // Check result consistency
+}
+
+// Rename test suite
+TEST(anufriev_d_integrals_simpson_tbb, test_task_run) {
+  // Using larger N values
+  std::vector<double> in = {2, 0.0, 1.0, 2000, 0.0, 1.0, 2000, 0};
+  std::vector<double> out(1, 0.0);
+
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.push_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data_tbb->inputs_count.push_back(static_cast<std::uint32_t>(in.size() * sizeof(double)));
+  task_data_tbb->outputs.push_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_tbb->outputs_count.push_back(static_cast<std::uint32_t>(out.size() * sizeof(double)));
+
+  // Use the TBB class
+  auto task_tbb = std::make_shared<anufriev_d_integrals_simpson_tbb::IntegralsSimpsonTBB>(task_data_tbb);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10; // Adjust as needed
+
+  // --- Corrected Timer Definition ---
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  // --- End Corrected Timer Definition ---
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(task_tbb);
+
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  double result = out[0];
+  EXPECT_NEAR(result, 2.0 / 3.0, 1e-3); // Check result consistency
+}

--- a/tasks/tbb/anufriev_d_integrals_simpson/src/ops_tbb.cpp
+++ b/tasks/tbb/anufriev_d_integrals_simpson/src/ops_tbb.cpp
@@ -75,14 +75,9 @@ bool IntegralsSimpsonTBB::PreProcessingImpl() {
   }
 
   dimension_ = d;
-  try {
-    a_.resize(dimension_);
-    b_.resize(dimension_);
-    n_.resize(dimension_);
-  } catch (const std::bad_alloc& e) {
-    std::cerr << "Error: Failed to allocate memory for dimension " << dimension_ << ": " << e.what() << '\n';
-    return false;
-  }
+  a_.resize(dimension_);
+  b_.resize(dimension_);
+  n_.resize(dimension_);
 
   int idx_ptr = 1;
   for (int i = 0; i < dimension_; i++) {

--- a/tasks/tbb/anufriev_d_integrals_simpson/src/ops_tbb.cpp
+++ b/tasks/tbb/anufriev_d_integrals_simpson/src/ops_tbb.cpp
@@ -8,7 +8,6 @@
 #include <exception>
 #include <iostream>
 #include <limits>
-#include <new>
 #include <vector>
 
 namespace {

--- a/tasks/tbb/anufriev_d_integrals_simpson/src/ops_tbb.cpp
+++ b/tasks/tbb/anufriev_d_integrals_simpson/src/ops_tbb.cpp
@@ -1,0 +1,232 @@
+#include "tbb/anufriev_d_integrals_simpson/include/ops_tbb.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <vector>
+#include <numeric> // For std::accumulate
+#include <stdexcept> // For potential errors
+#include <iostream> // For potential debug output
+
+#include <tbb/parallel_reduce.h>
+#include <tbb/blocked_range.h>
+
+namespace {
+
+// Simpson coefficient remains the same
+int SimpsonCoeff(int i, int n) {
+  if (i == 0 || i == n) {
+    return 1;
+  }
+  if (i % 2 != 0) {
+    return 4;
+  }
+  return 2;
+}
+} // namespace
+
+namespace anufriev_d_integrals_simpson_tbb {
+
+// FunctionN remains the same
+double IntegralsSimpsonTBB::FunctionN(const std::vector<double>& coords) const {
+  switch (func_code_) {
+    case 0: {
+      double s = 0.0;
+      for (double c : coords) {
+        s += c * c;
+      }
+      return s;
+    }
+    case 1: {
+      double val = 1.0;
+      for (size_t i = 0; i < coords.size(); i++) {
+        if (i % 2 == 0) {
+          val *= std::sin(coords[i]);
+        } else {
+          val *= std::cos(coords[i]);
+        }
+      }
+      return val;
+    }
+    default:
+      // Consider logging or throwing an error for unknown func_code_
+      // std::cerr << "Warning: Unknown function code: " << func_code_ << std::endl;
+      return 0.0;
+  }
+}
+
+// PreProcessingImpl remains the same, just class name changes
+bool IntegralsSimpsonTBB::PreProcessingImpl() {
+  if (task_data->inputs.empty() || task_data->inputs[0] == nullptr) {
+      // std::cerr << "Error: Input data pointer is null or inputs vector is empty." << std::endl;
+      return false;
+  }
+
+  auto* in_ptr = reinterpret_cast<double*>(task_data->inputs[0]);
+  size_t in_size_bytes = task_data->inputs_count[0];
+  size_t num_doubles = in_size_bytes / sizeof(double);
+
+  if (num_doubles < 1) {
+    // std::cerr << "Error: Not enough data for dimension." << std::endl;
+    return false;
+  }
+
+  // Check for potential overflow if dimension is excessively large
+  // although unlikely with double representation.
+  int d = static_cast<int>(in_ptr[0]);
+  if (d <= 0) { // Dimension must be positive
+    // std::cerr << "Error: Dimension must be positive, got " << d << std::endl;
+    return false;
+  }
+
+  // Calculate needed count safely
+  size_t required_elements = 1 + static_cast<size_t>(3 * d) + 1;
+  if (num_doubles < required_elements) {
+    // std::cerr << "Error: Not enough input data for dimension " << d
+              // << ". Need " << required_elements << " doubles, got " << num_doubles << "." << std::endl;
+    return false;
+  }
+
+  dimension_ = d;
+  try {
+      a_.resize(dimension_);
+      b_.resize(dimension_);
+      n_.resize(dimension_);
+  } catch (const std::bad_alloc& e) {
+      std::cerr << "Error: Failed to allocate memory for dimension " << dimension_ << ": " << e.what() << std::endl;
+    return false;
+  }
+
+
+  int idx_ptr = 1;
+  for (int i = 0; i < dimension_; i++) {
+    a_[i] = in_ptr[idx_ptr++];
+    b_[i] = in_ptr[idx_ptr++];
+    // Check for potential non-integer values before casting
+    double n_double = in_ptr[idx_ptr++];
+    if (std::floor(n_double) != n_double || n_double > static_cast<double>(std::numeric_limits<int>::max())) {
+        // std::cerr << "Error: Number of steps n[" << i << "] must be an integer." << std::endl;
+        return false;
+    }
+    n_[i] = static_cast<int>(n_double);
+
+    if (n_[i] <= 0 || (n_[i] % 2) != 0) {
+        // std::cerr << "Error: n[" << i << "] = " << n_[i] << " must be a positive even integer." << std::endl;
+      return false;
+    }
+    if (a_[i] > b_[i]) {
+        // std::cerr << "Warning: Lower bound a[" << i << "] = " << a_[i]
+        //           << " is greater than upper bound b[" << i << "] = " << b_[i] << "." << std::endl;
+        // Depending on requirements, this could be an error or just allowed (integral might be negative)
+    }
+  }
+
+  // Check if func_code can be safely cast to int
+  double func_code_double = in_ptr[idx_ptr];
+  if (std::floor(func_code_double) != func_code_double || func_code_double > static_cast<double>(std::numeric_limits<int>::max()) || func_code_double < static_cast<double>(std::numeric_limits<int>::min())) {
+     // std::cerr << "Error: Function code must be an integer." << std::endl;
+     return false;
+  }
+  func_code_ = static_cast<int>(func_code_double);
+
+  result_ = 0.0;
+
+  return true;
+}
+
+// ValidationImpl remains the same, just class name changes
+bool IntegralsSimpsonTBB::ValidationImpl() {
+  // Check if output pointer and count are valid
+  if (task_data->outputs.empty() || task_data->outputs[0] == nullptr) {
+    // std::cerr << "Error: Output data pointer is null or outputs vector is empty." << std::endl;
+    return false;
+  }
+  if (task_data->outputs_count.empty() || task_data->outputs_count[0] < sizeof(double)) {
+    // std::cerr << "Error: Output buffer size is insufficient." << std::endl;
+    return false;
+  }
+  // Optional: Could add validation for inputs here as well,
+  // though PreProcessingImpl already does a thorough job.
+  // For instance, check if dimension_ > 0 after potential PreProcessing.
+  // return dimension_ > 0; // Example: ensure dimension was set correctly
+  return true; // Basic validation passed
+}
+
+
+bool IntegralsSimpsonTBB::RunImpl() {
+    std::vector<double> steps(dimension_);
+    size_t total_points = 1; // Use size_t for potentially large number of points
+    double coeff_mult = 1.0;
+
+    for (int i = 0; i < dimension_; i++) {
+        if (n_[i] == 0) { // Should be caught by PreProcessing, but double-check
+            // std::cerr << "Error: n_[" << i << "] is zero." << std::endl;
+            return false;
+        }
+        steps[i] = (b_[i] - a_[i]) / n_[i];
+        coeff_mult *= steps[i] / 3.0;
+        // Check for potential overflow when calculating total_points
+        size_t points_in_dim = static_cast<size_t>(n_[i]) + 1;
+        if (total_points > std::numeric_limits<size_t>::max() / points_in_dim) {
+            // std::cerr << "Error: Total number of points exceeds size_t capacity." << std::endl;
+            return false; // Overflow would occur
+        }
+        total_points *= points_in_dim;
+    }
+
+     // Use thread-local storage for coords to avoid repeated allocations if performance-critical
+     // For simplicity here, we create it inside the lambda.
+    // std::vector<double> local_coords(dimension_);
+
+    double total_sum = tbb::parallel_reduce(
+        tbb::blocked_range<size_t>(0, total_points), // Range of linear indices
+        0.0, // Identity value for summation
+        [&](const tbb::blocked_range<size_t>& r, double running_sum) {
+            // Thread-local vector for coordinates to avoid race conditions
+            std::vector<double> coords(dimension_);
+            // Thread-local vector for multidimensional indices
+            std::vector<int> current_idx(dimension_);
+
+            for (size_t k = r.begin(); k != r.end(); ++k) {
+                double current_coeff_prod = 1.0;
+                size_t current_k = k; // Temporary variable for index calculation
+
+                // Convert linear index 'k' to multidimensional index 'current_idx'
+                // and calculate coordinates and Simpson coefficients product
+                //size_t product_of_dimensions = 1; // To help with index calculation
+                for (int dim = 0; dim < dimension_; ++dim) {
+                     size_t points_in_this_dim = static_cast<size_t>(n_[dim]) + 1;
+                     size_t index_in_this_dim = current_k % points_in_this_dim;
+                     current_idx[dim] = static_cast<int>(index_in_this_dim);
+                     current_k /= points_in_this_dim;
+
+                     coords[dim] = a_[dim] + current_idx[dim] * steps[dim];
+                     current_coeff_prod *= SimpsonCoeff(current_idx[dim], n_[dim]);
+                }
+
+                running_sum += current_coeff_prod * FunctionN(coords);
+            }
+            return running_sum;
+        },
+        [](double x, double y) { // Reduction operation: sum
+            return x + y;
+        }
+    );
+
+    result_ = coeff_mult * total_sum;
+    return true;
+}
+
+
+// PostProcessingImpl remains the same, just class name changes
+bool IntegralsSimpsonTBB::PostProcessingImpl() {
+  try {
+      auto* out_ptr = reinterpret_cast<double*>(task_data->outputs[0]);
+      out_ptr[0] = result_;
+  } catch (const std::exception& e) {
+      std::cerr << "Error during PostProcessing: " << e.what() << std::endl;
+    return false; // Indicate failure if access causes exception
+  }
+  return true;
+}
+
+} // namespace anufriev_d_integrals_simpson_tbb

--- a/tasks/tbb/anufriev_d_integrals_simpson/src/ops_tbb.cpp
+++ b/tasks/tbb/anufriev_d_integrals_simpson/src/ops_tbb.cpp
@@ -5,9 +5,10 @@
 
 #include <cmath>
 #include <cstddef>
+#include <exception>
 #include <iostream>
-#include <numeric>
-#include <stdexcept>
+#include <limits>
+#include <new>
 #include <vector>
 
 namespace {
@@ -79,7 +80,7 @@ bool IntegralsSimpsonTBB::PreProcessingImpl() {
     b_.resize(dimension_);
     n_.resize(dimension_);
   } catch (const std::bad_alloc& e) {
-    std::cerr << "Error: Failed to allocate memory for dimension " << dimension_ << ": " << e.what() << std::endl;
+    std::cerr << "Error: Failed to allocate memory for dimension " << dimension_ << ": " << e.what() << '\n';
     return false;
   }
 
@@ -176,7 +177,7 @@ bool IntegralsSimpsonTBB::PostProcessingImpl() {
     auto* out_ptr = reinterpret_cast<double*>(task_data->outputs[0]);
     out_ptr[0] = result_;
   } catch (const std::exception& e) {
-    std::cerr << "Error during PostProcessing: " << e.what() << std::endl;
+    std::cerr << "Error during PostProcessing: " << e.what() << '\n';
     return false;
   }
   return true;

--- a/tasks/tbb/anufriev_d_integrals_simpson/src/ops_tbb.cpp
+++ b/tasks/tbb/anufriev_d_integrals_simpson/src/ops_tbb.cpp
@@ -1,18 +1,17 @@
 #include "tbb/anufriev_d_integrals_simpson/include/ops_tbb.hpp"
 
-#include <cmath>
-#include <cstddef>
-#include <vector>
-#include <numeric> // For std::accumulate
-#include <stdexcept> // For potential errors
-#include <iostream> // For potential debug output
-
 #include <tbb/parallel_reduce.h>
 #include <tbb/blocked_range.h>
 
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <numeric>
+#include <stdexcept>
+#include <vector>
+
 namespace {
 
-// Simpson coefficient remains the same
 int SimpsonCoeff(int i, int n) {
   if (i == 0 || i == n) {
     return 1;
@@ -22,11 +21,10 @@ int SimpsonCoeff(int i, int n) {
   }
   return 2;
 }
-} // namespace
+}  // namespace
 
 namespace anufriev_d_integrals_simpson_tbb {
 
-// FunctionN remains the same
 double IntegralsSimpsonTBB::FunctionN(const std::vector<double>& coords) const {
   switch (func_code_) {
     case 0: {
@@ -48,17 +46,13 @@ double IntegralsSimpsonTBB::FunctionN(const std::vector<double>& coords) const {
       return val;
     }
     default:
-      // Consider logging or throwing an error for unknown func_code_
-      // std::cerr << "Warning: Unknown function code: " << func_code_ << std::endl;
       return 0.0;
   }
 }
 
-// PreProcessingImpl remains the same, just class name changes
 bool IntegralsSimpsonTBB::PreProcessingImpl() {
   if (task_data->inputs.empty() || task_data->inputs[0] == nullptr) {
-      // std::cerr << "Error: Input data pointer is null or inputs vector is empty." << std::endl;
-      return false;
+    return false;
   }
 
   auto* in_ptr = reinterpret_cast<double*>(task_data->inputs[0]);
@@ -66,33 +60,26 @@ bool IntegralsSimpsonTBB::PreProcessingImpl() {
   size_t num_doubles = in_size_bytes / sizeof(double);
 
   if (num_doubles < 1) {
-    // std::cerr << "Error: Not enough data for dimension." << std::endl;
     return false;
   }
 
-  // Check for potential overflow if dimension is excessively large
-  // although unlikely with double representation.
   int d = static_cast<int>(in_ptr[0]);
-  if (d <= 0) { // Dimension must be positive
-    // std::cerr << "Error: Dimension must be positive, got " << d << std::endl;
+  if (d <= 0) {
     return false;
   }
 
-  // Calculate needed count safely
   size_t required_elements = 1 + static_cast<size_t>(3 * d) + 1;
   if (num_doubles < required_elements) {
-    // std::cerr << "Error: Not enough input data for dimension " << d
-              // << ". Need " << required_elements << " doubles, got " << num_doubles << "." << std::endl;
     return false;
   }
 
   dimension_ = d;
   try {
-      a_.resize(dimension_);
-      b_.resize(dimension_);
-      n_.resize(dimension_);
+    a_.resize(dimension_);
+    b_.resize(dimension_);
+    n_.resize(dimension_);
   } catch (const std::bad_alloc& e) {
-      std::cerr << "Error: Failed to allocate memory for dimension " << dimension_ << ": " << e.what() << std::endl;
+    std::cerr << "Error: Failed to allocate memory for dimension " << dimension_ << ": " << e.what() << std::endl;
     return false;
   }
 
@@ -101,30 +88,24 @@ bool IntegralsSimpsonTBB::PreProcessingImpl() {
   for (int i = 0; i < dimension_; i++) {
     a_[i] = in_ptr[idx_ptr++];
     b_[i] = in_ptr[idx_ptr++];
-    // Check for potential non-integer values before casting
     double n_double = in_ptr[idx_ptr++];
     if (std::floor(n_double) != n_double || n_double > static_cast<double>(std::numeric_limits<int>::max())) {
-        // std::cerr << "Error: Number of steps n[" << i << "] must be an integer." << std::endl;
-        return false;
+      return false;
     }
     n_[i] = static_cast<int>(n_double);
 
     if (n_[i] <= 0 || (n_[i] % 2) != 0) {
-        // std::cerr << "Error: n[" << i << "] = " << n_[i] << " must be a positive even integer." << std::endl;
       return false;
     }
     if (a_[i] > b_[i]) {
-        // std::cerr << "Warning: Lower bound a[" << i << "] = " << a_[i]
-        //           << " is greater than upper bound b[" << i << "] = " << b_[i] << "." << std::endl;
-        // Depending on requirements, this could be an error or just allowed (integral might be negative)
     }
   }
 
-  // Check if func_code can be safely cast to int
   double func_code_double = in_ptr[idx_ptr];
-  if (std::floor(func_code_double) != func_code_double || func_code_double > static_cast<double>(std::numeric_limits<int>::max()) || func_code_double < static_cast<double>(std::numeric_limits<int>::min())) {
-     // std::cerr << "Error: Function code must be an integer." << std::endl;
-     return false;
+  if (std::floor(func_code_double) != func_code_double ||
+      func_code_double > static_cast<double>(std::numeric_limits<int>::max()) ||
+      func_code_double < static_cast<double>(std::numeric_limits<int>::min())) {
+    return false;
   }
   func_code_ = static_cast<int>(func_code_double);
 
@@ -133,98 +114,75 @@ bool IntegralsSimpsonTBB::PreProcessingImpl() {
   return true;
 }
 
-// ValidationImpl remains the same, just class name changes
 bool IntegralsSimpsonTBB::ValidationImpl() {
-  // Check if output pointer and count are valid
   if (task_data->outputs.empty() || task_data->outputs[0] == nullptr) {
-    // std::cerr << "Error: Output data pointer is null or outputs vector is empty." << std::endl;
     return false;
   }
   if (task_data->outputs_count.empty() || task_data->outputs_count[0] < sizeof(double)) {
-    // std::cerr << "Error: Output buffer size is insufficient." << std::endl;
     return false;
   }
-  // Optional: Could add validation for inputs here as well,
-  // though PreProcessingImpl already does a thorough job.
-  // For instance, check if dimension_ > 0 after potential PreProcessing.
-  // return dimension_ > 0; // Example: ensure dimension was set correctly
-  return true; // Basic validation passed
+  return true;
 }
 
 
 bool IntegralsSimpsonTBB::RunImpl() {
-    std::vector<double> steps(dimension_);
-    size_t total_points = 1; // Use size_t for potentially large number of points
-    double coeff_mult = 1.0;
+  std::vector<double> steps(dimension_);
+  size_t total_points = 1;
+  double coeff_mult = 1.0;
 
-    for (int i = 0; i < dimension_; i++) {
-        if (n_[i] == 0) { // Should be caught by PreProcessing, but double-check
-            // std::cerr << "Error: n_[" << i << "] is zero." << std::endl;
-            return false;
-        }
-        steps[i] = (b_[i] - a_[i]) / n_[i];
-        coeff_mult *= steps[i] / 3.0;
-        // Check for potential overflow when calculating total_points
-        size_t points_in_dim = static_cast<size_t>(n_[i]) + 1;
-        if (total_points > std::numeric_limits<size_t>::max() / points_in_dim) {
-            // std::cerr << "Error: Total number of points exceeds size_t capacity." << std::endl;
-            return false; // Overflow would occur
-        }
-        total_points *= points_in_dim;
-    }
+  for (int i = 0; i < dimension_; i++) {
+      if (n_[i] == 0) {
+        return false;
+      }
+      steps[i] = (b_[i] - a_[i]) / n_[i];
+      coeff_mult *= steps[i] / 3.0;
+      size_t points_in_dim = static_cast<size_t>(n_[i]) + 1;
+      if (total_points > std::numeric_limits<size_t>::max() / points_in_dim) {
+        return false;
+      }
+      total_points *= points_in_dim;
+  }
 
-     // Use thread-local storage for coords to avoid repeated allocations if performance-critical
-     // For simplicity here, we create it inside the lambda.
-    // std::vector<double> local_coords(dimension_);
+  double total_sum = tbb::parallel_reduce(
+      tbb::blocked_range<size_t>(0, total_points), 0.0,
+      [&](const tbb::blocked_range<size_t>& r, double running_sum) {
+          std::vector<double> coords(dimension_);
+          std::vector<int> current_idx(dimension_);
 
-    double total_sum = tbb::parallel_reduce(
-        tbb::blocked_range<size_t>(0, total_points), // Range of linear indices
-        0.0, // Identity value for summation
-        [&](const tbb::blocked_range<size_t>& r, double running_sum) {
-            // Thread-local vector for coordinates to avoid race conditions
-            std::vector<double> coords(dimension_);
-            // Thread-local vector for multidimensional indices
-            std::vector<int> current_idx(dimension_);
+          for (size_t k = r.begin(); k != r.end(); ++k) {
+            double current_coeff_prod = 1.0;
+            size_t current_k = k;
 
-            for (size_t k = r.begin(); k != r.end(); ++k) {
-                double current_coeff_prod = 1.0;
-                size_t current_k = k; // Temporary variable for index calculation
+            for (int dim = 0; dim < dimension_; ++dim) {
+              size_t points_in_this_dim = static_cast<size_t>(n_[dim]) + 1;
+              size_t index_in_this_dim = current_k % points_in_this_dim;
+              current_idx[dim] = static_cast<int>(index_in_this_dim);
+              current_k /= points_in_this_dim;
 
-                // Convert linear index 'k' to multidimensional index 'current_idx'
-                // and calculate coordinates and Simpson coefficients product
-                //size_t product_of_dimensions = 1; // To help with index calculation
-                for (int dim = 0; dim < dimension_; ++dim) {
-                     size_t points_in_this_dim = static_cast<size_t>(n_[dim]) + 1;
-                     size_t index_in_this_dim = current_k % points_in_this_dim;
-                     current_idx[dim] = static_cast<int>(index_in_this_dim);
-                     current_k /= points_in_this_dim;
-
-                     coords[dim] = a_[dim] + current_idx[dim] * steps[dim];
-                     current_coeff_prod *= SimpsonCoeff(current_idx[dim], n_[dim]);
-                }
-
-                running_sum += current_coeff_prod * FunctionN(coords);
+              coords[dim] = a_[dim] + current_idx[dim] * steps[dim];
+              current_coeff_prod *= SimpsonCoeff(current_idx[dim], n_[dim]);
             }
-            return running_sum;
-        },
-        [](double x, double y) { // Reduction operation: sum
-            return x + y;
-        }
-    );
 
-    result_ = coeff_mult * total_sum;
-    return true;
+            running_sum += current_coeff_prod * FunctionN(coords);
+          }
+          return running_sum;
+      },
+      [](double x, double y) {
+        return x + y;
+      }
+  );
+
+  result_ = coeff_mult * total_sum;
+  return true;
 }
 
-
-// PostProcessingImpl remains the same, just class name changes
 bool IntegralsSimpsonTBB::PostProcessingImpl() {
   try {
       auto* out_ptr = reinterpret_cast<double*>(task_data->outputs[0]);
       out_ptr[0] = result_;
   } catch (const std::exception& e) {
       std::cerr << "Error during PostProcessing: " << e.what() << std::endl;
-    return false; // Indicate failure if access causes exception
+    return false;
   }
   return true;
 }


### PR DESCRIPTION
## Оптимизация вычисления интегралов методом Симпсона с использованием TBB
Этот Pull Request заменяет последовательную рекурсивную реализацию многомерной интеграции методом Симпсона на оптимизированную версию с использованием Intel Threading Building Blocks (TBB) для повышения производительности на многоядерных системах.
### Основные изменения и стратегия:
* Замена рекурсии итеративным подходом:
Исходный рекурсивный метод RecursiveSimpsonSum был удален. Рекурсия затрудняет эффективное распараллеливание стандартными конструкциями TBB.
Вместо него реализован итеративный подход, который подготавливает почву для параллельной обработки.
* Параллельное суммирование с tbb::parallel_reduce:
Ядром оптимизации является использование tbb::parallel_reduce. Этот инструмент идеально подходит для параллельного вычисления суммы (или других операций редукции) по большому набору данных.
Он используется для параллельного суммирования вкладов от каждого узла сетки интегрирования (коэффициент_Симпсона * значение_функции).
* Обработка многомерной сетки:
Для tbb::parallel_reduce определяется одномерный диапазон, равный общему числу узлов во всех измерениях (total_points = (n[0]+1) * (n[1]+1) * ... * (n[d-1]+1)).
Внутри параллельно выполняемого кода реализована логика для преобразования линейного индекса k (от 0 до total_points - 1) обратно в многомерный индекс idx[0], ..., idx[dimension_ - 1]. Это позволяет каждому потоку определить, какой узел сетки он обрабатывает.
* Вычисления внутри параллельного цикла:
Для каждого узла (или блока узлов), обрабатываемого потоком в tbb::parallel_reduce, выполняются следующие шаги:
Преобразование линейного индекса k в многомерный idx.
Вычисление координат coords узла на основе idx и шагов steps.
Расчет произведения коэффициентов Симпсона для всех измерений на основе idx.
Вычисление значения интегрируемой функции FunctionN(coords) в данном узле.
Добавление взвешенного значения функции (произведение_коэффициентов * FunctionN(coords)) к локальной сумме потока.
* Редукция:
tbb::parallel_reduce автоматически использует предоставленную операцию (в данном случае, простое сложение) для объединения локальных сумм, вычисленных каждым потоком, в итоговую общую сумму.