### PR TITLE
Ополин Дмитрий. Вариант 18. Технология TBB. Поразрядная сортировка для целых чисел с четно-нечетным слиянием Бэтчера.

### DIFF
--- a/tasks/tbb/opolin_d_radix_sort_batcher_merge/func_tests/main.cpp
+++ b/tasks/tbb/opolin_d_radix_sort_batcher_merge/func_tests/main.cpp
@@ -1,0 +1,293 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "tbb/opolin_d_radix_sort_batcher_merge/include/ops_tbb.hpp"
+
+namespace opolin_d_radix_batcher_sort_tbb {
+namespace {
+void GenDataRadixSort(size_t size, std::vector<int> &vec, std::vector<int> &expected) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> dis(-1000, 1000);
+  vec.clear();
+  expected.clear();
+  vec.reserve(size);
+  for (size_t i = 0; i < size; ++i) {
+    vec.push_back(dis(gen));
+  }
+  expected = vec;
+  std::ranges::sort(expected);
+}
+}  // namespace
+}  // namespace opolin_d_radix_batcher_sort_tbb
+
+TEST(opolin_d_radix_batcher_sort_tbb, test_size_3) {
+  int size = 3;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {2, 1, 10};
+  expected = {1, 2, 10};
+
+  std::vector<int> out(size, 0);
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_tbb->inputs_count.emplace_back(out.size());
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(out.size());
+
+  auto test_task_tbb = std::make_shared<opolin_d_radix_batcher_sort_tbb::RadixBatcherSortTaskTbb>(task_data_tbb);
+  ASSERT_EQ(test_task_tbb->Validation(), true);
+  test_task_tbb->PreProcessing();
+  test_task_tbb->Run();
+  test_task_tbb->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_tbb, test_size_6) {
+  int size = 6;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {3, 1, 7, 0, 12, 2};
+  expected = {0, 1, 2, 3, 7, 12};
+  std::vector<int> out(size, 0);
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_tbb->inputs_count.emplace_back(out.size());
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(out.size());
+
+  auto test_task_tbb = std::make_shared<opolin_d_radix_batcher_sort_tbb::RadixBatcherSortTaskTbb>(task_data_tbb);
+  ASSERT_EQ(test_task_tbb->Validation(), true);
+  test_task_tbb->PreProcessing();
+  test_task_tbb->Run();
+  test_task_tbb->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_tbb, test_empty) {
+  int size = 0;
+  std::vector<int> expected;
+  std::vector<int> input;
+  std::vector<int> out;
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_tbb->inputs_count.emplace_back(size);
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(size);
+
+  auto test_task_tbb = std::make_shared<opolin_d_radix_batcher_sort_tbb::RadixBatcherSortTaskTbb>(task_data_tbb);
+  ASSERT_EQ(test_task_tbb->Validation(), false);
+}
+
+TEST(opolin_d_radix_batcher_sort_tbb, test_one_element) {
+  int size = 1;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {31};
+  expected = {31};
+  std::vector<int> out(size, 0);
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_tbb->inputs_count.emplace_back(out.size());
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(out.size());
+
+  auto test_task_tbb = std::make_shared<opolin_d_radix_batcher_sort_tbb::RadixBatcherSortTaskTbb>(task_data_tbb);
+  ASSERT_EQ(test_task_tbb->Validation(), true);
+  test_task_tbb->PreProcessing();
+  test_task_tbb->Run();
+  test_task_tbb->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_tbb, test_negative_values) {
+  int size = 5;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {-12, -4, -7, -2, -34};
+  expected = {-34, -12, -7, -4, -2};
+  std::vector<int> out(size, 0);
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_tbb->inputs_count.emplace_back(out.size());
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(out.size());
+
+  auto test_task_tbb = std::make_shared<opolin_d_radix_batcher_sort_tbb::RadixBatcherSortTaskTbb>(task_data_tbb);
+  ASSERT_EQ(test_task_tbb->Validation(), true);
+  test_task_tbb->PreProcessing();
+  test_task_tbb->Run();
+  test_task_tbb->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_tbb, test_sorted) {
+  int size = 5;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {0, 1, 2, 6, 7};
+  expected = {0, 1, 2, 6, 7};
+
+  std::vector<int> out(size, 0);
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_tbb->inputs_count.emplace_back(out.size());
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(out.size());
+
+  auto test_task_tbb = std::make_shared<opolin_d_radix_batcher_sort_tbb::RadixBatcherSortTaskTbb>(task_data_tbb);
+  ASSERT_EQ(test_task_tbb->Validation(), true);
+  test_task_tbb->PreProcessing();
+  test_task_tbb->Run();
+  test_task_tbb->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_tbb, test_equal_values) {
+  int size = 3;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {2, 2, 2};
+  expected = {2, 2, 2};
+  std::vector<int> out(size, 0);
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_tbb->inputs_count.emplace_back(out.size());
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(out.size());
+
+  auto test_task_tbb = std::make_shared<opolin_d_radix_batcher_sort_tbb::RadixBatcherSortTaskTbb>(task_data_tbb);
+  ASSERT_EQ(test_task_tbb->Validation(), true);
+  test_task_tbb->PreProcessing();
+  test_task_tbb->Run();
+  test_task_tbb->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_tbb, test_reversed) {
+  int size = 10;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {12, 8, 6, 3, 2, 0, -4, -6, -7, -10};
+  expected = {-10, -7, -6, -4, 0, 2, 3, 6, 8, 12};
+  std::vector<int> out(size, 0);
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_tbb->inputs_count.emplace_back(out.size());
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(out.size());
+
+  auto test_task_tbb = std::make_shared<opolin_d_radix_batcher_sort_tbb::RadixBatcherSortTaskTbb>(task_data_tbb);
+  ASSERT_EQ(test_task_tbb->Validation(), true);
+  test_task_tbb->PreProcessing();
+  test_task_tbb->Run();
+  test_task_tbb->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_tbb, test_varying_digit_counts) {
+  int size = 6;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {123456, 12, 123, 1, 12345, 1234};
+  expected = {1, 12, 123, 1234, 12345, 123456};
+  std::vector<int> out(size, 0);
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_tbb->inputs_count.emplace_back(out.size());
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(out.size());
+
+  auto test_task_tbb = std::make_shared<opolin_d_radix_batcher_sort_tbb::RadixBatcherSortTaskTbb>(task_data_tbb);
+  ASSERT_EQ(test_task_tbb->Validation(), true);
+  test_task_tbb->PreProcessing();
+  test_task_tbb->Run();
+  test_task_tbb->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_tbb, test_negative_size) {
+  int size = -1;
+  std::vector<int> expected;
+  std::vector<int> input;
+  std::vector<int> out;
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_tbb->inputs_count.emplace_back(size);
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(size);
+
+  auto test_task_tbb = std::make_shared<opolin_d_radix_batcher_sort_tbb::RadixBatcherSortTaskTbb>(task_data_tbb);
+  ASSERT_EQ(test_task_tbb->Validation(), false);
+}
+
+TEST(opolin_d_radix_batcher_sort_tbb, test_size_prime_7) {
+  int size = 7;
+  std::vector<int> expected;
+  std::vector<int> input;
+  opolin_d_radix_batcher_sort_tbb::GenDataRadixSort(size, input, expected);
+
+  std::vector<int> out(size, 0);
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_tbb->inputs_count.emplace_back(out.size());
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(out.size());
+
+  auto test_task_tbb = std::make_shared<opolin_d_radix_batcher_sort_tbb::RadixBatcherSortTaskTbb>(task_data_tbb);
+  ASSERT_EQ(test_task_tbb->Validation(), true);
+  test_task_tbb->PreProcessing();
+  test_task_tbb->Run();
+  test_task_tbb->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_tbb, test_size_prime_13) {
+  int size = 13;
+  std::vector<int> expected;
+  std::vector<int> input;
+  opolin_d_radix_batcher_sort_tbb::GenDataRadixSort(size, input, expected);
+
+  std::vector<int> out(size, 0);
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_tbb->inputs_count.emplace_back(out.size());
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(out.size());
+
+  auto test_task_tbb = std::make_shared<opolin_d_radix_batcher_sort_tbb::RadixBatcherSortTaskTbb>(task_data_tbb);
+  ASSERT_EQ(test_task_tbb->Validation(), true);
+  test_task_tbb->PreProcessing();
+  test_task_tbb->Run();
+  test_task_tbb->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_tbb, test_double_reversed_order) {
+  int size = 10;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {5, 4, 3, 2, 1, 10, 9, 8, 7, 6};
+  expected = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+
+  std::vector<int> out(size, 0);
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_tbb->inputs_count.emplace_back(out.size());
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(out.size());
+
+  auto test_task_tbb = std::make_shared<opolin_d_radix_batcher_sort_tbb::RadixBatcherSortTaskTbb>(task_data_tbb);
+  ASSERT_EQ(test_task_tbb->Validation(), true);
+  test_task_tbb->PreProcessing();
+  test_task_tbb->Run();
+  test_task_tbb->PostProcessing();
+  ASSERT_EQ(out, expected);
+}

