### PR TITLE
Коровин Никита. Вариант 14. Технология MPI + OMP. Сортировка Хоара с четно-нечетным слиянием Бэтчера.

### DIFF
--- a/tasks/all/korovin_n_qsort_batcher/func_tests/func_all.cpp
+++ b/tasks/all/korovin_n_qsort_batcher/func_tests/func_all.cpp
@@ -1,0 +1,126 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <climits>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "all/korovin_n_qsort_batcher/include/ops_all.hpp"
+#include "core/task/include/task.hpp"
+#include "core/util/include/util.hpp"
+
+namespace {
+struct GenParams {
+  int size;
+  int lower_bound = -500;
+  int upper_bound = 500;
+};
+
+std::vector<int> GenerateRndVector(GenParams param) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> dist(param.lower_bound, param.upper_bound);
+
+  std::vector<int> v1(param.size);
+  for (auto &num : v1) {
+    num = dist(gen);
+  }
+  return v1;
+}
+
+void RunTest(std::vector<int> &in) {
+  std::vector<int> out(in.size());
+
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_all->inputs_count.emplace_back(in.size());
+  task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_all->outputs_count.emplace_back(out.size());
+
+  korovin_n_qsort_batcher_all::TestTaskALL test_task_all(task_data_all);
+  ASSERT_TRUE(test_task_all.Validation());
+  ASSERT_TRUE(test_task_all.PreProcessing());
+  ASSERT_TRUE(test_task_all.Run());
+  ASSERT_TRUE(test_task_all.PostProcessing());
+  ASSERT_TRUE(std::ranges::is_sorted(out));
+}
+}  // namespace
+
+TEST(korovin_n_qsort_batcher_all, test_unsort) {
+  std::vector<int> in = {11, 5, 1, 42, 3, 8, 7, 25, 6};
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_all, test_reverse_sort) {
+  std::vector<int> in = {10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_all, test_double_reverse_sort) {
+  std::vector<int> in = {5, 4, 3, 2, 1, 5, 4, 3, 2, 1};
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_all, test_repeating_25_87) {
+  std::vector<int> in = {25, 87, 25, 87, 1, 25, 87, 0, -5};
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_all, test_all_elements_equal_25) {
+  std::vector<int> in(50, 25);
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_all, test_extreme_values_with_25_87) {
+  std::vector<int> in = {INT_MIN, 25, INT_MAX, 87, INT_MIN, 25, 0, INT_MAX, 87};
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_all, test_empty_sort) {
+  std::vector<int> in = {};
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_all, test_one_el_sort) {
+  std::vector<int> in = {42};
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_all, test_already_sort) {
+  std::vector<int> in = {1, 2, 3, 4, 5, 6};
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_all, test_random_sort) {
+  auto param = GenParams();
+  param.size = 20;
+
+  std::vector<int> in = GenerateRndVector(param);
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_all, test_random_sort_100) {
+  auto param = GenParams();
+  param.size = 100;
+
+  std::vector<int> in = GenerateRndVector(param);
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_all, test_random_sort_500) {
+  auto param = GenParams();
+  param.size = 500;
+
+  std::vector<int> in = GenerateRndVector(param);
+  RunTest(in);
+}
+
+TEST(korovin_n_qsort_batcher_all, test_random_sort_1000) {
+  auto param = GenParams();
+  param.size = 1000;
+
+  std::vector<int> in = GenerateRndVector(param);
+  RunTest(in);
+}

--- a/tasks/all/korovin_n_qsort_batcher/func_tests/func_all.cpp
+++ b/tasks/all/korovin_n_qsort_batcher/func_tests/func_all.cpp
@@ -9,7 +9,6 @@
 
 #include "all/korovin_n_qsort_batcher/include/ops_all.hpp"
 #include "core/task/include/task.hpp"
-#include "core/util/include/util.hpp"
 
 namespace {
 struct GenParams {

--- a/tasks/all/korovin_n_qsort_batcher/include/ops_all.hpp
+++ b/tasks/all/korovin_n_qsort_batcher/include/ops_all.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <boost/mpi/collectives.hpp>
-#include <boost/mpi/communicator.hpp>
 #include <utility>
 #include <vector>
 

--- a/tasks/all/korovin_n_qsort_batcher/include/ops_all.hpp
+++ b/tasks/all/korovin_n_qsort_batcher/include/ops_all.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace korovin_n_qsort_batcher_all {
+
+struct BlockRange {
+  std::vector<int>::iterator low;
+  std::vector<int>::iterator high;
+};
+
+class TestTaskALL : public ppc::core::Task {
+ public:
+  explicit TestTaskALL(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> input_;
+  static int GetRandomIndex(int low, int high);
+  static void QuickSort(std::vector<int>::iterator low, std::vector<int>::iterator high, int depth = 0);
+  static bool InPlaceMerge(const BlockRange& a, const BlockRange& b, std::vector<int>& buffer);
+  static std::vector<BlockRange> PartitionBlocks(std::vector<int>& arr, int p);
+  static void OddEvenMerge(std::vector<BlockRange>& blocks);
+};
+
+}  // namespace korovin_n_qsort_batcher_all

--- a/tasks/all/korovin_n_qsort_batcher/perf_tests/perf_all.cpp
+++ b/tasks/all/korovin_n_qsort_batcher/perf_tests/perf_all.cpp
@@ -1,0 +1,83 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <numeric>
+#include <vector>
+
+#include "all/korovin_n_qsort_batcher/include/ops_all.hpp"
+#include "boost/mpi/communicator.hpp"
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+
+TEST(korovin_n_qsort_batcher_all, test_pipeline_run) {
+  boost::mpi::communicator world;
+  constexpr int kSize = 250000;
+  std::vector<int> in(kSize);
+  std::vector<int> out(in.size());
+  std::iota(in.rbegin(), in.rend(), 1);
+
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data_all->inputs_count.emplace_back(in.size());
+  task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_all->outputs_count.emplace_back(out.size());
+
+  auto test_task_all = std::make_shared<korovin_n_qsort_batcher_all::TestTaskALL>(task_data_all);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto now = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(now - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_all);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+
+  if (world.rank() == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
+    ASSERT_TRUE(std::ranges::is_sorted(out));
+  }
+}
+
+TEST(korovin_n_qsort_batcher_all, test_task_run) {
+  boost::mpi::communicator world;
+  constexpr int kSize = 250000;
+  std::vector<int> in(kSize);
+  std::vector<int> out(in.size());
+  std::iota(in.rbegin(), in.rend(), 1);
+
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data_all->inputs_count.emplace_back(in.size());
+  task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_all->outputs_count.emplace_back(out.size());
+
+  auto test_task_all = std::make_shared<korovin_n_qsort_batcher_all::TestTaskALL>(task_data_all);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto now = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(now - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_all);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+
+  if (world.rank() == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
+    ASSERT_TRUE(std::ranges::is_sorted(out));
+  }
+}

--- a/tasks/all/korovin_n_qsort_batcher/perf_tests/perf_all.cpp
+++ b/tasks/all/korovin_n_qsort_batcher/perf_tests/perf_all.cpp
@@ -4,7 +4,7 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
-#include <numeric>
+#include <random>
 #include <vector>
 
 #include "all/korovin_n_qsort_batcher/include/ops_all.hpp"
@@ -12,17 +12,32 @@
 #include "core/perf/include/perf.hpp"
 #include "core/task/include/task.hpp"
 
+namespace {
+constexpr int kSize = 7000000;
+constexpr int kSeed = 25;
+
+std::vector<int> GenerateRndArray(int size, int seed) {
+  std::mt19937 gen(seed);
+  std::uniform_int_distribution<int> dist(-1000, 1000);
+
+  std::vector<int> result(size);
+  for (auto &elem : result) {
+    elem = dist(gen);
+  }
+  return result;
+}
+}  // namespace
+
 TEST(korovin_n_qsort_batcher_all, test_pipeline_run) {
   boost::mpi::communicator world;
-  constexpr int kSize = 250000;
-  std::vector<int> in(kSize);
+  std::vector<int> in = GenerateRndArray(kSize, kSeed);
   std::vector<int> out(in.size());
   std::iota(in.rbegin(), in.rend(), 1);
 
   auto task_data_all = std::make_shared<ppc::core::TaskData>();
-  task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
   task_data_all->inputs_count.emplace_back(in.size());
-  task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_all->outputs_count.emplace_back(out.size());
 
   auto test_task_all = std::make_shared<korovin_n_qsort_batcher_all::TestTaskALL>(task_data_all);
@@ -49,15 +64,14 @@ TEST(korovin_n_qsort_batcher_all, test_pipeline_run) {
 
 TEST(korovin_n_qsort_batcher_all, test_task_run) {
   boost::mpi::communicator world;
-  constexpr int kSize = 250000;
-  std::vector<int> in(kSize);
+  std::vector<int> in = GenerateRndArray(kSize, kSeed);
   std::vector<int> out(in.size());
   std::iota(in.rbegin(), in.rend(), 1);
 
   auto task_data_all = std::make_shared<ppc::core::TaskData>();
-  task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
   task_data_all->inputs_count.emplace_back(in.size());
-  task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
   task_data_all->outputs_count.emplace_back(out.size());
 
   auto test_task_all = std::make_shared<korovin_n_qsort_batcher_all::TestTaskALL>(task_data_all);

--- a/tasks/all/korovin_n_qsort_batcher/perf_tests/perf_all.cpp
+++ b/tasks/all/korovin_n_qsort_batcher/perf_tests/perf_all.cpp
@@ -32,7 +32,6 @@ TEST(korovin_n_qsort_batcher_all, test_pipeline_run) {
   boost::mpi::communicator world;
   std::vector<int> in = GenerateRndArray(kSize, kSeed);
   std::vector<int> out(in.size());
-  std::iota(in.rbegin(), in.rend(), 1);
 
   auto task_data_all = std::make_shared<ppc::core::TaskData>();
   task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
@@ -66,7 +65,6 @@ TEST(korovin_n_qsort_batcher_all, test_task_run) {
   boost::mpi::communicator world;
   std::vector<int> in = GenerateRndArray(kSize, kSeed);
   std::vector<int> out(in.size());
-  std::iota(in.rbegin(), in.rend(), 1);
 
   auto task_data_all = std::make_shared<ppc::core::TaskData>();
   task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));

--- a/tasks/all/korovin_n_qsort_batcher/src/ops_all.cpp
+++ b/tasks/all/korovin_n_qsort_batcher/src/ops_all.cpp
@@ -1,0 +1,191 @@
+#include "all/korovin_n_qsort_batcher/include/ops_all.hpp"
+
+#include <omp.h>
+
+#include <algorithm>
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/collectives/gatherv.hpp>
+#include <boost/mpi/collectives/scatterv.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <cmath>
+#include <cstddef>
+#include <iterator>
+#include <random>
+#include <ranges>
+#include <span>
+#include <vector>
+
+#include "core/util/include/util.hpp"
+
+namespace korovin_n_qsort_batcher_all {
+
+int TestTaskALL::GetRandomIndex(int low, int high) {
+  static thread_local std::mt19937 gen(std::random_device{}());
+  std::uniform_int_distribution<int> dist(low, high);
+  return dist(gen);
+}
+
+void TestTaskALL::QuickSort(std::vector<int>::iterator low, std::vector<int>::iterator high, int depth) {
+  if (std::distance(low, high) <= 1) {
+    return;
+  }
+  int n = static_cast<int>(std::distance(low, high));
+  int random_index = GetRandomIndex(0, n - 1);
+  auto pivot_iter = low + random_index;
+  int pivot = *pivot_iter;
+  auto partition_iter = std::partition(low, high, [pivot](int elem) { return elem <= pivot; });
+  auto mid_iter = std::partition(low, partition_iter, [pivot](int elem) { return elem < pivot; });
+
+  int max_depth = static_cast<int>(std::log2(ppc::util::GetPPCNumThreads())) + 1;
+
+  if (depth < max_depth) {
+#pragma omp parallel sections
+    {
+#pragma omp section
+      { QuickSort(low, mid_iter, depth + 1); }
+#pragma omp section
+      { QuickSort(partition_iter, high, depth + 1); }
+    }
+  } else {
+    QuickSort(low, mid_iter, depth + 1);
+    QuickSort(partition_iter, high, depth + 1);
+  }
+}
+
+bool TestTaskALL::InPlaceMerge(const BlockRange& a, const BlockRange& b, std::vector<int>& buffer) {
+  bool changed = false;
+  int len_a = static_cast<int>(std::distance(a.low, a.high));
+  int len_b = static_cast<int>(std::distance(b.low, b.high));
+  std::span<int> span_a{a.low, static_cast<size_t>(len_a)};
+  std::span<int> span_b{b.low, static_cast<size_t>(len_b)};
+  size_t i = 0;
+  size_t j = 0;
+  size_t k = 0;
+  while (i < span_a.size() && j < span_b.size()) {
+    if (span_a[i] <= span_b[j]) {
+      buffer[k++] = span_a[i++];
+    } else {
+      changed = true;
+      buffer[k++] = span_b[j++];
+    }
+  }
+  while (i < span_a.size()) {
+    buffer[k++] = span_a[i++];
+  }
+  while (j < span_b.size()) {
+    changed = true;
+    buffer[k++] = span_b[j++];
+  }
+  std::ranges::copy(buffer.begin(), buffer.begin() + len_a, a.low);
+  std::ranges::copy(buffer.begin() + len_a, buffer.begin() + len_a + len_b, b.low);
+  return changed;
+}
+
+std::vector<BlockRange> TestTaskALL::PartitionBlocks(std::vector<int>& arr, int p) {
+  std::vector<BlockRange> blocks;
+  blocks.reserve(p);
+  int n = static_cast<int>(arr.size());
+  int chunk_size = n / p;
+  int remainder = n % p;
+  auto it = arr.begin();
+  for (int i : std::views::iota(0, p)) {
+    int size = chunk_size + (i < remainder ? 1 : 0);
+    blocks.push_back({it, it + size});
+    it += size;
+  }
+  return blocks;
+}
+
+void TestTaskALL::OddEvenMerge(std::vector<BlockRange>& blocks) {
+  if (blocks.size() <= 1) {
+    return;
+  }
+  int p = static_cast<int>(blocks.size());
+  int max_iters = p * 2;
+  int max_block_len = 0;
+  for (auto& b : blocks) {
+    max_block_len = std::max(max_block_len, static_cast<int>(std::distance(b.low, b.high)));
+  }
+  int buffer_size = max_block_len * 2;
+  for (int iter : std::views::iota(0, max_iters)) {
+    bool changed_global = false;
+#pragma omp parallel for schedule(static) reduction(|| : changed_global)
+    for (int b = iter % 2; b < p; b += 2) {
+      static thread_local std::vector<int> buffer;
+      if ((int)buffer.size() < buffer_size) {
+        buffer.resize(buffer_size);
+      }
+      if (b + 1 < p) {
+        bool changed_local = InPlaceMerge(blocks[b], blocks[b + 1], buffer);
+        changed_global = changed_global || changed_local;
+      }
+    }
+    if (!changed_global) break;
+  }
+}
+
+bool TestTaskALL::PreProcessingImpl() {
+  unsigned int input_size = task_data->inputs_count[0];
+  auto* in_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
+  input_.assign(in_ptr, in_ptr + input_size);
+  return true;
+}
+
+bool TestTaskALL::ValidationImpl() {
+  return (!task_data->inputs.empty()) && (!task_data->outputs.empty()) &&
+         (task_data->inputs_count[0] == task_data->outputs_count[0]);
+}
+
+bool TestTaskALL::RunImpl() {
+  boost::mpi::communicator world;
+  int rank = world.rank();
+  int size = world.size();
+  int n = static_cast<int>(input_.size());
+  std::vector<int> counts(size), displs(size);
+  int chunk = n / size, rem = n % size;
+  for (int i = 0; i < size; i++) {
+    counts[i] = chunk + (i < rem ? 1 : 0);
+    displs[i] = (i == 0 ? 0 : displs[i - 1] + counts[i - 1]);
+  }
+  std::vector<int> local(counts[rank]);
+  if (rank == 0) {
+    boost::mpi::scatterv(world, input_.data(), counts, displs, local.data(), counts[rank], 0);
+  } else {
+    boost::mpi::scatterv(world, local.data(), counts[rank], 0);
+  }
+  int threads = ppc::util::GetPPCNumThreads();
+  ;
+  int p = std::max(threads, 1);
+  auto blocks = PartitionBlocks(local, p);
+#pragma omp parallel for schedule(static)
+  for (int i = 0; i < p; i++) {
+    QuickSort(blocks[i].low, blocks[i].high, 0);
+  }
+  OddEvenMerge(blocks);
+  if (rank == 0) {
+    boost::mpi::gatherv(world, local.data(), counts[rank], input_.data(), counts, displs, 0);
+  } else {
+    boost::mpi::gatherv(world, local.data(), counts[rank], 0);
+  }
+  if (rank == 0) {
+    int thr2 = omp_get_max_threads();
+    int p2 = std::max(thr2, 1);
+    auto blocks2 = PartitionBlocks(input_, p2);
+#pragma omp parallel for schedule(static)
+    for (int i = 0; i < p2; i++) {
+      QuickSort(blocks2[i].low, blocks2[i].high, 0);
+    }
+    OddEvenMerge(blocks2);
+  }
+  return true;
+}
+
+bool TestTaskALL::PostProcessingImpl() {
+  boost::mpi::communicator world;
+  if (world.rank() == 0) {
+    std::ranges::copy(input_, reinterpret_cast<int*>(task_data->outputs[0]));
+  }
+  return true;
+}
+
+}  // namespace korovin_n_qsort_batcher_all

--- a/tasks/all/korovin_n_qsort_batcher/src/ops_all.cpp
+++ b/tasks/all/korovin_n_qsort_batcher/src/ops_all.cpp
@@ -166,7 +166,6 @@ bool TestTaskALL::RunImpl() {
   for (int i = 0; i < p; i++) {
     QuickSort(blocks[i].low, blocks[i].high, 0);
   }
-  OddEvenMerge(blocks);
   if (rank == 0) {
     boost::mpi::gatherv(world, local_ptr, counts[rank], input_.data(), counts, displs, 0);
   } else {

--- a/tasks/all/korovin_n_qsort_batcher/src/ops_all.cpp
+++ b/tasks/all/korovin_n_qsort_batcher/src/ops_all.cpp
@@ -156,13 +156,10 @@ bool TestTaskALL::RunImpl() {
   }
   std::vector<int> local(counts[rank]);
   int dummy = 0;
-  int* local_ptr = counts[rank] ? local.data() : &dummy;
-  const int* root_in = input_.empty() ? &dummy : input_.data();
-  if (rank == 0) {
-    boost::mpi::scatterv(world, root_in, counts, displs, local_ptr, counts[rank], 0);
-  } else {
-    boost::mpi::scatterv(world, local_ptr, counts[rank], 0);
-  }
+  bool have_local = counts[rank] != 0;
+  int* local_ptr = have_local ? local.data() : &dummy;
+  const int* root_ptr = input_.empty() ? &dummy : input_.data();
+  boost::mpi::scatterv(world, root_ptr, counts, displs, local_ptr, counts[rank], 0);
   int p = std::max(ppc::util::GetPPCNumThreads(), 1);
   auto blocks = PartitionBlocks(local, p);
 #pragma omp parallel for schedule(static)

--- a/tasks/all/korovin_n_qsort_batcher/src/ops_all.cpp
+++ b/tasks/all/korovin_n_qsort_batcher/src/ops_all.cpp
@@ -10,8 +10,9 @@
 #include <cmath>
 #include <cstddef>
 #include <iterator>
-#include <numeric>
 #include <random>
+#include <ranges>
+#include <span>
 #include <vector>
 
 #include "core/util/include/util.hpp"

--- a/tasks/all/korovin_n_qsort_batcher/src/ops_all.cpp
+++ b/tasks/all/korovin_n_qsort_batcher/src/ops_all.cpp
@@ -10,11 +10,9 @@
 #include <cmath>
 #include <cstddef>
 #include <iterator>
+#include <numeric>
 #include <random>
-#include <ranges>
-#include <span>
 #include <vector>
-#include <views>
 
 #include "core/util/include/util.hpp"
 

--- a/tasks/all/korovin_n_qsort_batcher/src/ops_all.cpp
+++ b/tasks/all/korovin_n_qsort_batcher/src/ops_all.cpp
@@ -14,6 +14,7 @@
 #include <ranges>
 #include <span>
 #include <vector>
+#include <views>
 
 #include "core/util/include/util.hpp"
 


### PR DESCRIPTION
# Постановка задачи

Данный код реализует сортировку Хоара с четно-нечетным слиянием Бэтчера. Основная идея состоит в том, чтобы:
- Разбить исходный массив на независимые блоки
- Локально отсортировать каждый блок с помощью рекурсивной QuickSort с параллелизмом на ранних этапах рекурсии
- Объединить отсортированные блоки в единый массив через итеративное четно-нечетное слияние, выполняемое параллельно

---
# Схема распараллеливания

## 1. Локальная сортировка с параллелизмом (QuickSort)

- **Выбор опорного элемента**  

- **Разбиение массива**  

- **Параллелизация рекурсии:**  
  - На начальных этапах рекурсии, когда глубина меньше логарифма числа потоков, сортировка выполняется параллельно с использованием  `#pragma omp parallel sections `

---

## 2. Объединение блоков: четно-нечетное слияние (Odd-Even Merge)

- **Разбиение на блоки:**  
  Функция `PartitionBlocks` делит исходный массив на `p` блоков с равномерным количеством элементов

- **Итеративное слияние:**  
  Функция `OddEvenMerge` объединяет соседние блоки, используя вспомогательную функцию `InPlaceMerge`
  - **InPlaceMerge:**  
    Сливает два отсортированных блока во временный буфер, затем копирует обратно. Возвращает флаг changed, указывающий на изменение порядка
  - **Цикл слияния:**  
    На каждой итерации обрабатываются чётные или нечётные пары. Для параллельной обработки пар используется `#pragma omp parallel for с reduction(|| : changed_global)`
---

# Основной этап алгоритма

### RunImpl()
- Используется `boost::mpi::scatterv` для распределения частей массива между процессами MPI
- В каждом процессе:
  - Локальный фрагмент массива разбивается на блоки с помощью `PartitionBlocks`
  - Каждый блок сортируется параллельно с использованием OpenMP через `#pragma omp parallel for` и `QuickSort`
  - Блоки объединяются с помощью `OddEvenMerge`, в котором пары блоков также сливаются параллельно через `#pragma omp parallel for`
- После локальной сортировки вызывается `boost::mpi::gatherv` для сбора всех отсортированных фрагментов на корневой процесс
