### PR TITLE
Козлова Екатерина. Вариант 28. TBB. Повышение контраста полутонового изображения посредством линейной растяжки гистограммы.

### DIFF
--- a/tasks/tbb/kozlova_e_contrast_enhancement/func_tests/main.cpp
+++ b/tasks/tbb/kozlova_e_contrast_enhancement/func_tests/main.cpp
@@ -1,10 +1,10 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <fstream>
+#include <cstdlib>
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "core/task/include/task.hpp"

--- a/tasks/tbb/kozlova_e_contrast_enhancement/func_tests/main.cpp
+++ b/tasks/tbb/kozlova_e_contrast_enhancement/func_tests/main.cpp
@@ -1,0 +1,94 @@
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "tbb/kozlova_e_contrast_enhancement/include/ops_tbb.hpp"
+
+namespace {
+
+std::vector<uint8_t> GenerateVector(int length) {
+  std::vector<uint8_t> vec(length);
+  for (int i = 0; i < length; ++i) {
+    vec[i] = rand() % 256;
+  }
+  return vec;
+}
+
+std::shared_ptr<ppc::core::TaskData> CreateTaskData(std::vector<uint8_t>& in, std::vector<uint8_t>& out, size_t width,
+                                                    size_t height) {
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(in.data());
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->inputs_count.emplace_back(width);
+  task_data->inputs_count.emplace_back(height);
+  task_data->outputs.emplace_back(out.data());
+  task_data->outputs_count.emplace_back(out.size());
+
+  return task_data;
+}
+
+void TestRun(std::vector<uint8_t> in, std::vector<uint8_t> out, size_t width, size_t height) {
+  auto task_data_omp = CreateTaskData(in, out, width, height);
+  kozlova_e_contrast_enhancement_tbb::TestTaskTBB test_task_omp(task_data_omp);
+
+  ASSERT_TRUE(test_task_omp.Validation());
+  test_task_omp.PreProcessing();
+  test_task_omp.Run();
+  test_task_omp.PostProcessing();
+
+  uint8_t min_value = *std::ranges::min_element(in);
+  uint8_t max_value = *std::ranges::max_element(in);
+
+  for (size_t i = 0; i < in.size(); ++i) {
+    uint8_t expected = (max_value == min_value)
+                           ? in[i]
+                           : static_cast<uint8_t>(((in[i] - min_value) / double(max_value - min_value)) * 255);
+    EXPECT_EQ(out[i], expected);
+  }
+}
+
+void TestValidation(std::vector<uint8_t> in, std::vector<uint8_t> out, size_t width, size_t height) {
+  auto task_data_omp = CreateTaskData(in, out, width, height);
+  kozlova_e_contrast_enhancement_tbb::TestTaskTBB test_task_omp(task_data_omp);
+  ASSERT_FALSE(test_task_omp.Validation());
+}
+
+}  // namespace
+
+TEST(kozlova_e_contrast_enhancement_tbb, test_1st_image) {
+  std::vector<uint8_t> in{10, 0, 50, 100, 200, 34};
+  std::vector<uint8_t> out(6, 0);
+  TestRun(in, out, 2, 3);
+}
+
+TEST(kozlova_e_contrast_enhancement_tbb, test_large_image) {
+  std::vector<uint8_t> in = GenerateVector(400);
+  std::vector<uint8_t> out(400, 0);
+  TestRun(in, out, 10, 40);
+}
+
+TEST(kozlova_e_contrast_enhancement_tbb, test_empty_input) { TestValidation({}, {}, 0, 0); }
+
+TEST(kozlova_e_contrast_enhancement_tbb, test_same_values_input) {
+  std::vector<uint8_t> in(6, 100);
+  std::vector<uint8_t> out(6, 0);
+  TestRun(in, out, 2, 3);
+}
+
+TEST(kozlova_e_contrast_enhancement_tbb, test_difference_input) {
+  std::vector<uint8_t> in{10, 20, 30, 100, 200, 250};
+  std::vector<uint8_t> out(6, 0);
+  TestRun(in, out, 2, 3);
+}
+
+TEST(kozlova_e_contrast_enhancement_tbb, test_incorrect_input_size) { TestValidation({3, 3, 3}, {}, 3, 1); }
+
+TEST(kozlova_e_contrast_enhancement_tbb, test_incorrect_input_width) {
+  TestValidation({3, 3, 3, 3}, {0, 0, 0, 0}, 3, 1);
+}