--- a/tasks/tbb/opolin_d_radix_sort_batcher_merge/func_tests/main.cpp
+++ b/tasks/tbb/opolin_d_radix_sort_batcher_merge/func_tests/main.cpp
@@ -291,3 +291,24 @@ TEST(opolin_d_radix_batcher_sort_tbb, test_double_reversed_order) {
   test_task_tbb->PostProcessing();
   ASSERT_EQ(out, expected);
 }
+
+TEST(opolin_d_radix_batcher_sort_tbb, test_large_size) {
+  int size = 10000;
+  std::vector<int> expected;
+  std::vector<int> input;
+  opolin_d_radix_batcher_sort_tbb::GenDataRadixSort(size, input, expected);
+
+  std::vector<int> out(size, 0);
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_tbb->inputs_count.emplace_back(out.size());
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(out.size());
+
+  auto test_task_tbb = std::make_shared<opolin_d_radix_batcher_sort_tbb::RadixBatcherSortTaskTbb>(task_data_tbb);
+  ASSERT_EQ(test_task_tbb->Validation(), true);
+  test_task_tbb->PreProcessing();
+  test_task_tbb->Run();
+  test_task_tbb->PostProcessing();
+  ASSERT_EQ(out, expected);
+}

--- a/tasks/tbb/opolin_d_radix_sort_batcher_merge/include/ops_tbb.hpp
+++ b/tasks/tbb/opolin_d_radix_sort_batcher_merge/include/ops_tbb.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace opolin_d_radix_batcher_sort_tbb {
+uint32_t ConvertIntToUint(int num);
+int ConvertUintToInt(uint32_t unum);
+void RadixSort(std::vector<uint32_t>& uns_vec);
+void BatcherOddEvenMerge(std::vector<int>& vec, int low, int high);
+
+class RadixBatcherSortTaskTbb : public ppc::core::Task {
+ public:
+  explicit RadixBatcherSortTaskTbb(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> input_;
+  std::vector<int> output_;
+  size_t size_;
+};
+}  // namespace opolin_d_radix_batcher_sort_tbb

--- a/tasks/tbb/opolin_d_radix_sort_batcher_merge/include/ops_tbb.hpp
+++ b/tasks/tbb/opolin_d_radix_sort_batcher_merge/include/ops_tbb.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <utility>
 #include <vector>
 

--- a/tasks/tbb/opolin_d_radix_sort_batcher_merge/perf_tests/main.cpp
+++ b/tasks/tbb/opolin_d_radix_sort_batcher_merge/perf_tests/main.cpp
@@ -67,6 +67,7 @@ TEST(opolin_d_radix_batcher_sort_tbb, test_pipeline_run) {
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_tbb);
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(expected, out);
 }
 
 TEST(opolin_d_radix_batcher_sort_tbb, test_task_run) {
@@ -104,4 +105,5 @@ TEST(opolin_d_radix_batcher_sort_tbb, test_task_run) {
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_tbb);
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(expected, out);
 }

