### PR TITLE
Кудряшова Ирина. Вариант 20. Технология TBB. Поразрядная сортировка для вещественных чисел (тип double) с четно-нечетным слиянием Бэтчера

### DIFF
--- a/tasks/tbb/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncTBB.cpp
+++ b/tasks/tbb/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncTBB.cpp
@@ -30,11 +30,11 @@ TEST(kudryashova_i_radix_batcher_tbb, tbb_radix_test_1) {
   task_data->inputs_count.emplace_back(global_vector.size());
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   task_data->outputs_count.emplace_back(result.size());
-  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_open_mp(task_data);
-  ASSERT_TRUE(task_open_mp.ValidationImpl());
-  task_open_mp.PreProcessingImpl();
-  task_open_mp.RunImpl();
-  task_open_mp.PostProcessingImpl();
+  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_tbb(task_data);
+  ASSERT_TRUE(task_tbb.ValidationImpl());
+  task_tbb.PreProcessingImpl();
+  task_tbb.RunImpl();
+  task_tbb.PostProcessingImpl();
   std::vector<double> sort_global_vector = global_vector;
   std::ranges::sort(sort_global_vector);
   ASSERT_EQ(result, sort_global_vector);
@@ -50,11 +50,11 @@ TEST(kudryashova_i_radix_batcher_tbb, tbb_radix_test_2) {
   task_data->inputs_count.emplace_back(global_vector.size());
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   task_data->outputs_count.emplace_back(result.size());
-  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_open_mp(task_data);
-  ASSERT_TRUE(task_open_mp.ValidationImpl());
-  task_open_mp.PreProcessingImpl();
-  task_open_mp.RunImpl();
-  task_open_mp.PostProcessingImpl();
+  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_tbb(task_data);
+  ASSERT_TRUE(task_tbb.ValidationImpl());
+  task_tbb.PreProcessingImpl();
+  task_tbb.RunImpl();
+  task_tbb.PostProcessingImpl();
   std::vector<double> sorted_global_vector = global_vector;
   std::ranges::sort(sorted_global_vector);
   ASSERT_EQ(result, sorted_global_vector);
@@ -69,11 +69,11 @@ TEST(kudryashova_i_radix_batcher_tbb, tbb_radix_all_equal_elem_test_3) {
   task_data->inputs_count.emplace_back(global_vector.size());
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   task_data->outputs_count.emplace_back(result.size());
-  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_open_mp(task_data);
-  ASSERT_TRUE(task_open_mp.ValidationImpl());
-  task_open_mp.PreProcessingImpl();
-  task_open_mp.RunImpl();
-  task_open_mp.PostProcessingImpl();
+  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_tbb(task_data);
+  ASSERT_TRUE(task_tbb.ValidationImpl());
+  task_tbb.PreProcessingImpl();
+  task_tbb.RunImpl();
+  task_tbb.PostProcessingImpl();
   std::vector<double> sorted_global_vector = global_vector;
   std::ranges::sort(sorted_global_vector);
   ASSERT_EQ(result, sorted_global_vector);
@@ -88,29 +88,31 @@ TEST(kudryashova_i_radix_batcher_tbb, tbb_radix_all_zero_elem_test_4) {
   task_data->inputs_count.emplace_back(global_vector.size());
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   task_data->outputs_count.emplace_back(result.size());
-  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_open_mp(task_data);
-  ASSERT_TRUE(task_open_mp.ValidationImpl());
-  task_open_mp.PreProcessingImpl();
-  task_open_mp.RunImpl();
-  task_open_mp.PostProcessingImpl();
+  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_tbb(task_data);
+  ASSERT_TRUE(task_tbb.ValidationImpl());
+  task_tbb.PreProcessingImpl();
+  task_tbb.RunImpl();
+  task_tbb.PostProcessingImpl();
   ASSERT_EQ(result, global_vector);
 }
 
-TEST(kudryashova_i_radix_batcher_tbb, tbb_radix_all_zero_test_3) {
+TEST(kudryashova_i_radix_batcher_tbb, tbb_radix_test_5) {
   int global_vector_size = 8;
-  std::vector<double> global_vector = {1.57, 1.57, 1.57, 1.57, 1.57, 1.57, 1.57, 1.57};
+  std::vector<double> global_vector = {1.852, 1.2, 1.7852, 5.57, 4.525, 100.769, 75.123, 85.57};
   std::vector<double> result(global_vector_size);
   std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
   task_data->inputs_count.emplace_back(global_vector.size());
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   task_data->outputs_count.emplace_back(result.size());
-  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_open_mp(task_data);
-  ASSERT_TRUE(task_open_mp.ValidationImpl());
-  task_open_mp.PreProcessingImpl();
-  task_open_mp.RunImpl();
-  task_open_mp.PostProcessingImpl();
-  ASSERT_EQ(result, global_vector);
+  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_tbb(task_data);
+  ASSERT_TRUE(task_tbb.ValidationImpl());
+  task_tbb.PreProcessingImpl();
+  task_tbb.RunImpl();
+  task_tbb.PostProcessingImpl();
+  std::vector<double> sorted_global_vector = global_vector;
+  std::ranges::sort(sorted_global_vector);
+  ASSERT_EQ(result, sorted_global_vector);
 }
 
 TEST(kudryashova_i_radix_batcher_tbb, tbb_radix_random_test_1) {
@@ -122,11 +124,11 @@ TEST(kudryashova_i_radix_batcher_tbb, tbb_radix_random_test_1) {
   task_data->inputs_count.emplace_back(global_vector.size());
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   task_data->outputs_count.emplace_back(result.size());
-  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_open_mp(task_data);
-  ASSERT_TRUE(task_open_mp.ValidationImpl());
-  task_open_mp.PreProcessingImpl();
-  task_open_mp.RunImpl();
-  task_open_mp.PostProcessingImpl();
+  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_tbb(task_data);
+  ASSERT_TRUE(task_tbb.ValidationImpl());
+  task_tbb.PreProcessingImpl();
+  task_tbb.RunImpl();
+  task_tbb.PostProcessingImpl();
   std::vector<double> sorted_global_vector = global_vector;
   std::ranges::sort(sorted_global_vector);
   ASSERT_EQ(result, sorted_global_vector);
@@ -141,11 +143,11 @@ TEST(kudryashova_i_radix_batcher_tbb, tbb_radix_random_test_2) {
   task_data->inputs_count.emplace_back(global_vector.size());
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   task_data->outputs_count.emplace_back(result.size());
-  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_open_mp(task_data);
-  ASSERT_TRUE(task_open_mp.ValidationImpl());
-  task_open_mp.PreProcessingImpl();
-  task_open_mp.RunImpl();
-  task_open_mp.PostProcessingImpl();
+  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_tbb(task_data);
+  ASSERT_TRUE(task_tbb.ValidationImpl());
+  task_tbb.PreProcessingImpl();
+  task_tbb.RunImpl();
+  task_tbb.PostProcessingImpl();
   std::vector<double> sorted_global_vector = global_vector;
   std::ranges::sort(sorted_global_vector);
   ASSERT_EQ(result, sorted_global_vector);
@@ -161,11 +163,11 @@ TEST(kudryashova_i_radix_batcher_tbb, tbb_radix_test_regular_order) {
   task_data->inputs_count.emplace_back(global_vector.size());
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   task_data->outputs_count.emplace_back(result.size());
-  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_open_mp(task_data);
-  ASSERT_TRUE(task_open_mp.ValidationImpl());
-  task_open_mp.PreProcessingImpl();
-  task_open_mp.RunImpl();
-  task_open_mp.PostProcessingImpl();
+  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_tbb(task_data);
+  ASSERT_TRUE(task_tbb.ValidationImpl());
+  task_tbb.PreProcessingImpl();
+  task_tbb.RunImpl();
+  task_tbb.PostProcessingImpl();
   ASSERT_EQ(result, global_vector);
 }
 
@@ -179,11 +181,11 @@ TEST(kudryashova_i_radix_batcher_tbb, tbb_radix_test_reverse_order) {
   task_data->inputs_count.emplace_back(global_vector.size());
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   task_data->outputs_count.emplace_back(result.size());
-  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_open_mp(task_data);
-  ASSERT_TRUE(task_open_mp.ValidationImpl());
-  task_open_mp.PreProcessingImpl();
-  task_open_mp.RunImpl();
-  task_open_mp.PostProcessingImpl();
+  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_tbb(task_data);
+  ASSERT_TRUE(task_tbb.ValidationImpl());
+  task_tbb.PreProcessingImpl();
+  task_tbb.RunImpl();
+  task_tbb.PostProcessingImpl();
   std::vector<double> sorted_global_vector = global_vector;
   std::ranges::sort(sorted_global_vector);
   ASSERT_EQ(result, sorted_global_vector);

--- a/tasks/tbb/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncTBB.cpp
+++ b/tasks/tbb/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncTBB.cpp
@@ -1,0 +1,141 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <functional>
+#include <memory>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "core/util/include/util.hpp"
+#include "tbb/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherTBB.hpp"
+
+std::vector<double> kudryashova_i_radix_batcher_tbb::GetRandomDoubleVector(int size) {
+  std::vector<double> vector(size);
+  std::mt19937 generator(static_cast<unsigned>(std::time(nullptr)));
+  std::uniform_real_distribution<double> distribution(-1000.0, 1000.0);
+  for (int i = 0; i < size; ++i) {
+    vector[i] = distribution(generator);
+  }
+  return vector;
+}
+
+TEST(kudryashova_i_radix_batcher_tbb, tbb_radix_test_1) {
+  int global_vector_size = 3;
+  std::vector<double> global_vector = {5.69, -2.11, 0.52};
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_open_mp(task_data);
+  ASSERT_TRUE(task_open_mp.ValidationImpl());
+  task_open_mp.PreProcessingImpl();
+  task_open_mp.RunImpl();
+  task_open_mp.PostProcessingImpl();
+  std::vector<double> sort_global_vector = global_vector;
+  std::ranges::sort(sort_global_vector);
+  ASSERT_EQ(result, sort_global_vector);
+}
+
+TEST(kudryashova_i_radix_batcher_tbb, tbb_radix_test_2) {
+  int global_vector_size = 11;
+  std::vector<double> global_vector = {-8.55,   1.85,   -4.0,   2.81828, 8.77,   -5.56562,
+                                       -15.823, -6.971, 3.1615, 0.0,     10.1415};
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_open_mp(task_data);
+  ASSERT_TRUE(task_open_mp.ValidationImpl());
+  task_open_mp.PreProcessingImpl();
+  task_open_mp.RunImpl();
+  task_open_mp.PostProcessingImpl();
+  std::vector<double> sorted_global_vector = global_vector;
+  std::ranges::sort(sorted_global_vector);
+  ASSERT_EQ(result, sorted_global_vector);
+}
+
+TEST(kudryashova_i_radix_batcher_tbb, tbb_radix_random_test_1) {
+  int global_vector_size = 18;
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_tbb::GetRandomDoubleVector(global_vector_size);
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_open_mp(task_data);
+  ASSERT_TRUE(task_open_mp.ValidationImpl());
+  task_open_mp.PreProcessingImpl();
+  task_open_mp.RunImpl();
+  task_open_mp.PostProcessingImpl();
+  std::vector<double> sorted_global_vector = global_vector;
+  std::ranges::sort(sorted_global_vector);
+  ASSERT_EQ(result, sorted_global_vector);
+}
+
+TEST(kudryashova_i_radix_batcher_tbb, tbb_radix_random_test_2) {
+  int global_vector_size = 512;
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_tbb::GetRandomDoubleVector(global_vector_size);
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_open_mp(task_data);
+  ASSERT_TRUE(task_open_mp.ValidationImpl());
+  task_open_mp.PreProcessingImpl();
+  task_open_mp.RunImpl();
+  task_open_mp.PostProcessingImpl();
+  std::vector<double> sorted_global_vector = global_vector;
+  std::ranges::sort(sorted_global_vector);
+  ASSERT_EQ(result, sorted_global_vector);
+}
+
+TEST(kudryashova_i_radix_batcher_tbb, tbb_radix_test_regular_order) {
+  int global_vector_size = 100;
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_tbb::GetRandomDoubleVector(global_vector_size);
+  std::ranges::sort(global_vector);
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_open_mp(task_data);
+  ASSERT_TRUE(task_open_mp.ValidationImpl());
+  task_open_mp.PreProcessingImpl();
+  task_open_mp.RunImpl();
+  task_open_mp.PostProcessingImpl();
+  ASSERT_EQ(result, global_vector);
+}
+
+TEST(kudryashova_i_radix_batcher_tbb, tbb_radix_test_reverse_order) {
+  int global_vector_size = 100;
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_tbb::GetRandomDoubleVector(global_vector_size);
+  std::ranges::sort(global_vector, std::greater<>());
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_open_mp(task_data);
+  ASSERT_TRUE(task_open_mp.ValidationImpl());
+  task_open_mp.PreProcessingImpl();
+  task_open_mp.RunImpl();
+  task_open_mp.PostProcessingImpl();
+  std::vector<double> sorted_global_vector = global_vector;
+  std::ranges::sort(sorted_global_vector);
+  ASSERT_EQ(result, sorted_global_vector);
+}

--- a/tasks/tbb/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncTBB.cpp
+++ b/tasks/tbb/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncTBB.cpp
@@ -60,6 +60,59 @@ TEST(kudryashova_i_radix_batcher_tbb, tbb_radix_test_2) {
   ASSERT_EQ(result, sorted_global_vector);
 }
 
+TEST(kudryashova_i_radix_batcher_tbb, tbb_radix_all_equal_elem_test_3) {
+  int global_vector_size = 8;
+  std::vector<double> global_vector = {1.57, 1.57, 1.57, 1.57, 1.57, 1.57, 1.57, 1.57};
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_open_mp(task_data);
+  ASSERT_TRUE(task_open_mp.ValidationImpl());
+  task_open_mp.PreProcessingImpl();
+  task_open_mp.RunImpl();
+  task_open_mp.PostProcessingImpl();
+  std::vector<double> sorted_global_vector = global_vector;
+  std::ranges::sort(sorted_global_vector);
+  ASSERT_EQ(result, sorted_global_vector);
+}
+
+TEST(kudryashova_i_radix_batcher_tbb, tbb_radix_all_zero_elem_test_4) {
+  int global_vector_size = 7;
+  std::vector<double> global_vector = {0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00};
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_open_mp(task_data);
+  ASSERT_TRUE(task_open_mp.ValidationImpl());
+  task_open_mp.PreProcessingImpl();
+  task_open_mp.RunImpl();
+  task_open_mp.PostProcessingImpl();
+  ASSERT_EQ(result, global_vector);
+}
+
+TEST(kudryashova_i_radix_batcher_tbb, tbb_radix_all_zero_test_3) {
+  int global_vector_size = 8;
+  std::vector<double> global_vector = {1.57, 1.57, 1.57, 1.57, 1.57, 1.57, 1.57, 1.57};
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_tbb::TestTaskTBB task_open_mp(task_data);
+  ASSERT_TRUE(task_open_mp.ValidationImpl());
+  task_open_mp.PreProcessingImpl();
+  task_open_mp.RunImpl();
+  task_open_mp.PostProcessingImpl();
+  ASSERT_EQ(result, global_vector);
+}
+
 TEST(kudryashova_i_radix_batcher_tbb, tbb_radix_random_test_1) {
   int global_vector_size = 18;
   std::vector<double> global_vector = kudryashova_i_radix_batcher_tbb::GetRandomDoubleVector(global_vector_size);

--- a/tasks/tbb/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncTBB.cpp
+++ b/tasks/tbb/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncTBB.cpp
@@ -1,18 +1,14 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
-#include <cstddef>
 #include <cstdint>
 #include <ctime>
-#include <fstream>
 #include <functional>
 #include <memory>
 #include <random>
-#include <string>
 #include <vector>
 
 #include "core/task/include/task.hpp"
-#include "core/util/include/util.hpp"
 #include "tbb/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherTBB.hpp"
 
 std::vector<double> kudryashova_i_radix_batcher_tbb::GetRandomDoubleVector(int size) {

--- a/tasks/tbb/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherTBB.hpp
+++ b/tasks/tbb/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherTBB.hpp
@@ -9,6 +9,8 @@
 
 namespace kudryashova_i_radix_batcher_tbb {
 std::vector<double> GetRandomDoubleVector(int size);
+void ConvertDoublesToUint64(const std::vector<double>& data, std::vector<uint64_t>& converted, size_t first);
+void ConvertUint64ToDoubles(std::vector<double>& data, const std::vector<uint64_t>& converted, size_t first);
 void RadixDoubleSort(std::vector<double>& data, size_t first, size_t last);
 void BatcherMerge(std::vector<double>& target_array, size_t merge_start, size_t mid_point, size_t merge_end);
 

--- a/tasks/tbb/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherTBB.hpp
+++ b/tasks/tbb/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherTBB.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kudryashova_i_radix_batcher_tbb {
+std::vector<double> GetRandomDoubleVector(int size);
+void RadixDoubleSort(std::vector<double>& data, size_t first, size_t last);
+void BatcherMerge(std::vector<double>& target_array, size_t merge_start, size_t mid_point, size_t merge_end);
+
+class TestTaskTBB : public ppc::core::Task {
+ public:
+  explicit TestTaskTBB(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<double> input_data_;
+};
+
+}  // namespace kudryashova_i_radix_batcher_tbb

--- a/tasks/tbb/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherTBB.hpp
+++ b/tasks/tbb/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherTBB.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cmath>
+#include <cstddef>
 #include <utility>
 #include <vector>
 

--- a/tasks/tbb/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherTBB.hpp
+++ b/tasks/tbb/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherTBB.hpp
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <utility>
 #include <vector>
 

--- a/tasks/tbb/kudryashova_i_radix_batcher/perf_tests/kudryashovaRadixBatcherPerfTBB.cpp
+++ b/tasks/tbb/kudryashova_i_radix_batcher/perf_tests/kudryashovaRadixBatcherPerfTBB.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
-#include <cstddef>
 #include <cstdint>
 #include <ctime>
 #include <memory>

--- a/tasks/tbb/kudryashova_i_radix_batcher/perf_tests/kudryashovaRadixBatcherPerfTBB.cpp
+++ b/tasks/tbb/kudryashova_i_radix_batcher/perf_tests/kudryashovaRadixBatcherPerfTBB.cpp
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <ctime>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "tbb/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherTBB.hpp"
+
+std::vector<double> kudryashova_i_radix_batcher_tbb::GetRandomDoubleVector(int size) {
+  std::vector<double> vector(size);
+  std::mt19937 generator(static_cast<unsigned>(std::time(nullptr)));
+  std::uniform_real_distribution<double> distribution(-1000.0, 1000.0);
+  for (int i = 0; i < size; ++i) {
+    vector[i] = distribution(generator);
+  }
+  return vector;
+}
+
+TEST(kudryashova_i_radix_batcher_tbb, test_pipeline_run) {
+  int global_vector_size = 300000;
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_tbb::GetRandomDoubleVector(global_vector_size);
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  auto test_task_open_mp = std::make_shared<kudryashova_i_radix_batcher_tbb::TestTaskTBB>(task_data);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 3;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_open_mp);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
+    ASSERT_LE(result[i - 1], result[i]);
+  }
+}
+
+TEST(kudryashova_i_radix_batcher_tbb, test_task_run) {
+  int global_vector_size = 300000;
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_tbb::GetRandomDoubleVector(global_vector_size);
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  auto test_task_open_mp = std::make_shared<kudryashova_i_radix_batcher_tbb::TestTaskTBB>(task_data);
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 3;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_open_mp);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
+    ASSERT_LE(result[i - 1], result[i]);
+  }
+}

--- a/tasks/tbb/kudryashova_i_radix_batcher/perf_tests/kudryashovaRadixBatcherPerfTBB.cpp
+++ b/tasks/tbb/kudryashova_i_radix_batcher/perf_tests/kudryashovaRadixBatcherPerfTBB.cpp
@@ -30,7 +30,7 @@ TEST(kudryashova_i_radix_batcher_tbb, test_pipeline_run) {
   task_data->inputs_count.emplace_back(global_vector.size());
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   task_data->outputs_count.emplace_back(result.size());
-  auto test_task_open_mp = std::make_shared<kudryashova_i_radix_batcher_tbb::TestTaskTBB>(task_data);
+  auto test_task_tbb = std::make_shared<kudryashova_i_radix_batcher_tbb::TestTaskTBB>(task_data);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 3;
@@ -41,7 +41,7 @@ TEST(kudryashova_i_radix_batcher_tbb, test_pipeline_run) {
     return static_cast<double>(duration) * 1e-9;
   };
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
-  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_open_mp);
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_tbb);
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
   for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
@@ -58,7 +58,7 @@ TEST(kudryashova_i_radix_batcher_tbb, test_task_run) {
   task_data->inputs_count.emplace_back(global_vector.size());
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
   task_data->outputs_count.emplace_back(result.size());
-  auto test_task_open_mp = std::make_shared<kudryashova_i_radix_batcher_tbb::TestTaskTBB>(task_data);
+  auto test_task_tbb = std::make_shared<kudryashova_i_radix_batcher_tbb::TestTaskTBB>(task_data);
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 3;
   const auto t0 = std::chrono::high_resolution_clock::now();
@@ -68,7 +68,7 @@ TEST(kudryashova_i_radix_batcher_tbb, test_task_run) {
     return static_cast<double>(duration) * 1e-9;
   };
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
-  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_open_mp);
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_tbb);
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
   for (std::vector<double>::size_type i = 1; i < result.size(); i++) {

--- a/tasks/tbb/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherTBB.cpp
+++ b/tasks/tbb/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherTBB.cpp
@@ -53,7 +53,7 @@ void kudryashova_i_radix_batcher_tbb::RadixDoubleSort(std::vector<double>& data,
   int bits_int_byte = 8;
   int max_byte_value = 255;
   size_t total_bits = sizeof(uint64_t) * CHAR_BIT;
-  for (int shift = 0; shift < total_bits; shift += bits_int_byte) {
+  for (size_t shift = 0; shift < total_bits; shift += bits_int_byte) {
     tbb::combinable<std::array<size_t, 256>> local_counts;
     tbb::parallel_for(tbb::blocked_range<size_t>(0, sort_size), [&](const auto& range) {
       auto& counts = local_counts.local();

--- a/tasks/tbb/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherTBB.cpp
+++ b/tasks/tbb/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherTBB.cpp
@@ -1,0 +1,143 @@
+#include "tbb/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherTBB.hpp"
+
+#include <tbb/blocked_range.h>
+#include <tbb/combinable.h>
+#include <tbb/global_control.h>
+#include <tbb/parallel_for.h>
+#include <tbb/parallel_invoke.h>
+#include <tbb/partitioner.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+void kudryashova_i_radix_batcher_tbb::RadixDoubleSort(std::vector<double>& data, size_t first, size_t last) {
+  const size_t sort_size = last - first;
+  std::vector<uint64_t> converted(sort_size);
+  // Convert each double to uint64_t representation
+  tbb::parallel_for(
+      tbb::blocked_range<size_t>(0, sort_size),
+      [&](const tbb::blocked_range<size_t>& range) {
+        for (size_t i = range.begin(); i < range.end(); ++i) {
+          double value = data[first + i];
+          uint64_t bits = 0;
+          std::memcpy(&bits, &value, sizeof(value));
+          converted[i] = ((bits & (1ULL << 63)) != 0) ? ~bits : bits ^ (1ULL << 63);
+        }
+      },
+      tbb::auto_partitioner());
+
+  std::vector<uint64_t> buffer(sort_size);
+  int bits_int_byte = 8;
+  int max_byte_value = 255;
+  for (int shift = 0; shift < 64; shift += bits_int_byte) {
+    tbb::combinable<std::array<size_t, 256>> local_counts;
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, sort_size), [&](const auto& range) {
+      auto& counts = local_counts.local();
+      for (size_t i = range.begin(); i < range.end(); ++i) {
+        ++counts[(converted[i] >> shift) & max_byte_value];
+      }
+    });
+
+    std::array<size_t, 256> total_counts{};
+    local_counts.combine_each([&](const auto& local_count) {
+      for (size_t i = 0; i < 256; ++i) {
+        total_counts[i] += local_count[i];
+      }
+    });
+    // Convert the count array to a prefix sum array
+    size_t total = 0;
+    for (auto& safe : total_counts) {
+      size_t old = safe;
+      safe = total;
+      total += old;
+    }
+
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, 256), [&](const auto& range) {
+      for (size_t j = range.begin(); j < range.end(); ++j) {
+        size_t count = total_counts[j];
+        for (size_t i = 0; i < sort_size; ++i) {
+          if (((converted[i] >> shift) & max_byte_value) == j) {
+            buffer[count++] = converted[i];
+          }
+        }
+      }
+    });
+
+    converted.swap(buffer);
+  }
+  tbb::parallel_for(
+      tbb::blocked_range<size_t>(0, sort_size),
+      [&](const tbb::blocked_range<size_t>& range) {
+        for (size_t i = range.begin(); i < range.end(); ++i) {
+          uint64_t bits = converted[i];
+          bits = ((bits & (1ULL << 63)) != 0) ? (bits ^ (1ULL << 63)) : ~bits;
+          std::memcpy(&data[first + i], &bits, sizeof(double));
+        }
+      },
+      tbb::auto_partitioner());
+}
+
+void kudryashova_i_radix_batcher_tbb::BatcherMerge(std::vector<double>& target_array, size_t merge_start,
+                                                   size_t mid_point, size_t merge_end) {
+  const size_t n = merge_end - merge_start;
+  if (n <= 1) {
+    return;
+  }
+  tbb::parallel_invoke([&] { BatcherMerge(target_array, merge_start, (merge_start + mid_point) / 2, mid_point); },
+                       [&] { BatcherMerge(target_array, mid_point, (mid_point + merge_end) / 2, merge_end); });
+
+  for (size_t step = 1; step < n; step *= 2) {
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, n / (2 * step)), [&](const auto& batch_range) {
+      for (size_t i = batch_range.begin(); i < batch_range.end(); ++i) {
+        const size_t left = merge_start + (2 * step * i);
+        const size_t block_end = std::min(left + (2 * step), merge_end);
+        for (size_t j = left + 1; j < block_end; j += 2) {
+          if (target_array[j - 1] > target_array[j]) {
+            std::swap(target_array[j - 1], target_array[j]);
+          }
+        }
+      }
+    });
+  }
+}
+
+bool kudryashova_i_radix_batcher_tbb::TestTaskTBB::RunImpl() {
+  size_t n = input_data_.size();
+  RadixDoubleSort(input_data_, 0, n);
+  for (size_t step = 1; step < n; step *= 2) {
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, n / (2 * step)), [&](const auto& merge_range) {
+      for (size_t i = merge_range.begin(); i < merge_range.end(); ++i) {
+        const size_t start = 2 * step * i;
+        const size_t mid = start + step;
+        const size_t end = std::min(start + (2 * step), n);
+        if (mid < end) {
+          BatcherMerge(input_data_, start, mid, end);
+        }
+      }
+    });
+  }
+  return true;
+}
+
+bool kudryashova_i_radix_batcher_tbb::TestTaskTBB::PreProcessingImpl() {
+  input_data_.resize(task_data->inputs_count[0]);
+  if (task_data->inputs[0] == nullptr || task_data->inputs_count[0] == 0) {
+    return false;
+  }
+  auto* tmp_ptr = reinterpret_cast<double*>(task_data->inputs[0]);
+  std::copy(tmp_ptr, tmp_ptr + task_data->inputs_count[0], input_data_.begin());
+  return true;
+}
+
+bool kudryashova_i_radix_batcher_tbb::TestTaskTBB::ValidationImpl() {
+  return task_data->inputs_count[0] > 0 && task_data->outputs_count[0] == task_data->inputs_count[0];
+}
+
+bool kudryashova_i_radix_batcher_tbb::TestTaskTBB::PostProcessingImpl() {
+  std::ranges::copy(input_data_, reinterpret_cast<double*>(task_data->outputs[0]));
+  return true;
+}


### PR DESCRIPTION
Данная реализация демонстрирует поразрядную сортировку и чётно-нечётное слияние Бэтчера с использованием TBB для параллелизации. Функция сортировки RadixDoubleSort работает с числами double, преобразуя их битовое представление в uint64_t для корректной обработки знака и порядка. Основные этапы включают: параллельное преобразование данных в целочисленный формат, поразрядную сортировку по байтам с использованием tbb::combinable для подсчёта частот и обратное преобразование в double. Параллельные циклы tbb::parallel_for ускоряют преобразование данных, подсчёт гистограмм и перераспределение элементов
Слияние Бэтчера реализовано рекурсивно с помощью tbb::parallel_invoke, параллельно сортирует половины массива, а в tbb::parallel_for объединяет отсортированные подмассивы, сравнивая элементы с шагом, растущим степенями двойки.