### PR TITLE
[CI] Remove additional PPA installation on Ubuntu

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,6 @@ jobs:
           submodules: recursive
       - name: Setup environment
         run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y gcc-14 g++-14 ninja-build libmpich-dev libomp-dev valgrind
           python3 -m pip install -r requirements.txt
@@ -91,7 +90,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup environment
         run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y gcc-14 g++-14 ninja-build libmpich-dev libomp-dev valgrind
           python3 -m pip install -r requirements.txt
@@ -147,7 +145,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup environment
         run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y gcc-14 g++-14 ninja-build libmpich-dev libomp-dev valgrind
           python3 -m pip install -r requirements.txt
@@ -202,7 +199,6 @@ jobs:
           submodules: recursive
       - name: Setup environment
         run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y ninja-build libmpich-dev python3-pip valgrind
           wget https://apt.llvm.org/llvm.sh
@@ -248,7 +244,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup environment
         run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y ninja-build libmpich-dev python3-pip valgrind
           wget https://apt.llvm.org/llvm.sh
@@ -306,7 +301,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup environment
         run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y ninja-build libmpich-dev python3-pip valgrind
           wget https://apt.llvm.org/llvm.sh
@@ -362,7 +356,6 @@ jobs:
           submodules: recursive
       - name: Setup environment
         run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y ninja-build libmpich-dev mpi* openmpi-bin python3-pip
           wget https://apt.llvm.org/llvm.sh
@@ -410,7 +403,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup environment
         run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y ninja-build libmpich-dev python3-pip valgrind
           wget https://apt.llvm.org/llvm.sh
@@ -468,7 +460,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup environment
         run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y ninja-build libmpich-dev python3-pip valgrind
           wget https://apt.llvm.org/llvm.sh
@@ -1093,7 +1084,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup environment
         run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y gcc-14 g++-14 ninja-build libmpich-dev libomp-dev valgrind
           python3 -m pip install -r requirements.txt


### PR DESCRIPTION
PPA is not required anymore, since Ubuntu 24.04 is in use. Its repositories already contain gcc-14 package out of the box.