### PR TITLE
Волочаев Серафим. Вариант 16. Технология: ALL (MPI + STL) Сортировка Шелла с четно-нечетным слиянием Бэтчера.

### DIFF
--- a/tasks/all/volochaev_s_Shell_sort_with_Batchers_even-odd_merge/func_tests/main.cpp
+++ b/tasks/all/volochaev_s_Shell_sort_with_Batchers_even-odd_merge/func_tests/main.cpp
@@ -1,0 +1,2510 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <stdexcept>
+#include <vector>
+
+#include "all/volochaev_s_Shell_sort_with_Batchers_even-odd_merge/include/ops_all.hpp"
+#include "core/task/include/task.hpp"
+
+namespace {
+void GetRandomVector(std::vector<int> &v, int a, int b) {
+  std::random_device dev;
+  std::mt19937 gen(dev());
+
+  if (a >= b) {
+    throw std::invalid_argument("error.");
+  }
+
+  std::uniform_int_distribution<> dis(a, b);
+
+  for (size_t i = 0; i < v.size(); ++i) {
+    v[i] = dis(gen);
+  }
+}
+}  // namespace
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_error_in_val) {
+  constexpr size_t kSizeOfVector = 0;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  std::vector<int> out(kSizeOfVector, 0);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), false);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_error_in_generate) {
+  constexpr size_t kSizeOfVector = 100;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  ASSERT_ANY_THROW(GetRandomVector(in, 1000, -1000));
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_small_vector) {
+  constexpr size_t kSizeOfVector = 100;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_small_vector2) {
+  constexpr size_t kSizeOfVector = 200;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_small_vector3) {
+  constexpr size_t kSizeOfVector = 300;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_small_vector4) {
+  constexpr size_t kSizeOfVector = 400;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_medium_vector) {
+  constexpr size_t kSizeOfVector = 500;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_medium_vector2) {
+  constexpr size_t kSizeOfVector = 600;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_medium_vector3) {
+  constexpr size_t kSizeOfVector = 700;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_medium_vector4) {
+  constexpr size_t kSizeOfVector = 800;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_medium_vector5) {
+  constexpr size_t kSizeOfVector = 900;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_big_vector) {
+  constexpr size_t kSizeOfVector = 1000;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_big_vector2) {
+  constexpr size_t kSizeOfVector = 2000;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_big_vector3) {
+  constexpr size_t kSizeOfVector = 3000;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_big_vector4) {
+  constexpr size_t kSizeOfVector = 4000;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_extra_big_vector) {
+  constexpr size_t kSizeOfVector = 10000;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_prime_size_vector) {
+  constexpr size_t kSizeOfVector = 7;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_prime_size_vector1) {
+  constexpr size_t kSizeOfVector = 13;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_prime_size_vector2) {
+  constexpr size_t kSizeOfVector = 17;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_prime_size_vector3) {
+  constexpr size_t kSizeOfVector = 23;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_prime_size_vector4) {
+  constexpr size_t kSizeOfVector = 29;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_odd_number_of_elements) {
+  constexpr size_t kSizeOfVector = 101;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_odd_number_of_elements1) {
+  constexpr size_t kSizeOfVector = 99;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_odd_number_of_elements2) {
+  constexpr size_t kSizeOfVector = 201;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_odd_number_of_elements3) {
+  constexpr size_t kSizeOfVector = 199;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_odd_number_of_elements4) {
+  constexpr size_t kSizeOfVector = 301;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_odd_number_of_elements5) {
+  constexpr size_t kSizeOfVector = 299;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_odd_number_of_elements6) {
+  constexpr size_t kSizeOfVector = 401;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_odd_number_of_elements7) {
+  constexpr size_t kSizeOfVector = 399;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_shell_sort_with_batchers_even_odd_merge_all, test_with_reverse) {
+  constexpr size_t kSizeOfVector = 399;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  std::ranges::sort(in);
+  std::ranges::reverse(in);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Fermats_1) {
+  constexpr size_t kSizeOfVector = 3;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Fermats_2) {
+  constexpr size_t kSizeOfVector = 5;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Fermats_3) {
+  constexpr size_t kSizeOfVector = 17;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Fermats_4) {
+  constexpr size_t kSizeOfVector = 257;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Fermats_5) {
+  constexpr size_t kSizeOfVector = 65537;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Euler_base_2_1) {
+  constexpr size_t kSizeOfVector = 561;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Euler_base_2_2) {
+  constexpr size_t kSizeOfVector = 1105;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Euler_base_2_3) {
+  constexpr size_t kSizeOfVector = 1729;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Euler_base_2_4) {
+  constexpr size_t kSizeOfVector = 1905;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Euler_base_2_5) {
+  constexpr size_t kSizeOfVector = 2047;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Euler_base_2_6) {
+  constexpr size_t kSizeOfVector = 2465;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Euler_base_2_7) {
+  constexpr size_t kSizeOfVector = 3277;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Euler_base_2_8) {
+  constexpr size_t kSizeOfVector = 4033;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Euler_base_2_9) {
+  constexpr size_t kSizeOfVector = 4681;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Euler_base_2_10) {
+  constexpr size_t kSizeOfVector = 6601;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Euler_base_3_1) {
+  constexpr size_t kSizeOfVector = 121;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Euler_base_3_2) {
+  constexpr size_t kSizeOfVector = 703;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Euler_base_3_3) {
+  constexpr size_t kSizeOfVector = 1729;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Euler_base_3_4) {
+  constexpr size_t kSizeOfVector = 2821;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Euler_base_3_5) {
+  constexpr size_t kSizeOfVector = 3281;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Euler_base_3_6) {
+  constexpr size_t kSizeOfVector = 7381;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Euler_base_3_7) {
+  constexpr size_t kSizeOfVector = 8401;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Euler_base_3_8) {
+  constexpr size_t kSizeOfVector = 8911;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Euler_base_3_9) {
+  constexpr size_t kSizeOfVector = 10585;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Euler_base_3_10) {
+  constexpr size_t kSizeOfVector = 12403;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Mersenne_1) {
+  constexpr size_t kSizeOfVector = 16383;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Mersenne_2) {
+  constexpr size_t kSizeOfVector = 32767;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Mersenne_3) {
+  constexpr size_t kSizeOfVector = 65535;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Mersenne_4) {
+  constexpr size_t kSizeOfVector = 131071;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Mersenne_5) {
+  constexpr size_t kSizeOfVector = 524287;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Lucas_1) {
+  constexpr size_t kSizeOfVector = 1;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Lucas_2) {
+  constexpr size_t kSizeOfVector = 2;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Lucas_3) {
+  constexpr size_t kSizeOfVector = 3;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Lucas_4) {
+  constexpr size_t kSizeOfVector = 4;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Lucas_5) {
+  constexpr size_t kSizeOfVector = 7;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Lucas_6) {
+  constexpr size_t kSizeOfVector = 11;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Lucas_7) {
+  constexpr size_t kSizeOfVector = 18;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Lucas_8) {
+  constexpr size_t kSizeOfVector = 29;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Lucas_9) {
+  constexpr size_t kSizeOfVector = 47;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Lucas_10) {
+  constexpr size_t kSizeOfVector = 76;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Lucas_11) {
+  constexpr size_t kSizeOfVector = 123;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Lucas_12) {
+  constexpr size_t kSizeOfVector = 199;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Lucas_13) {
+  constexpr size_t kSizeOfVector = 322;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_1) {
+  constexpr size_t kSizeOfVector = 1729;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_2) {
+  constexpr size_t kSizeOfVector = 4104;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_3) {
+  constexpr size_t kSizeOfVector = 13832;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_4) {
+  constexpr size_t kSizeOfVector = 20683;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_5) {
+  constexpr size_t kSizeOfVector = 32832;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_6) {
+  constexpr size_t kSizeOfVector = 39312;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_7) {
+  constexpr size_t kSizeOfVector = 40033;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_8) {
+  constexpr size_t kSizeOfVector = 46683;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_9) {
+  constexpr size_t kSizeOfVector = 64232;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_10) {
+  constexpr size_t kSizeOfVector = 65728;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_11) {
+  constexpr size_t kSizeOfVector = 110656;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_12) {
+  constexpr size_t kSizeOfVector = 110808;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_13) {
+  constexpr size_t kSizeOfVector = 134379;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_14) {
+  constexpr size_t kSizeOfVector = 149389;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_15) {
+  constexpr size_t kSizeOfVector = 165464;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_16) {
+  constexpr size_t kSizeOfVector = 171288;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_17) {
+  constexpr size_t kSizeOfVector = 195841;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_18) {
+  constexpr size_t kSizeOfVector = 216027;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_19) {
+  constexpr size_t kSizeOfVector = 216125;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_20) {
+  constexpr size_t kSizeOfVector = 262656;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_21) {
+  constexpr size_t kSizeOfVector = 314496;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_22) {
+  constexpr size_t kSizeOfVector = 320264;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Ramanujan_23) {
+  constexpr size_t kSizeOfVector = 327763;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Carmichael_1) {
+  constexpr size_t kSizeOfVector = 561;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Carmichael_2) {
+  constexpr size_t kSizeOfVector = 41041;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_with_len_Carmichael_3) {
+  constexpr size_t kSizeOfVector = 825265;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 0);
+  GetRandomVector(in, -100, 100);
+  std::vector<int> out(kSizeOfVector, 0);
+  std::vector<int> answer(in);
+  std::ranges::sort(answer);
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL test_task_sequential(task_data_seq);
+  ASSERT_EQ(test_task_sequential.Validation(), true);
+  test_task_sequential.PreProcessing();
+  test_task_sequential.Run();
+  test_task_sequential.PostProcessing();
+  EXPECT_EQ(answer, out);
+}