--- a/tasks/tbb/opolin_d_radix_sort_batcher_merge/perf_tests/main.cpp
+++ b/tasks/tbb/opolin_d_radix_sort_batcher_merge/perf_tests/main.cpp
@@ -1,0 +1,107 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "tbb/opolin_d_radix_sort_batcher_merge/include/ops_tbb.hpp"
+
+namespace opolin_d_radix_batcher_sort_tbb {
+namespace {
+void GenDataRadixSort(size_t size, std::vector<int> &vec, std::vector<int> &expected) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> dis(-1000, 1000);
+  vec.clear();
+  expected.clear();
+  vec.reserve(size);
+  for (size_t i = 0; i < size; ++i) {
+    vec.push_back(dis(gen));
+  }
+  expected = vec;
+  std::ranges::sort(expected);
+}
+}  // namespace
+}  // namespace opolin_d_radix_batcher_sort_tbb
+
+TEST(opolin_d_radix_batcher_sort_tbb, test_pipeline_run) {
+  int size = 500000;
+  std::vector<int> input;
+  std::vector<int> expected;
+  opolin_d_radix_batcher_sort_tbb::GenDataRadixSort(size, input, expected);
+  std::vector<int> out(size, 0);
+  // Create TaskData
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_tbb->inputs_count.emplace_back(out.size());
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_tbb = std::make_shared<opolin_d_radix_batcher_sort_tbb::RadixBatcherSortTaskTbb>(task_data_tbb);
+  ASSERT_EQ(test_task_tbb->Validation(), true);
+  test_task_tbb->PreProcessing();
+  test_task_tbb->Run();
+  test_task_tbb->PostProcessing();
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_tbb);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}
+
+TEST(opolin_d_radix_batcher_sort_tbb, test_task_run) {
+  int size = 500000;
+  std::vector<int> input;
+  std::vector<int> expected;
+  opolin_d_radix_batcher_sort_tbb::GenDataRadixSort(size, input, expected);
+  std::vector<int> out(size, 0);
+  // Create TaskData
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_tbb->inputs_count.emplace_back(out.size());
+  task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_tbb->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_tbb = std::make_shared<opolin_d_radix_batcher_sort_tbb::RadixBatcherSortTaskTbb>(task_data_tbb);
+  ASSERT_EQ(test_task_tbb->Validation(), true);
+  test_task_tbb->PreProcessing();
+  test_task_tbb->Run();
+  test_task_tbb->PostProcessing();
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_tbb);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}

