### PR TITLE
[CI] Fix perf tests run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1108,11 +1108,12 @@ jobs:
       - name: Run perf count checker
         run: |
           python3 scripts/run_perf_counter.py --required-tests-number=2
-        env:
-          OMP_NUM_THREADS: 4
       - name: Run perf tests
         run: |
           bash -e scripts/generate_perf_results.sh
+        env:
+          OMP_NUM_THREADS: 2
+          PROC_COUNT: 2
       - name: Archive results
         uses: montudor/action-zip@v1
         with:


### PR DESCRIPTION
- Add missing process level parallelism enforcement for task 'all'
- Set `PROC_COUNT` and `OMP_NUM_THREADS` for the correct step