--- a/tasks/tbb/kozlova_e_contrast_enhancement/include/ops_tbb.hpp
+++ b/tasks/tbb/kozlova_e_contrast_enhancement/include/ops_tbb.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kozlova_e_contrast_enhancement_tbb {
+
+class TestTaskTBB : public ppc::core::Task {
+ public:
+  explicit TestTaskTBB(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<uint8_t> input_;
+  size_t width_ = 0;
+  size_t height_ = 0;
+  std::vector<uint8_t> output_;
+};
+
+}  // namespace kozlova_e_contrast_enhancement_tbb

--- a/tasks/tbb/kozlova_e_contrast_enhancement/include/ops_tbb.hpp
+++ b/tasks/tbb/kozlova_e_contrast_enhancement/include/ops_tbb.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <utility>
 #include <vector>
 

--- a/tasks/tbb/kozlova_e_contrast_enhancement/perf_tests/main.cpp
+++ b/tasks/tbb/kozlova_e_contrast_enhancement/perf_tests/main.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <memory>
 #include <vector>
 

--- a/tasks/tbb/kozlova_e_contrast_enhancement/perf_tests/main.cpp
+++ b/tasks/tbb/kozlova_e_contrast_enhancement/perf_tests/main.cpp
@@ -1,0 +1,121 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "tbb/kozlova_e_contrast_enhancement/include/ops_tbb.hpp"
+
+namespace {
+std::vector<uint8_t> GenerateVector(int length);
+
+std::vector<uint8_t> GenerateVector(int length) {
+  std::vector<uint8_t> vec;
+  vec.reserve(length);
+  for (int i = 0; i < length; ++i) {
+    vec.push_back(rand() % 256);
+  }
+  return vec;
+}
+}  // namespace
+
+TEST(kozlova_e_contrast_enhancement_tbb, test_pipeline_run) {
+  constexpr int kSize = 19875000;
+  size_t width = 7500;
+  size_t height = 2650;
+  // Create data
+  std::vector<uint8_t> in = GenerateVector(kSize);
+  std::vector<uint8_t> out(kSize, 0);
+
+  // Create task_data
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(in.data());
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->inputs_count.emplace_back(width);
+  task_data_omp->inputs_count.emplace_back(height);
+  task_data_omp->outputs.emplace_back(out.data());
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_omp = std::make_shared<kozlova_e_contrast_enhancement_tbb::TestTaskTBB>(task_data_omp);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  uint8_t min_value = *std::ranges::min_element(in);
+  uint8_t max_value = *std::ranges::max_element(in);
+
+  for (size_t i = 0; i < in.size(); ++i) {
+    int expected = static_cast<int>(((in[i] - min_value) / (double)(max_value - min_value)) * 255);
+    expected = std::clamp(expected, 0, 255);
+    EXPECT_EQ(out[i], static_cast<uint8_t>(expected));
+  }
+}
+
+TEST(kozlova_e_contrast_enhancement_tbb, test_task_run) {
+  constexpr int kSize = 19875000;
+  size_t width = 7500;
+  size_t height = 2650;
+  // Create data
+  std::vector<uint8_t> in = GenerateVector(kSize);
+  std::vector<uint8_t> out(kSize, 0);
+
+  // Create task_data
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(in.data());
+  task_data_omp->inputs_count.emplace_back(in.size());
+  task_data_omp->inputs_count.emplace_back(width);
+  task_data_omp->inputs_count.emplace_back(height);
+  task_data_omp->outputs.emplace_back(out.data());
+  task_data_omp->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_omp = std::make_shared<kozlova_e_contrast_enhancement_tbb::TestTaskTBB>(task_data_omp);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  uint8_t min_value = *std::ranges::min_element(in);
+  uint8_t max_value = *std::ranges::max_element(in);
+
+  for (size_t i = 0; i < in.size(); ++i) {
+    int expected = static_cast<int>(((in[i] - min_value) / (double)(max_value - min_value)) * 255);
+    expected = std::clamp(expected, 0, 255);
+    EXPECT_EQ(out[i], static_cast<uint8_t>(expected));
+  }
+}

--- a/tasks/tbb/kozlova_e_contrast_enhancement/src/ops_tbb.cpp
+++ b/tasks/tbb/kozlova_e_contrast_enhancement/src/ops_tbb.cpp
@@ -1,0 +1,63 @@
+#include "tbb/kozlova_e_contrast_enhancement/include/ops_tbb.hpp"
+
+#include <tbb/tbb.h>
+
+#include <algorithm>
+#include <cmath>
+#include <core/util/include/util.hpp>
+#include <cstddef>
+#include <vector>
+
+#include "oneapi/tbb/blocked_range.h"
+#include "oneapi/tbb/task_arena.h"
+#include "oneapi/tbb/task_group.h"
+
+bool kozlova_e_contrast_enhancement_tbb::TestTaskTBB::PreProcessingImpl() {
+  auto *input_ptr = reinterpret_cast<uint8_t *>(task_data->inputs[0]);
+  size_t size = task_data->inputs_count[0];
+  width_ = task_data->inputs_count[1];
+  height_ = task_data->inputs_count[2];
+  output_.resize(size, 0);
+  input_.resize(size);
+  std::copy(input_ptr, input_ptr + size, input_.begin());
+
+  return true;
+}
+
+bool kozlova_e_contrast_enhancement_tbb::TestTaskTBB::ValidationImpl() {
+  size_t size = task_data->inputs_count[0];
+  size_t check_width = task_data->inputs_count[1];
+  size_t check_height = task_data->inputs_count[2];
+  return size == task_data->outputs_count[0] && size > 0 && (size % 2 == 0) && check_width >= 1 && check_height >= 1 &&
+         (size == check_height * check_width);
+}
+
+bool kozlova_e_contrast_enhancement_tbb::TestTaskTBB::RunImpl() {
+  uint8_t min_value = *std::ranges::min_element(input_);
+  uint8_t max_value = *std::ranges::max_element(input_);
+
+  if (min_value == max_value) {
+    std::ranges::copy(input_, output_.begin());
+    return true;
+  }
+
+  oneapi::tbb::task_arena task_arena(ppc::util::GetPPCNumThreads());
+  task_arena.execute([&] {
+    tbb::parallel_for(tbb::blocked_range<int>(0, input_.size()), [&](const tbb::blocked_range<int> &r) {
+      for (int i = r.begin(); i < r.end(); ++i) {
+        output_[i] =
+            static_cast<uint8_t>(((input_[i] - min_value) / static_cast<double>(max_value - min_value)) * 255.0);
+        output_[i] = std::clamp(static_cast<int>(output_[i]), 0, 255);
+      }
+    });
+  });
+
+  return true;
+}
+
+bool kozlova_e_contrast_enhancement_tbb::TestTaskTBB::PostProcessingImpl() {
+  for (size_t i = 0; i < output_.size(); ++i) {
+    reinterpret_cast<uint8_t *>(task_data->outputs[0])[i] = output_[i];
+  }
+  return true;
+}

--- a/tasks/tbb/kozlova_e_contrast_enhancement/src/ops_tbb.cpp
+++ b/tasks/tbb/kozlova_e_contrast_enhancement/src/ops_tbb.cpp
@@ -6,11 +6,12 @@
 #include <cmath>
 #include <core/util/include/util.hpp>
 #include <cstddef>
+#include <cstdint>
 #include <vector>
 
 #include "oneapi/tbb/blocked_range.h"
+#include "oneapi/tbb/parallel_for.h"
 #include "oneapi/tbb/task_arena.h"
-#include "oneapi/tbb/task_group.h"
 
 bool kozlova_e_contrast_enhancement_tbb::TestTaskTBB::PreProcessingImpl() {
   auto *input_ptr = reinterpret_cast<uint8_t *>(task_data->inputs[0]);
@@ -43,7 +44,7 @@ bool kozlova_e_contrast_enhancement_tbb::TestTaskTBB::RunImpl() {
 
   oneapi::tbb::task_arena task_arena(ppc::util::GetPPCNumThreads());
   task_arena.execute([&] {
-    tbb::parallel_for(tbb::blocked_range<int>(0, input_.size()), [&](const tbb::blocked_range<int> &r) {
+    tbb::parallel_for(tbb::blocked_range<int>(0, (int)input_.size()), [&](const tbb::blocked_range<int> &r) {
       for (int i = r.begin(); i < r.end(); ++i) {
         output_[i] =
             static_cast<uint8_t>(((input_[i] - min_value) / static_cast<double>(max_value - min_value)) * 255.0);


### PR DESCRIPTION
Полутоновое изображение представлено вектором целых чисел. Значения пикселей изображения масштабируются на весь диапазон от 0 до 255. Для этого находятся минимальное и максимальное значения пикселей, которые используются как конечные точки для растяжки, распределяя все пиксели между этими границами. Распараллеливание реализовано с использованием Intel TBB через конструкцию tbb::parallel_for внутри task_arena, что позволяет выполнять обработку пикселей параллельно на нескольких потоках, повышая производительность.