--- a/tasks/tbb/opolin_d_radix_sort_batcher_merge/src/ops_tbb.cpp
+++ b/tasks/tbb/opolin_d_radix_sort_batcher_merge/src/ops_tbb.cpp
@@ -32,13 +32,13 @@ bool opolin_d_radix_batcher_sort_tbb::RadixBatcherSortTaskTbb::RunImpl() {
   std::vector<uint32_t> keys(size_);
   tbb::parallel_for(tbb::blocked_range<size_t>(0, size_), [&](const tbb::blocked_range<size_t>& r) {
     for (size_t i = r.begin(); i < r.end(); ++i) {
-      keys[i] = ConvertIntToKey(input_[i]);
+      keys[i] = ConvertIntToUint(input_[i]);
     }
   });
   RadixSort(keys);
   tbb::parallel_for(tbb::blocked_range<size_t>(0, size_), [&](const tbb::blocked_range<size_t>& r) {
     for (size_t i = r.begin(); i < r.end(); ++i) {
-      output_[i] = ConvertKeyToInt(keys[i]);
+      output_[i] = ConvertUintToInt(keys[i]);
     }
   });
   BatcherOddEvenMerge(output_, 0, static_cast<int>(size_));

--- a/tasks/tbb/opolin_d_radix_sort_batcher_merge/src/ops_tbb.cpp
+++ b/tasks/tbb/opolin_d_radix_sort_batcher_merge/src/ops_tbb.cpp
@@ -8,6 +8,11 @@
 #include <cstdint>
 #include <vector>
 
+#include "oneapi/tbb/blocked_range.h"
+#include "oneapi/tbb/enumerable_thread_specific.h"
+#include "oneapi/tbb/parallel_for.h"
+#include "oneapi/tbb/parallel_invoke.h"
+
 bool opolin_d_radix_batcher_sort_tbb::RadixBatcherSortTaskTbb::PreProcessingImpl() {
   auto* in_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
   input_ = std::vector<int>(in_ptr, in_ptr + size_);

--- a/tasks/tbb/opolin_d_radix_sort_batcher_merge/src/ops_tbb.cpp
+++ b/tasks/tbb/opolin_d_radix_sort_batcher_merge/src/ops_tbb.cpp
@@ -1,0 +1,107 @@
+#include "tbb/opolin_d_radix_sort_batcher_merge/include/ops_tbb.hpp"
+
+#include <tbb/tbb.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+bool opolin_d_radix_batcher_sort_tbb::RadixBatcherSortTaskTbb::PreProcessingImpl() {
+  auto* in_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
+  input_ = std::vector<int>(in_ptr, in_ptr + size_);
+  unsigned int output_size = task_data->outputs_count[0];
+  output_ = std::vector<int>(output_size, 0);
+  return true;
+}
+
+bool opolin_d_radix_batcher_sort_tbb::RadixBatcherSortTaskTbb::ValidationImpl() {
+  // Check equality of counts elements
+  size_ = static_cast<int>(task_data->inputs_count[0]);
+  if (size_ <= 0 || task_data->inputs.empty() || task_data->outputs.empty()) {
+    return false;
+  }
+  if (task_data->inputs[0] == nullptr || task_data->outputs[0] == nullptr) {
+    return false;
+  }
+  return task_data->inputs_count[0] == task_data->outputs_count[0];
+}
+
+bool opolin_d_radix_batcher_sort_tbb::RadixBatcherSortTaskTbb::RunImpl() {
+  std::vector<uint32_t> keys(size_);
+  tbb::parallel_for(tbb::blocked_range<size_t>(0, size_), [&](const tbb::blocked_range<size_t>& r) {
+    for (size_t i = r.begin(); i < r.end(); ++i) {
+      keys[i] = ConvertIntToKey(input_[i]);
+    }
+  });
+  RadixSort(keys);
+  tbb::parallel_for(tbb::blocked_range<size_t>(0, size_), [&](const tbb::blocked_range<size_t>& r) {
+    for (size_t i = r.begin(); i < r.end(); ++i) {
+      output_[i] = ConvertKeyToInt(keys[i]);
+    }
+  });
+  BatcherOddEvenMerge(output_, 0, static_cast<int>(size_));
+  return true;
+}
+
+bool opolin_d_radix_batcher_sort_tbb::RadixBatcherSortTaskTbb::PostProcessingImpl() {
+  for (size_t i = 0; i < output_.size(); i++) {
+    reinterpret_cast<int*>(task_data->outputs[0])[i] = output_[i];
+  }
+  return true;
+}
+
+uint32_t opolin_d_radix_batcher_sort_tbb::ConvertIntToUint(int num) { return static_cast<uint32_t>(num) ^ 0x80000000U; }
+
+int opolin_d_radix_batcher_sort_tbb::ConvertUintToInt(uint32_t unum) { return static_cast<int>(unum ^ 0x80000000U); }
+
+void opolin_d_radix_batcher_sort_tbb::RadixSort(std::vector<uint32_t>& uns_vec) {
+  size_t sz = uns_vec.size();
+  if (sz <= 1) {
+    return;
+  }
+  const int rad = 256;
+  std::vector<uint32_t> res(sz);
+  for (int stage = 0; stage < 4; stage++) {
+    tbb::enumerable_thread_specific<std::vector<size_t>> local_counts(
+        [] { return std::vector<size_t>(rad, 0); });
+    int shift = stage * 8;
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, sz), [&](const tbb::blocked_range<size_t>& r) {
+      auto& lc = local_counts.local();
+      for (size_t i = r.begin(); i < r.end(); ++i) {
+        const uint8_t byte = (uns_vec[i] >> shift) & 255;
+        lc[byte]++;
+      }
+    });
+    std::vector<size_t> pref(rad, 0);
+    for (auto& lc : local_counts) {
+      for (int j = 0; j < rad; ++j) {
+        pref[j] += lc[j];
+      }
+    }
+    for (int j = 1; j < rad; ++j) {
+      pref[j] += pref[j - 1];
+    }
+    for (int i = static_cast<int>(sz) - 1; i >= 0; --i) {
+      const uint8_t byte = (uns_vec[i] >> shift) & 255;
+      res[--pref[byte]] = uns_vec[i];
+    }
+    uns_vec.swap(res);
+  }
+}
+
+void opolin_d_radix_batcher_sort_tbb::BatcherOddEvenMerge(std::vector<int>& vec, int low, int high) {
+  if (high - low <= 1) {
+    return;
+  }
+  int mid = (low + high) / 2;
+  tbb::parallel_invoke([&] { BatcherOddEvenMerge(vec, low, mid); }, [&] { BatcherOddEvenMerge(vec, mid, high); });
+  tbb::parallel_for(tbb::blocked_range<int>(low, mid), [&](const tbb::blocked_range<int>& r) {
+    for (int i = r.begin(); i < r.end(); ++i) {
+      if (vec[i] > vec[i + mid - low]) {
+        std::swap(vec[i], vec[i + mid - low]);
+      }
+    }
+  });
+}