--- a/tasks/all/volochaev_s_Shell_sort_with_Batchers_even-odd_merge/include/ops_all.hpp
+++ b/tasks/all/volochaev_s_Shell_sort_with_Batchers_even-odd_merge/include/ops_all.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace volochaev_s_shell_sort_with_batchers_even_odd_merge_all {
+
+class ShellSortALL : public ppc::core::Task {
+ public:
+  explicit ShellSortALL(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  int rank_{0};
+  int world_size_{1};
+  std::vector<int> local_data_;
+
+  int c_threads_{1};
+  int mini_batch_{0};
+  int size_{0};
+  int n_{0};
+  int n_local_{0};
+
+  std::vector<int> array_;
+  std::vector<int> mass_;
+
+  void DistributeData();
+  void GatherAndMerge();
+
+  void ParallelShellSortLocal();
+  void ShellSort(int start);
+  void MergeLocal();
+  void MergeBlocks(int id_l, int id_r, int len);
+  void LastMerge();
+  void FindThreadVariables();
+};
+
+}  // namespace volochaev_s_shell_sort_with_batchers_even_odd_merge_all

--- a/tasks/all/volochaev_s_Shell_sort_with_Batchers_even-odd_merge/perf_tests/main.cpp
+++ b/tasks/all/volochaev_s_Shell_sort_with_Batchers_even-odd_merge/perf_tests/main.cpp
@@ -1,0 +1,86 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "all/volochaev_s_Shell_sort_with_Batchers_even-odd_merge/include/ops_all.hpp"
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_pipeline_run) {
+  constexpr int kSizeOfVector = 50000;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 1);
+  std::vector<int> out(kSizeOfVector, 1);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_sequential =
+      std::make_shared<volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL>(task_data_seq);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(in, out);
+}
+
+TEST(volochaev_s_Shell_sort_with_Batchers_even_odd_merge_all, test_task_run) {
+  constexpr int kSizeOfVector = 50000;
+
+  // Create data
+  std::vector<int> in(kSizeOfVector, 1);
+  std::vector<int> out(kSizeOfVector, 1);
+
+  // Create task_data
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_seq->inputs_count.emplace_back(in.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_sequential =
+      std::make_shared<volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL>(task_data_seq);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(in, out);
+}

--- a/tasks/all/volochaev_s_Shell_sort_with_Batchers_even-odd_merge/src/ops_all.cpp
+++ b/tasks/all/volochaev_s_Shell_sort_with_Batchers_even-odd_merge/src/ops_all.cpp
@@ -1,0 +1,146 @@
+#include <mpi.h>
+
+#include <algorithm>
+#include <cmath>
+#include <future>
+#include <limits>
+#include <ranges>
+#include <thread>
+#include <vector>
+
+#include "all/volochaev_s_Shell_sort_with_Batchers_even-odd_merge/include/ops_all.hpp"
+
+bool volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL::PreProcessingImpl() {
+  MPI_Init(NULL, NULL);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank_);
+  MPI_Comm_size(MPI_COMM_WORLD, &world_size_);
+
+  if (rank_ == 0) {
+    size_ = static_cast<int>(task_data->inputs_count[0]);
+    auto* input_pointer = reinterpret_cast<int*>(task_data->inputs[0]);
+    array_ = std::vector<int>(input_pointer, input_pointer + size_);
+  }
+
+  MPI_Bcast(&size_, 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+  return true;
+}
+
+void volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL::DistributeData() {
+  int local_size = size_ / world_size_;
+  int remainder = size_ % world_size_;
+
+  std::vector<int> counts(world_size_, local_size);
+  std::vector<int> displacements(world_size_, 0);
+
+  for (int i = 0; i < remainder; ++i) {
+    counts[i]++;
+  }
+
+  for (int i = 1; i < world_size_; ++i) {
+    displacements[i] = displacements[i - 1] + counts[i - 1];
+  }
+
+  local_data_.resize(counts[rank_]);
+
+  MPI_Scatterv(array_.data(), counts.data(), displacements.data(), MPI_INT, local_data_.data(), local_data_.size(),
+               MPI_INT, 0, MPI_COMM_WORLD);
+}
+
+void volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL::ParallelShellSortLocal() {
+  unsigned int max_threads = std::thread::hardware_concurrency();
+  c_threads_ = static_cast<int>(std::pow(2, std::floor(std::log2(max_threads))));
+  n_local_ = local_data_.size();
+  mini_batch_ = n_local_ / c_threads_;
+
+  if (mini_batch_ == 0) {
+    mini_batch_ = n_local_;
+    c_threads_ = 1;
+  }
+
+  mass_.resize(n_local_);
+  std::ranges::copy(local_data_, mass_.begin());
+
+  std::vector<std::future<void>> futures;
+  futures.reserve(c_threads_);
+
+  for (int i = 0; i < c_threads_; ++i) {
+    futures.emplace_back(std::async(std::launch::async, [this, i]() { ShellSort(i * mini_batch_); }));
+  }
+
+  for (auto& future : futures) {
+    future.get();
+  }
+
+  MergeLocal();
+}
+
+void volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL::MergeLocal() {
+  int current_threads = c_threads_;
+
+  while (current_threads > 1) {
+    std::vector<std::future<void>> futures;
+    int l = mini_batch_ * (c_threads_ / current_threads);
+
+    for (int i = 0; i < current_threads / 2; ++i) {
+      futures.emplace_back(
+          std::async(std::launch::async, [this, i, l]() { MergeBlocks((i * 2 * l), (i * 2 * l) + l, l); }));
+
+      futures.emplace_back(
+          std::async(std::launch::async, [this, i, l]() { MergeBlocks((i * 2 * l) + 1, (i * 2 * l) + l + 1, l - 1); }));
+    }
+
+    for (auto& future : futures) {
+      future.get();
+    }
+
+    current_threads /= 2;
+  }
+
+  std::ranges::copy(mass_, local_data_.begin());
+}
+
+void volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL::GatherAndMerge() {
+  std::vector<int> all_sizes(world_size_);
+  int local_size = local_data_.size();
+  MPI_Allgather(&local_size, 1, MPI_INT, all_sizes.data(), 1, MPI_INT, MPI_COMM_WORLD);
+
+  std::vector<int> displacements(world_size_, 0);
+  for (int i = 1; i < world_size_; ++i) {
+    displacements[i] = displacements[i - 1] + all_sizes[i - 1];
+  }
+
+  if (rank_ == 0) {
+    array_.resize(size_);
+  }
+
+  MPI_Gatherv(local_data_.data(), local_size, MPI_INT, array_.data(), all_sizes.data(), displacements.data(), MPI_INT,
+              0, MPI_COMM_WORLD);
+
+  if (rank_ == 0) {
+    n_ = size_;
+    mass_ = array_;
+    LastMerge();
+    array_ = mass_;
+  }
+}
+
+bool volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL::RunImpl() {
+  DistributeData();
+
+  ParallelShellSortLocal();
+
+  GatherAndMerge();
+
+  return true;
+}
+
+bool volochaev_s_shell_sort_with_batchers_even_odd_merge_all::ShellSortALL::PostProcessingImpl() {
+  if (rank_ == 0) {
+    int* ptr_ans = reinterpret_cast<int*>(task_data->outputs[0]);
+    std::ranges::copy(array_ | std::views::take(size_), ptr_ans);
+  }
+
+  MPI_Finalize();
+  return true;
+}


### PR DESCRIPTION
так как слияние Бэтчера работает только с количеством потоков, степени двойки, то мы используем только максимальное кол-во потоков дающее нам право использовать такое слияние. Далее делим массив на n равных частей (каждая часть пойдет отдельному потоку). Если размер не делится нацело, то добиваем до того, чтобы делился значением максимального инта (чтобы все добивающие элементы были в конце и при отправке ответа на чекер у нас они в него не попали). Далее происходит сам алгоритм слияния. Так как у нас есть определенный батч, то мы используем такой алгоритм: будем сливать 2 соседние части массива в 1 большую, но по четности, то есть элементы с нечетными индексами сливаем отдельно, с нечетными отдельно. В итоге получаем 1 большую часть в которой будут отсортированы элементы на четных индексах и на нечетных. В итоге мы получим отсортированные 2 последовательности. Далее не составит труда слить их в 1 часть.