### PR TITLE
Борисов Сергей. Задача 1. Вариант 3. Технология TBB. Умножение плотных матриц. Элементы типа double. Алгоритм Штрассена.

### DIFF
--- a/tasks/tbb/borisov_s_strassen/func_tests/main.cpp
+++ b/tasks/tbb/borisov_s_strassen/func_tests/main.cpp
@@ -1,0 +1,674 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "tbb/borisov_s_strassen/include/ops_tbb.hpp"
+
+namespace {
+
+std::vector<double> MultiplyNaiveDouble(const std::vector<double>& a, const std::vector<double>& b, int rows_a,
+                                        int cols_a, int cols_b) {
+  std::vector<double> c(rows_a * cols_b, 0.0);
+  for (int i = 0; i < rows_a; ++i) {
+    for (int j = 0; j < cols_b; ++j) {
+      double sum = 0.0;
+      for (int k = 0; k < cols_a; ++k) {
+        sum += a[(i * cols_a) + k] * b[(k * cols_b) + j];
+      }
+      c[(i * cols_b) + j] = sum;
+    }
+  }
+  return c;
+}
+
+std::vector<double> GenerateRandomMatrix(int rows, int cols, int seed, double min_val = -50.0, double max_val = 50.0) {
+  std::mt19937 rng(seed);
+
+  std::uniform_real_distribution<double> dist(min_val, max_val);
+  std::vector<double> matrix(rows * cols);
+  for (double& x : matrix) {
+    x = dist(rng);
+  }
+  return matrix;
+}
+
+}  // namespace
+
+TEST(borisov_s_strassen_seq, OneByOne) {
+  std::vector<double> in_data = {1.0, 1.0, 1.0, 1.0, 7.5, 2.5};
+
+  std::size_t output_count = 3;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_tbb::ParallelStrassenTBB task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], 1.0);
+  EXPECT_DOUBLE_EQ(out_ptr[1], 1.0);
+  EXPECT_DOUBLE_EQ(out_ptr[2], 18.75);
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, TwoByTwo) {
+  std::vector<double> a = {1.0, 2.5, 3.0, 4.0};
+  std::vector<double> b = {1.5, 2.0, 0.5, 3.5};
+  std::vector<double> c_expected = {2.75, 10.75, 6.5, 20.0};
+
+  std::vector<double> in_data = {2.0, 2.0, 2.0, 2.0};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + 4;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_tbb::ParallelStrassenTBB task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], 2.0);
+  EXPECT_DOUBLE_EQ(out_ptr[1], 2.0);
+  for (int i = 0; i < 4; ++i) {
+    EXPECT_NEAR(out_ptr[2 + i], c_expected[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Rectangular2x3_3x4) {
+  std::vector<double> a = {1.0, 2.5, 3.0, 4.0, 5.5, 6.0};
+  std::vector<double> b = {0.5, 1.0, 2.0, 1.5, 2.0, 0.5, 1.0, 3.0, 4.0, 2.5, 0.5, 1.0};
+
+  auto c_expected = MultiplyNaiveDouble(a, b, 2, 3, 4);
+
+  std::vector<double> in_data = {2.0, 3.0, 3.0, 4.0};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + (2 * 4);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_tbb::ParallelStrassenTBB task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], 2.0);
+  EXPECT_DOUBLE_EQ(out_ptr[1], 4.0);
+
+  std::vector<double> c_result(2 * 4);
+  for (int i = 0; i < 2 * 4; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Square5x5_Random) {
+  const int n = 5;
+
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_tbb::ParallelStrassenTBB task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+  std::vector<double> c_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Square20x20_Random) {
+  const int n = 20;
+
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_tbb::ParallelStrassenTBB task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+  std::vector<double> c_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Square32x32_Random) {
+  const int n = 32;
+
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_tbb::ParallelStrassenTBB task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+  std::vector<double> c_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Square128x128_Random) {
+  const int n = 128;
+
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_tbb::ParallelStrassenTBB task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+  std::vector<double> c_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Square128x128_IdentityMatrix) {
+  const int n = 128;
+
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+
+  std::vector<double> e(n * n, 0.0);
+  for (int i = 0; i < n; ++i) {
+    e[(i * n) + i] = 1.0;
+  }
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), e.begin(), e.end());
+
+  std::size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_tbb::ParallelStrassenTBB task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+  std::vector<double> c_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(a.size(), c_result.size());
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    EXPECT_NEAR(a[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Square129x129_Random) {
+  const int n = 129;
+
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_tbb::ParallelStrassenTBB task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+  std::vector<double> c_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Square240x240_Random) {
+  const int n = 240;
+
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_tbb::ParallelStrassenTBB task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+  std::vector<double> c_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, ValidCase) {
+  std::vector<double> input_data = {2.0, 3.0, 3.0, 2.0};
+  input_data.insert(input_data.end(), {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
+  input_data.insert(input_data.end(), {7.0, 8.0, 9.0, 10.0, 11.0, 12.0});
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(input_data.data()));
+  task_data->inputs_count.push_back(input_data.size());
+
+  task_data->outputs.push_back(nullptr);
+  task_data->outputs_count.push_back(0);
+
+  borisov_s_strassen_tbb::ParallelStrassenTBB task(task_data);
+
+  task.PreProcessingImpl();
+
+  EXPECT_TRUE(task.ValidationImpl());
+}
+
+TEST(borisov_s_strassen_seq, MismatchCase) {
+  std::vector<double> input_data = {
+      2.0,
+      2.0,
+      3.0,
+      3.0,
+  };
+  input_data.insert(input_data.end(), {1.0, 2.0, 3.0, 4.0});
+  input_data.insert(input_data.end(), {5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0});
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(input_data.data()));
+  task_data->inputs_count.push_back(input_data.size());
+
+  task_data->outputs.push_back(nullptr);
+  task_data->outputs_count.push_back(0);
+
+  borisov_s_strassen_tbb::ParallelStrassenTBB task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_FALSE(task.ValidationImpl());
+}
+
+TEST(borisov_s_strassen_seq, NotEnoughDataCase) {
+  std::vector<double> input_data = {2.0, 2.0, 2.0, 2.0};
+  input_data.insert(input_data.end(), {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(input_data.data()));
+  task_data->inputs_count.push_back(input_data.size());
+
+  task_data->outputs.push_back(nullptr);
+  task_data->outputs_count.push_back(0);
+
+  borisov_s_strassen_tbb::ParallelStrassenTBB task(task_data);
+
+  task.PreProcessingImpl();
+
+  EXPECT_FALSE(task.ValidationImpl());
+}
+
+TEST(borisov_s_strassen_seq, Rectangular16x17_Random) {
+  const int rows_a = 16;
+  const int cols_a = 17;
+  const int cols_b = 18;
+
+  std::vector<double> a = GenerateRandomMatrix(rows_a, cols_a, 7777);
+  std::vector<double> b = GenerateRandomMatrix(cols_a, cols_b, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, rows_a, cols_a, cols_b);
+
+  std::vector<double> in_data = {static_cast<double>(rows_a), static_cast<double>(cols_a), static_cast<double>(cols_a),
+                                 static_cast<double>(cols_b)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + (rows_a * cols_b);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_tbb::ParallelStrassenTBB task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(rows_a));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(cols_b));
+
+  std::vector<double> c_result(rows_a * cols_b);
+  for (int i = 0; i < rows_a * cols_b; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Rectangular19x23_Random) {
+  const int rows_a = 19;
+  const int cols_a = 23;
+  const int cols_b = 21;
+
+  std::vector<double> a = GenerateRandomMatrix(rows_a, cols_a, 7777);
+  std::vector<double> b = GenerateRandomMatrix(cols_a, cols_b, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, rows_a, cols_a, cols_b);
+
+  std::vector<double> in_data = {static_cast<double>(rows_a), static_cast<double>(cols_a), static_cast<double>(cols_a),
+                                 static_cast<double>(cols_b)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + (rows_a * cols_b);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_tbb::ParallelStrassenTBB task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(rows_a));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(cols_b));
+
+  std::vector<double> c_result(rows_a * cols_b);
+  for (int i = 0; i < rows_a * cols_b; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Rectangular32x64_Random) {
+  const int rows_a = 32;
+  const int cols_a = 64;
+  const int cols_b = 32;
+
+  std::vector<double> a = GenerateRandomMatrix(rows_a, cols_a, 7777);
+  std::vector<double> b = GenerateRandomMatrix(cols_a, cols_b, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, rows_a, cols_a, cols_b);
+
+  std::vector<double> in_data = {static_cast<double>(rows_a), static_cast<double>(cols_a), static_cast<double>(cols_a),
+                                 static_cast<double>(cols_b)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + (rows_a * cols_b);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_tbb::ParallelStrassenTBB task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(rows_a));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(cols_b));
+
+  std::vector<double> c_result(rows_a * cols_b);
+  for (int i = 0; i < rows_a * cols_b; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}

--- a/tasks/tbb/borisov_s_strassen/func_tests/main.cpp
+++ b/tasks/tbb/borisov_s_strassen/func_tests/main.cpp
@@ -40,7 +40,7 @@ std::vector<double> GenerateRandomMatrix(int rows, int cols, int seed, double mi
 
 }  // namespace
 
-TEST(borisov_s_strassen_seq, OneByOne) {
+TEST(borisov_s_strassen_tbb, OneByOne) {
   std::vector<double> in_data = {1.0, 1.0, 1.0, 1.0, 7.5, 2.5};
 
   std::size_t output_count = 3;
@@ -67,7 +67,7 @@ TEST(borisov_s_strassen_seq, OneByOne) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, TwoByTwo) {
+TEST(borisov_s_strassen_tbb, TwoByTwo) {
   std::vector<double> a = {1.0, 2.5, 3.0, 4.0};
   std::vector<double> b = {1.5, 2.0, 0.5, 3.5};
   std::vector<double> c_expected = {2.75, 10.75, 6.5, 20.0};
@@ -102,7 +102,7 @@ TEST(borisov_s_strassen_seq, TwoByTwo) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, Rectangular2x3_3x4) {
+TEST(borisov_s_strassen_tbb, Rectangular2x3_3x4) {
   std::vector<double> a = {1.0, 2.5, 3.0, 4.0, 5.5, 6.0};
   std::vector<double> b = {0.5, 1.0, 2.0, 1.5, 2.0, 0.5, 1.0, 3.0, 4.0, 2.5, 0.5, 1.0};
 
@@ -145,7 +145,7 @@ TEST(borisov_s_strassen_seq, Rectangular2x3_3x4) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, Square5x5_Random) {
+TEST(borisov_s_strassen_tbb, Square5x5_Random) {
   const int n = 5;
 
   std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
@@ -191,7 +191,7 @@ TEST(borisov_s_strassen_seq, Square5x5_Random) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, Square20x20_Random) {
+TEST(borisov_s_strassen_tbb, Square20x20_Random) {
   const int n = 20;
 
   std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
@@ -237,7 +237,7 @@ TEST(borisov_s_strassen_seq, Square20x20_Random) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, Square32x32_Random) {
+TEST(borisov_s_strassen_tbb, Square32x32_Random) {
   const int n = 32;
 
   std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
@@ -283,7 +283,7 @@ TEST(borisov_s_strassen_seq, Square32x32_Random) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, Square128x128_Random) {
+TEST(borisov_s_strassen_tbb, Square128x128_Random) {
   const int n = 128;
 
   std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
@@ -329,7 +329,7 @@ TEST(borisov_s_strassen_seq, Square128x128_Random) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, Square128x128_IdentityMatrix) {
+TEST(borisov_s_strassen_tbb, Square128x128_IdentityMatrix) {
   const int n = 128;
 
   std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
@@ -377,7 +377,7 @@ TEST(borisov_s_strassen_seq, Square128x128_IdentityMatrix) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, Square129x129_Random) {
+TEST(borisov_s_strassen_tbb, Square129x129_Random) {
   const int n = 129;
 
   std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
@@ -423,7 +423,7 @@ TEST(borisov_s_strassen_seq, Square129x129_Random) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, Square240x240_Random) {
+TEST(borisov_s_strassen_tbb, Square240x240_Random) {
   const int n = 240;
 
   std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
@@ -469,7 +469,7 @@ TEST(borisov_s_strassen_seq, Square240x240_Random) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, ValidCase) {
+TEST(borisov_s_strassen_tbb, ValidCase) {
   std::vector<double> input_data = {2.0, 3.0, 3.0, 2.0};
   input_data.insert(input_data.end(), {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
   input_data.insert(input_data.end(), {7.0, 8.0, 9.0, 10.0, 11.0, 12.0});
@@ -488,7 +488,7 @@ TEST(borisov_s_strassen_seq, ValidCase) {
   EXPECT_TRUE(task.ValidationImpl());
 }
 
-TEST(borisov_s_strassen_seq, MismatchCase) {
+TEST(borisov_s_strassen_tbb, MismatchCase) {
   std::vector<double> input_data = {
       2.0,
       2.0,
@@ -511,7 +511,7 @@ TEST(borisov_s_strassen_seq, MismatchCase) {
   EXPECT_FALSE(task.ValidationImpl());
 }
 
-TEST(borisov_s_strassen_seq, NotEnoughDataCase) {
+TEST(borisov_s_strassen_tbb, NotEnoughDataCase) {
   std::vector<double> input_data = {2.0, 2.0, 2.0, 2.0};
   input_data.insert(input_data.end(), {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
 
@@ -529,7 +529,7 @@ TEST(borisov_s_strassen_seq, NotEnoughDataCase) {
   EXPECT_FALSE(task.ValidationImpl());
 }
 
-TEST(borisov_s_strassen_seq, Rectangular16x17_Random) {
+TEST(borisov_s_strassen_tbb, Rectangular16x17_Random) {
   const int rows_a = 16;
   const int cols_a = 17;
   const int cols_b = 18;
@@ -577,7 +577,7 @@ TEST(borisov_s_strassen_seq, Rectangular16x17_Random) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, Rectangular19x23_Random) {
+TEST(borisov_s_strassen_tbb, Rectangular19x23_Random) {
   const int rows_a = 19;
   const int cols_a = 23;
   const int cols_b = 21;
@@ -625,7 +625,7 @@ TEST(borisov_s_strassen_seq, Rectangular19x23_Random) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, Rectangular32x64_Random) {
+TEST(borisov_s_strassen_tbb, Rectangular32x64_Random) {
   const int rows_a = 32;
   const int cols_a = 64;
   const int cols_b = 32;

--- a/tasks/tbb/borisov_s_strassen/include/ops_tbb.hpp
+++ b/tasks/tbb/borisov_s_strassen/include/ops_tbb.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace borisov_s_strassen_tbb {
+
+class ParallelStrassenTBB : public ppc::core::Task {
+ public:
+  explicit ParallelStrassenTBB(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<double> input_;
+
+  std::vector<double> output_;
+
+  int rowsA_ = 0;
+  int colsA_ = 0;
+  int rowsB_ = 0;
+  int colsB_ = 0;
+};
+
+}  // namespace borisov_s_strassen_tbb

--- a/tasks/tbb/borisov_s_strassen/perf_tests/main.cpp
+++ b/tasks/tbb/borisov_s_strassen/perf_tests/main.cpp
@@ -25,7 +25,7 @@ void GenerateRandomMatrix(int rows, int cols, std::vector<double>& matrix) {
 
 }  // namespace
 
-TEST(borisov_s_strassen_perf_seq, test_pipeline_run) {
+TEST(borisov_s_strassen_perf_tbb, test_pipeline_run) {
   constexpr int kRowsA = 1024;
   constexpr int kColsA = 512;
   constexpr int kRowsB = 512;
@@ -44,13 +44,13 @@ TEST(borisov_s_strassen_perf_seq, test_pipeline_run) {
   size_t output_count = 2 + (kRowsA * kColsB);
   std::vector<double> out(output_count, 0.0);
 
-  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
-  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(in_data.data()));
-  task_data_seq->inputs_count.emplace_back(in_data.size());
-  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
-  task_data_seq->outputs_count.emplace_back(out.size());
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data_tbb->inputs_count.emplace_back(in_data.size());
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(out.size());
 
-  auto test_task_sequential = std::make_shared<borisov_s_strassen_tbb::ParallelStrassenTBB>(task_data_seq);
+  auto test_task_parallel = std::make_shared<borisov_s_strassen_tbb::ParallelStrassenTBB>(task_data_tbb);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;
@@ -63,12 +63,12 @@ TEST(borisov_s_strassen_perf_seq, test_pipeline_run) {
 
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
 
-  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_parallel);
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 }
 
-TEST(borisov_s_strassen_perf_seq, test_task_run) {
+TEST(borisov_s_strassen_perf_tbb, test_task_run) {
   constexpr int kRowsA = 1024;
   constexpr int kColsA = 512;
   constexpr int kRowsB = 512;
@@ -87,13 +87,13 @@ TEST(borisov_s_strassen_perf_seq, test_task_run) {
   size_t output_count = 2 + (kRowsA * kColsB);
   std::vector<double> out(output_count, 0.0);
 
-  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
-  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(in_data.data()));
-  task_data_seq->inputs_count.emplace_back(in_data.size());
-  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
-  task_data_seq->outputs_count.emplace_back(out.size());
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data_tbb->inputs_count.emplace_back(in_data.size());
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(out.size());
 
-  auto test_task_sequential = std::make_shared<borisov_s_strassen_tbb::ParallelStrassenTBB>(task_data_seq);
+  auto test_task_parallel = std::make_shared<borisov_s_strassen_tbb::ParallelStrassenTBB>(task_data_tbb);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;
@@ -106,7 +106,7 @@ TEST(borisov_s_strassen_perf_seq, test_task_run) {
 
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
 
-  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_parallel);
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 }

--- a/tasks/tbb/borisov_s_strassen/perf_tests/main.cpp
+++ b/tasks/tbb/borisov_s_strassen/perf_tests/main.cpp
@@ -1,0 +1,112 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "tbb/borisov_s_strassen/include/ops_tbb.hpp"
+
+namespace {
+
+void GenerateRandomMatrix(int rows, int cols, std::vector<double>& matrix) {
+  std::random_device rd;
+  std::mt19937 rng(rd());
+  std::uniform_real_distribution<double> dist(-50.0, 50.0);
+  matrix.resize(rows * cols);
+  for (auto& value : matrix) {
+    value = dist(rng);
+  }
+}
+
+}  // namespace
+
+TEST(borisov_s_strassen_perf_seq, test_pipeline_run) {
+  constexpr int kRowsA = 1024;
+  constexpr int kColsA = 512;
+  constexpr int kRowsB = 512;
+  constexpr int kColsB = 1024;
+
+  std::vector<double> a;
+  std::vector<double> b;
+  GenerateRandomMatrix(kRowsA, kColsA, a);
+  GenerateRandomMatrix(kRowsB, kColsB, b);
+
+  std::vector<double> in_data = {static_cast<double>(kRowsA), static_cast<double>(kColsA), static_cast<double>(kRowsB),
+                                 static_cast<double>(kColsB)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  size_t output_count = 2 + (kRowsA * kColsB);
+  std::vector<double> out(output_count, 0.0);
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data_seq->inputs_count.emplace_back(in_data.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  auto test_task_sequential = std::make_shared<borisov_s_strassen_tbb::ParallelStrassenTBB>(task_data_seq);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}
+
+TEST(borisov_s_strassen_perf_seq, test_task_run) {
+  constexpr int kRowsA = 1024;
+  constexpr int kColsA = 512;
+  constexpr int kRowsB = 512;
+  constexpr int kColsB = 1024;
+
+  std::vector<double> a;
+  std::vector<double> b;
+  GenerateRandomMatrix(kRowsA, kColsA, a);
+  GenerateRandomMatrix(kRowsB, kColsB, b);
+
+  std::vector<double> in_data = {static_cast<double>(kRowsA), static_cast<double>(kColsA), static_cast<double>(kRowsB),
+                                 static_cast<double>(kColsB)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  size_t output_count = 2 + (kRowsA * kColsB);
+  std::vector<double> out(output_count, 0.0);
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data_seq->inputs_count.emplace_back(in_data.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  auto test_task_sequential = std::make_shared<borisov_s_strassen_tbb::ParallelStrassenTBB>(task_data_seq);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}

--- a/tasks/tbb/borisov_s_strassen/src/ops_tbb.cpp
+++ b/tasks/tbb/borisov_s_strassen/src/ops_tbb.cpp
@@ -3,7 +3,6 @@
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_for.h>
 #include <tbb/parallel_invoke.h>
-#include <tbb/tbb.h>
 
 #include <algorithm>
 #include <cstddef>

--- a/tasks/tbb/borisov_s_strassen/src/ops_tbb.cpp
+++ b/tasks/tbb/borisov_s_strassen/src/ops_tbb.cpp
@@ -1,8 +1,8 @@
-#include "tbb/borisov_s_strassen/include/ops_tbb.hpp"
-
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_for.h>
 #include <tbb/parallel_invoke.h>
+
+#include "tbb/borisov_s_strassen/include/ops_tbb.hpp"
 
 #include <algorithm>
 #include <cstddef>
@@ -12,7 +12,7 @@ namespace borisov_s_strassen_tbb {
 
 namespace {
 
-const int SEQ_THRESHOLD = 64;
+const int kSeqThreshold = 64;
 
 std::vector<double> MultiplyNaive(const std::vector<double>& a, const std::vector<double>& b, int n) {
   std::vector<double> c(n * n, 0.0);
@@ -80,7 +80,7 @@ void SetSubMatrix(std::vector<double>& m, const std::vector<double>& sub, int n,
 }
 
 std::vector<double> StrassenRecursive(const std::vector<double>& a, const std::vector<double>& b, int n) {
-  if (n <= SEQ_THRESHOLD) {
+  if (n <= kSeqThreshold) {
     return MultiplyNaive(a, b, n);
   }
   int k = n / 2;

--- a/tasks/tbb/borisov_s_strassen/src/ops_tbb.cpp
+++ b/tasks/tbb/borisov_s_strassen/src/ops_tbb.cpp
@@ -1,0 +1,223 @@
+#include "tbb/borisov_s_strassen/include/ops_tbb.hpp"
+
+#include <tbb/blocked_range.h>
+#include <tbb/parallel_for.h>
+#include <tbb/parallel_invoke.h>
+#include <tbb/tbb.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <vector>
+
+namespace borisov_s_strassen_tbb {
+
+namespace {
+
+const int SEQ_THRESHOLD = 64;
+
+std::vector<double> MultiplyNaive(const std::vector<double>& a, const std::vector<double>& b, int n) {
+  std::vector<double> c(n * n, 0.0);
+  int grain_size = std::max(1, n / 8);
+  tbb::parallel_for(tbb::blocked_range<int>(0, n, grain_size), [&](const tbb::blocked_range<int>& r) {
+    for (int i = r.begin(); i < r.end(); ++i) {
+      for (int j = 0; j < n; ++j) {
+        double sum = 0.0;
+        for (int k = 0; k < n; ++k) {
+          sum += a[i * n + k] * b[k * n + j];
+        }
+        c[i * n + j] = sum;
+      }
+    }
+  });
+  return c;
+}
+
+std::vector<double> AddMatr(const std::vector<double>& a, const std::vector<double>& b, int n) {
+  std::vector<double> c(n * n, 0.0);
+  int total = n * n;
+  int grain = std::max(1, total / 64);
+  tbb::parallel_for(tbb::blocked_range<int>(0, total, grain), [&](const tbb::blocked_range<int>& r) {
+    for (int i = r.begin(); i < r.end(); ++i) {
+      c[i] = a[i] + b[i];
+    }
+  });
+  return c;
+}
+
+std::vector<double> SubMatr(const std::vector<double>& a, const std::vector<double>& b, int n) {
+  std::vector<double> c(n * n, 0.0);
+  int total = n * n;
+  int grain = std::max(1, total / 64);
+  tbb::parallel_for(tbb::blocked_range<int>(0, total, grain), [&](const tbb::blocked_range<int>& r) {
+    for (int i = r.begin(); i < r.end(); ++i) {
+      c[i] = a[i] - b[i];
+    }
+  });
+  return c;
+}
+
+std::vector<double> SubMatrix(const std::vector<double>& m, int n, int row, int col, int size) {
+  std::vector<double> sub(size * size, 0.0);
+  int grain = std::max(1, size / 4);
+  tbb::parallel_for(tbb::blocked_range<int>(0, size, grain), [&](const tbb::blocked_range<int>& r) {
+    for (int i = r.begin(); i < r.end(); ++i) {
+      for (int j = 0; j < size; ++j) {
+        sub[i * size + j] = m[(row + i) * n + (col + j)];
+      }
+    }
+  });
+  return sub;
+}
+
+void SetSubMatrix(std::vector<double>& m, const std::vector<double>& sub, int n, int row, int col, int size) {
+  int grain = std::max(1, size / 4);
+  tbb::parallel_for(tbb::blocked_range<int>(0, size, grain), [&](const tbb::blocked_range<int>& r) {
+    for (int i = r.begin(); i < r.end(); ++i) {
+      for (int j = 0; j < size; ++j) {
+        m[(row + i) * n + (col + j)] = sub[i * size + j];
+      }
+    }
+  });
+}
+
+std::vector<double> StrassenRecursive(const std::vector<double>& a, const std::vector<double>& b, int n) {
+  if (n <= SEQ_THRESHOLD) {
+    return MultiplyNaive(a, b, n);
+  }
+  int k = n / 2;
+  auto a11 = SubMatrix(a, n, 0, 0, k);
+  auto a12 = SubMatrix(a, n, 0, k, k);
+  auto a21 = SubMatrix(a, n, k, 0, k);
+  auto a22 = SubMatrix(a, n, k, k, k);
+
+  auto b11 = SubMatrix(b, n, 0, 0, k);
+  auto b12 = SubMatrix(b, n, 0, k, k);
+  auto b21 = SubMatrix(b, n, k, 0, k);
+  auto b22 = SubMatrix(b, n, k, k, k);
+
+  std::vector<double> m1, m2, m3, m4, m5, m6, m7;
+  tbb::parallel_invoke([&] { m1 = StrassenRecursive(AddMatr(a11, a22, k), AddMatr(b11, b22, k), k); },
+                       [&] { m2 = StrassenRecursive(AddMatr(a21, a22, k), b11, k); },
+                       [&] { m3 = StrassenRecursive(a11, SubMatr(b12, b22, k), k); },
+                       [&] { m4 = StrassenRecursive(a22, SubMatr(b21, b11, k), k); },
+                       [&] { m5 = StrassenRecursive(AddMatr(a11, a12, k), b22, k); },
+                       [&] { m6 = StrassenRecursive(SubMatr(a21, a11, k), AddMatr(b11, b12, k), k); },
+                       [&] { m7 = StrassenRecursive(SubMatr(a12, a22, k), AddMatr(b21, b22, k), k); });
+
+  std::vector<double> c(n * n, 0.0);
+  auto c11 = AddMatr(SubMatr(AddMatr(m1, m4, k), m5, k), m7, k);
+  auto c12 = AddMatr(m3, m5, k);
+  auto c21 = AddMatr(m2, m4, k);
+  auto c22 = AddMatr(AddMatr(SubMatr(m1, m2, k), m3, k), m6, k);
+
+  SetSubMatrix(c, c11, n, 0, 0, k);
+  SetSubMatrix(c, c12, n, 0, k, k);
+  SetSubMatrix(c, c21, n, k, 0, k);
+  SetSubMatrix(c, c22, n, k, k, k);
+
+  return c;
+}
+
+int NextPowerOfTwo(int n) {
+  int r = 1;
+  while (r < n) {
+    r <<= 1;
+  }
+  return r;
+}
+
+}  // namespace
+
+bool ParallelStrassenTBB::PreProcessingImpl() {
+  size_t input_count = task_data->inputs_count[0];
+  auto* double_ptr = reinterpret_cast<double*>(task_data->inputs[0]);
+  input_.assign(double_ptr, double_ptr + input_count);
+
+  size_t output_count = task_data->outputs_count[0];
+  output_.resize(output_count, 0.0);
+
+  if (input_.size() < 4) {
+    return false;
+  }
+
+  rowsA_ = static_cast<int>(input_[0]);
+  colsA_ = static_cast<int>(input_[1]);
+  rowsB_ = static_cast<int>(input_[2]);
+  colsB_ = static_cast<int>(input_[3]);
+
+  return true;
+}
+
+bool ParallelStrassenTBB::ValidationImpl() {
+  if (colsA_ != rowsB_) {
+    return false;
+  }
+  size_t needed = 4 + (static_cast<size_t>(rowsA_) * colsA_) + (static_cast<size_t>(rowsB_) * colsB_);
+  return input_.size() >= needed;
+}
+
+bool ParallelStrassenTBB::RunImpl() {
+  size_t offset = 4;
+  std::vector<double> a(rowsA_ * colsA_);
+  for (int i = 0; i < rowsA_ * colsA_; ++i) {
+    a[i] = input_[offset + i];
+  }
+  offset += static_cast<size_t>(rowsA_ * colsA_);
+
+  std::vector<double> b(rowsB_ * colsB_);
+  for (int i = 0; i < rowsB_ * colsB_; ++i) {
+    b[i] = input_[offset + i];
+  }
+
+  int max_dim = std::max({rowsA_, colsA_, colsB_});
+  int m = NextPowerOfTwo(max_dim);
+
+  std::vector<double> a_exp(m * m, 0.0);
+  std::vector<double> b_exp(m * m, 0.0);
+
+  tbb::parallel_for(tbb::blocked_range<int>(0, rowsA_), [&](const tbb::blocked_range<int>& r) {
+    for (int i = r.begin(); i < r.end(); ++i) {
+      for (int j = 0; j < colsA_; ++j) {
+        a_exp[i * m + j] = a[i * colsA_ + j];
+      }
+    }
+  });
+  tbb::parallel_for(tbb::blocked_range<int>(0, rowsB_), [&](const tbb::blocked_range<int>& r) {
+    for (int i = r.begin(); i < r.end(); ++i) {
+      for (int j = 0; j < colsB_; ++j) {
+        b_exp[i * m + j] = b[i * colsB_ + j];
+      }
+    }
+  });
+
+  auto c_exp = StrassenRecursive(a_exp, b_exp, m);
+
+  std::vector<double> c(rowsA_ * colsB_, 0.0);
+  tbb::parallel_for(tbb::blocked_range<int>(0, rowsA_), [&](const tbb::blocked_range<int>& r) {
+    for (int i = r.begin(); i < r.end(); ++i) {
+      for (int j = 0; j < colsB_; ++j) {
+        c[i * colsB_ + j] = c_exp[i * m + j];
+      }
+    }
+  });
+
+  output_[0] = static_cast<double>(rowsA_);
+  output_[1] = static_cast<double>(colsB_);
+  tbb::parallel_for(tbb::blocked_range<int>(0, rowsA_ * colsB_), [&](const tbb::blocked_range<int>& r) {
+    for (int i = r.begin(); i < r.end(); ++i) {
+      output_[2 + i] = c[i];
+    }
+  });
+
+  return true;
+}
+
+bool ParallelStrassenTBB::PostProcessingImpl() {
+  auto* out_ptr = reinterpret_cast<double*>(task_data->outputs[0]);
+  for (size_t i = 0; i < output_.size(); ++i) {
+    out_ptr[i] = output_[i];
+  }
+  return true;
+}
+
+}  // namespace borisov_s_strassen_tbb

--- a/tasks/tbb/borisov_s_strassen/src/ops_tbb.cpp
+++ b/tasks/tbb/borisov_s_strassen/src/ops_tbb.cpp
@@ -23,9 +23,9 @@ std::vector<double> MultiplyNaive(const std::vector<double>& a, const std::vecto
       for (int j = 0; j < n; ++j) {
         double sum = 0.0;
         for (int k = 0; k < n; ++k) {
-          sum += a[i * n + k] * b[k * n + j];
+          sum += a[(i * n) + k] * b[(k * n) + j];
         }
-        c[i * n + j] = sum;
+        c[(i * n) + j] = sum;
       }
     }
   });
@@ -62,7 +62,7 @@ std::vector<double> SubMatrix(const std::vector<double>& m, int n, int row, int 
   tbb::parallel_for(tbb::blocked_range<int>(0, size, grain), [&](const tbb::blocked_range<int>& r) {
     for (int i = r.begin(); i < r.end(); ++i) {
       for (int j = 0; j < size; ++j) {
-        sub[i * size + j] = m[(row + i) * n + (col + j)];
+        sub[(i * size) + j] = m[((row + i) * n) + (col + j)];
       }
     }
   });
@@ -74,7 +74,7 @@ void SetSubMatrix(std::vector<double>& m, const std::vector<double>& sub, int n,
   tbb::parallel_for(tbb::blocked_range<int>(0, size, grain), [&](const tbb::blocked_range<int>& r) {
     for (int i = r.begin(); i < r.end(); ++i) {
       for (int j = 0; j < size; ++j) {
-        m[(row + i) * n + (col + j)] = sub[i * size + j];
+        m[((row + i) * n) + (col + j)] = sub[(i * size) + j];
       }
     }
   });
@@ -95,7 +95,13 @@ std::vector<double> StrassenRecursive(const std::vector<double>& a, const std::v
   auto b21 = SubMatrix(b, n, k, 0, k);
   auto b22 = SubMatrix(b, n, k, k, k);
 
-  std::vector<double> m1, m2, m3, m4, m5, m6, m7;
+  std::vector<double> m1;
+  std::vector<double> m2;
+  std::vector<double> m3;
+  std::vector<double> m4;
+  std::vector<double> m5;
+  std::vector<double> m6;
+  std::vector<double> m7;
   tbb::parallel_invoke([&] { m1 = StrassenRecursive(AddMatr(a11, a22, k), AddMatr(b11, b22, k), k); },
                        [&] { m2 = StrassenRecursive(AddMatr(a21, a22, k), b11, k); },
                        [&] { m3 = StrassenRecursive(a11, SubMatr(b12, b22, k), k); },
@@ -178,14 +184,14 @@ bool ParallelStrassenTBB::RunImpl() {
   tbb::parallel_for(tbb::blocked_range<int>(0, rowsA_), [&](const tbb::blocked_range<int>& r) {
     for (int i = r.begin(); i < r.end(); ++i) {
       for (int j = 0; j < colsA_; ++j) {
-        a_exp[i * m + j] = a[i * colsA_ + j];
+        a_exp[(i * m) + j] = a[(i * colsA_) + j];
       }
     }
   });
   tbb::parallel_for(tbb::blocked_range<int>(0, rowsB_), [&](const tbb::blocked_range<int>& r) {
     for (int i = r.begin(); i < r.end(); ++i) {
       for (int j = 0; j < colsB_; ++j) {
-        b_exp[i * m + j] = b[i * colsB_ + j];
+        b_exp[(i * m) + j] = b[(i * colsB_) + j];
       }
     }
   });
@@ -196,7 +202,7 @@ bool ParallelStrassenTBB::RunImpl() {
   tbb::parallel_for(tbb::blocked_range<int>(0, rowsA_), [&](const tbb::blocked_range<int>& r) {
     for (int i = r.begin(); i < r.end(); ++i) {
       for (int j = 0; j < colsB_; ++j) {
-        c[i * colsB_ + j] = c_exp[i * m + j];
+        c[(i * colsB_) + j] = c_exp[(i * m) + j];
       }
     }
   });

--- a/tasks/tbb/borisov_s_strassen/src/ops_tbb.cpp
+++ b/tasks/tbb/borisov_s_strassen/src/ops_tbb.cpp
@@ -1,8 +1,8 @@
-#include <tbb/blocked_range.h>
-#include <tbb/parallel_for.h>
-#include <tbb/parallel_invoke.h>
-
 #include "tbb/borisov_s_strassen/include/ops_tbb.hpp"
+
+#include <oneapi/tbb/blocked_range.h>
+#include <oneapi/tbb/parallel_for.h>
+#include <oneapi/tbb/parallel_invoke.h>
 
 #include <algorithm>
 #include <cstddef>


### PR DESCRIPTION
Реализована TBB-версия алгоритма Штрассена для умножения плотных матриц с элементами типа double. Аналогично предыдущей реализации, для прямоугольных матриц или тех, чья размерность не является степенью двойки, матрицы дополняются нулями до ближайшей степени двойки. При малых размерах (n ≤ 64) применяется классическое умножение (O(n^3)), а для больших матриц используется рекурсивный алгоритм Штрассена с асимптотикой O(n^(log₂7) ≈ O(n^2.8074)), что обеспечивает значительный выигрыш по скорости на крупных матрицах.

В TBB-версии параллелизация операций умножения, сложения и вычитания матриц реализована с помощью tbb::parallel_for, при этом для снижения накладных расходов используются tbb::blocked_range с оптимальными grain_size. Для рекурсивной части, где вычисляются семь независимых подзадач (M1..M7), применяется tbb::parallel_invoke, позволяя выполнять их параллельно с минимальными затратами на планирование задач. Такой подход обеспечивает корректную обработку любых размеров матриц (включая прямоугольные) и демонстрирует выигрыш по скорости на больших объемах вычислений.