--- a/tasks/tbb/opolin_d_radix_sort_batcher_merge/src/ops_tbb.cpp
+++ b/tasks/tbb/opolin_d_radix_sort_batcher_merge/src/ops_tbb.cpp
@@ -64,8 +64,7 @@ void opolin_d_radix_batcher_sort_tbb::RadixSort(std::vector<uint32_t>& uns_vec) 
   const int rad = 256;
   std::vector<uint32_t> res(sz);
   for (int stage = 0; stage < 4; stage++) {
-    tbb::enumerable_thread_specific<std::vector<size_t>> local_counts(
-        [] { return std::vector<size_t>(rad, 0); });
+    tbb::enumerable_thread_specific<std::vector<size_t>> local_counts([] { return std::vector<size_t>(rad, 0); });
     int shift = stage * 8;
     tbb::parallel_for(tbb::blocked_range<size_t>(0, sz), [&](const tbb::blocked_range<size_t>& r) {
       auto& lc = local_counts.local();


### PR DESCRIPTION
Исходный массив обрабатывается блоками.
Переводим весь массив uint чтобы сортировать и отрицательные и положительные.
Поразрядная сортировка (LSD) для блоков.
Переводим массив с отсортированными блоками обратно в int.
Четно-нечетное слияние Бэтчера:
Рекурсивное разделение:
Массив делится на две части (low-mid и mid-high), которые сливаются параллельно через tbb::parallel_invoke.