### PR TITLE
Кудряшова Ирина. Вариант 20. Технология STL. Поразрядная сортировка для вещественных чисел (тип double) с четно-нечетным слиянием Бэтчера

### DIFF
--- a/tasks/stl/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSTL.cpp
+++ b/tasks/stl/kudryashova_i_radix_batcher/func_tests/kudryashovaRadixBatcherFuncSTL.cpp
@@ -1,0 +1,155 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <ctime>
+#include <functional>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "core/util/include/util.hpp"
+#include "stl/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSTL.hpp"
+
+std::vector<double> kudryashova_i_radix_batcher_stl::GetRandomDoubleVector(int size) {
+  std::vector<double> vector(size);
+  std::mt19937 generator(static_cast<unsigned>(std::time(nullptr)));
+  std::uniform_real_distribution<double> distribution(-1000.0, 1000.0);
+  for (int i = 0; i < size; ++i) {
+    vector[i] = distribution(generator);
+  }
+  return vector;
+}
+
+TEST(kudryashova_i_radix_batcher_stl, stl_radix_test_1) {
+  int global_vector_size = 3;
+  std::vector<double> global_vector = {5.69, -2.11, 0.52};
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_stl::TestTaskSTL task_stl(task_data);
+  ASSERT_TRUE(task_stl.ValidationImpl());
+  task_stl.PreProcessingImpl();
+  task_stl.RunImpl();
+  task_stl.PostProcessingImpl();
+  std::vector<double> sort_global_vector = global_vector;
+  std::ranges::sort(sort_global_vector);
+  ASSERT_EQ(result, sort_global_vector);
+}
+
+TEST(kudryashova_i_radix_batcher_stl, stl_radix_test_2) {
+  int global_vector_size = 11;
+  std::vector<double> global_vector = {-8.55,   1.85,   -4.0,   2.81828, 8.77,   -5.56562,
+                                       -15.823, -6.971, 3.1615, 0.0,     10.1415};
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_stl::TestTaskSTL task_stl(task_data);
+  ASSERT_TRUE(task_stl.ValidationImpl());
+  task_stl.PreProcessingImpl();
+  task_stl.RunImpl();
+  task_stl.PostProcessingImpl();
+  std::vector<double> sorted_global_vector = global_vector;
+  std::ranges::sort(sorted_global_vector);
+  ASSERT_EQ(result, sorted_global_vector);
+}
+
+TEST(kudryashova_i_radix_batcher_stl, stl_radix_all_zero_elem_test_3) {
+  int global_vector_size = 7;
+  std::vector<double> global_vector = {0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00};
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_stl::TestTaskSTL task_stl(task_data);
+  ASSERT_TRUE(task_stl.ValidationImpl());
+  task_stl.PreProcessingImpl();
+  task_stl.RunImpl();
+  task_stl.PostProcessingImpl();
+  ASSERT_EQ(result, global_vector);
+}
+
+TEST(kudryashova_i_radix_batcher_stl, stl_radix_random_test_1) {
+  int global_vector_size = 18;
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_stl::GetRandomDoubleVector(global_vector_size);
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_stl::TestTaskSTL task_stl(task_data);
+  ASSERT_TRUE(task_stl.ValidationImpl());
+  task_stl.PreProcessingImpl();
+  task_stl.RunImpl();
+  task_stl.PostProcessingImpl();
+  std::vector<double> sorted_global_vector = global_vector;
+  std::ranges::sort(sorted_global_vector);
+  ASSERT_EQ(result, sorted_global_vector);
+}
+
+TEST(kudryashova_i_radix_batcher_stl, stl_radix_random_test_2) {
+  int global_vector_size = 528;
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_stl::GetRandomDoubleVector(global_vector_size);
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_stl::TestTaskSTL task_stl(task_data);
+  ASSERT_TRUE(task_stl.ValidationImpl());
+  task_stl.PreProcessingImpl();
+  task_stl.RunImpl();
+  task_stl.PostProcessingImpl();
+  std::vector<double> sorted_global_vector = global_vector;
+  std::ranges::sort(sorted_global_vector);
+  ASSERT_EQ(result, sorted_global_vector);
+}
+
+TEST(kudryashova_i_radix_batcher_stl, stl_radix_test_regular_order) {
+  int global_vector_size = 127;
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_stl::GetRandomDoubleVector(global_vector_size);
+  std::ranges::sort(global_vector);
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_stl::TestTaskSTL task_stl(task_data);
+  ASSERT_TRUE(task_stl.ValidationImpl());
+  task_stl.PreProcessingImpl();
+  task_stl.RunImpl();
+  task_stl.PostProcessingImpl();
+  ASSERT_EQ(result, global_vector);
+}
+
+TEST(kudryashova_i_radix_batcher_stl, stl_radix_test_reverse_order) {
+  int global_vector_size = 132;
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_stl::GetRandomDoubleVector(global_vector_size);
+  std::ranges::sort(global_vector, std::greater<>());
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  kudryashova_i_radix_batcher_stl::TestTaskSTL task_stl(task_data);
+  ASSERT_TRUE(task_stl.ValidationImpl());
+  task_stl.PreProcessingImpl();
+  task_stl.RunImpl();
+  task_stl.PostProcessingImpl();
+  std::vector<double> sorted_global_vector = global_vector;
+  std::ranges::sort(sorted_global_vector);
+  ASSERT_EQ(result, sorted_global_vector);
+}

--- a/tasks/stl/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSTL.hpp
+++ b/tasks/stl/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSTL.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kudryashova_i_radix_batcher_stl {
+std::vector<double> GetRandomDoubleVector(int size);
+void RadixDoubleSort(std::vector<double>& data, size_t first, size_t last);
+void BatcherMerge(std::vector<double>& target_array, size_t merge_start, size_t mid_point, size_t merge_end);
+
+class TestTaskSTL : public ppc::core::Task {
+ public:
+  explicit TestTaskSTL(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<double> input_data_;
+};
+
+}  // namespace kudryashova_i_radix_batcher_stl

--- a/tasks/stl/kudryashova_i_radix_batcher/perf_tests/kudryashovaRadixBatcherPerfSTL.cpp
+++ b/tasks/stl/kudryashova_i_radix_batcher/perf_tests/kudryashovaRadixBatcherPerfSTL.cpp
@@ -1,0 +1,77 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "stl/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSTL.hpp"
+
+std::vector<double> kudryashova_i_radix_batcher_stl::GetRandomDoubleVector(int size) {
+  std::vector<double> vector(size);
+  std::mt19937 generator(static_cast<unsigned>(std::time(nullptr)));
+  std::uniform_real_distribution<double> distribution(-1000.0, 1000.0);
+  for (int i = 0; i < size; ++i) {
+    vector[i] = distribution(generator);
+  }
+  return vector;
+}
+
+TEST(kudryashova_i_radix_batcher_stl, test_pipeline_run) {
+  int global_vector_size = 3000000;
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_stl::GetRandomDoubleVector(global_vector_size);
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  auto test_task_stl = std::make_shared<kudryashova_i_radix_batcher_stl::TestTaskSTL>(task_data);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 3;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_stl);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
+    ASSERT_LE(result[i - 1], result[i]);
+  }
+}
+
+TEST(kudryashova_i_radix_batcher_stl, test_task_run) {
+  int global_vector_size = 3000000;
+  std::vector<double> global_vector = kudryashova_i_radix_batcher_stl::GetRandomDoubleVector(global_vector_size);
+  std::vector<double> result(global_vector_size);
+  std::shared_ptr<ppc::core::TaskData> task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t *>(global_vector.data()));
+  task_data->inputs_count.emplace_back(global_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t *>(result.data()));
+  task_data->outputs_count.emplace_back(result.size());
+  auto test_task_stl = std::make_shared<kudryashova_i_radix_batcher_stl::TestTaskSTL>(task_data);
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 3;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_stl);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  for (std::vector<double>::size_type i = 1; i < result.size(); i++) {
+    ASSERT_LE(result[i - 1], result[i]);
+  }
+}

--- a/tasks/stl/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherSTL.cpp
+++ b/tasks/stl/kudryashova_i_radix_batcher/src/kudryashovaRadixBatcherSTL.cpp
@@ -1,0 +1,162 @@
+#include "stl/kudryashova_i_radix_batcher/include/kudryashovaRadixBatcherSTL.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "core/util/include/util.hpp"
+
+void kudryashova_i_radix_batcher_stl::RadixDoubleSort(std::vector<double> &data, size_t first, size_t last) {
+  const size_t sort_size = last - first;
+  std::vector<uint64_t> converted(sort_size);
+  // Convert each double to uint64_t representation
+  for (size_t i = 0; i < sort_size; ++i) {
+    double value = data[first + i];
+    uint64_t bits = 0;
+    std::memcpy(&bits, &value, sizeof(value));
+    converted[i] = ((bits & (1ULL << 63)) != 0) ? ~bits : bits ^ (1ULL << 63);  // sign of the number
+  }
+  std::vector<uint64_t> buffer(sort_size);
+  int bits_int_byte = 8;
+  int total_passes = sizeof(uint64_t);  // Total number of passes based on uint64_t size
+  int max_byte_value = 255;
+
+  for (int shift = 0; shift < total_passes; ++shift) {
+    size_t count[256] = {0};                      // Array to count occurrences of each byte
+    const int shift_loc = shift * bits_int_byte;  // Determine shift for the current pass
+
+    // Count occurrences of each byte in the current shift position
+    for (const auto &num : converted) {
+      ++count[(num >> shift_loc) & max_byte_value];
+    }
+
+    size_t total = 0;
+    // Convert the count array to a prefix sum array
+    for (auto &safe : count) {
+      size_t old = safe;
+      safe = total;
+      total += old;
+    }
+    // Rearrange the elements based on the prefix sums
+    for (const auto &num : converted) {
+      const uint8_t byte = (num >> shift_loc) & max_byte_value;
+      buffer[count[byte]++] = num;
+    }
+    converted.swap(buffer);
+  }
+  // Convert the sorted uint64_t representations back to double
+  for (size_t i = 0; i < sort_size; ++i) {
+    uint64_t bits = converted[i];
+    bits = ((bits & (1ULL << 63)) != 0) ? (bits ^ (1ULL << 63)) : ~bits;
+    std::memcpy(&data[first + i], &bits, sizeof(double));
+  }
+}
+
+void kudryashova_i_radix_batcher_stl::BatcherMerge(std::vector<double> &target_array, size_t merge_start,
+                                                   size_t mid_point, size_t merge_end) {
+  const size_t total_elements = merge_end - merge_start;
+  const size_t left_size = mid_point - merge_start;
+  const size_t right_size = merge_end - mid_point;
+  std::vector<double> left_array(target_array.begin() + static_cast<std::ptrdiff_t>(merge_start),
+                                 target_array.begin() + static_cast<std::ptrdiff_t>(mid_point));
+  std::vector<double> right_array(target_array.begin() + static_cast<std::ptrdiff_t>(mid_point),
+                                  target_array.begin() + static_cast<std::ptrdiff_t>(merge_end));
+  size_t left_ptr = 0;
+  size_t right_ptr = 0;
+  size_t merge_ptr = merge_start;
+
+  for (size_t i = 0; i < total_elements; ++i) {
+    if (i % 2 == 0) {
+      if (left_ptr < left_size && (right_ptr >= right_size || left_array[left_ptr] <= right_array[right_ptr])) {
+        target_array[merge_ptr++] = left_array[left_ptr++];
+      } else {
+        target_array[merge_ptr++] = right_array[right_ptr++];
+      }
+    } else {
+      if (right_ptr < right_size && (left_ptr >= left_size || right_array[right_ptr] <= left_array[left_ptr])) {
+        target_array[merge_ptr++] = right_array[right_ptr++];
+      } else {
+        target_array[merge_ptr++] = left_array[left_ptr++];
+      }
+    }
+  }
+}
+
+bool kudryashova_i_radix_batcher_stl::TestTaskSTL::RunImpl() {
+  const size_t input_size = input_data_.size();
+  if (input_size <= 1) {
+    return true;
+  }
+
+  const size_t num_threads = ppc::util::GetPPCNumThreads();
+  const size_t sort_block_size = (input_size + num_threads - 1) / num_threads;
+
+  std::vector<std::thread> sort_threads;
+  for (size_t thread_idx = 0; thread_idx < num_threads; ++thread_idx) {
+    const size_t block_start = thread_idx * sort_block_size;
+    const size_t block_end = std::min(block_start + sort_block_size, input_size);
+
+    if (block_start >= input_size) {
+      break;
+    }
+
+    sort_threads.emplace_back([&, block_start, block_end] { RadixDoubleSort(input_data_, block_start, block_end); });
+  }
+  for (auto &thread : sort_threads) {
+    thread.join();
+  }
+
+  for (size_t current_merge_size = sort_block_size; current_merge_size < input_size; current_merge_size *= 2) {
+    const size_t merge_group_size = 2 * current_merge_size;
+    const size_t total_merge_groups = (input_size + merge_group_size - 1) / merge_group_size;
+
+    std::vector<std::thread> merge_threads;
+    const size_t merge_groups_per_thread = (total_merge_groups + num_threads - 1) / num_threads;
+
+    for (size_t thread_idx = 0; thread_idx < num_threads; ++thread_idx) {
+      const size_t group_range_start = thread_idx * merge_groups_per_thread;
+      const size_t group_range_end = std::min(group_range_start + merge_groups_per_thread, total_merge_groups);
+
+      if (group_range_start >= group_range_end) {
+        break;
+      }
+      merge_threads.emplace_back([&, group_range_start, group_range_end, current_merge_size, merge_group_size] {
+        for (size_t group_index = group_range_start; group_index < group_range_end; ++group_index) {
+          const size_t merge_start = group_index * merge_group_size;
+          const size_t merge_mid = std::min(merge_start + current_merge_size, input_size);
+          const size_t merge_end = std::min(merge_start + merge_group_size, input_size);
+          if (merge_mid < merge_end) {
+            BatcherMerge(input_data_, merge_start, merge_mid, merge_end);
+          }
+        }
+      });
+    }
+    for (auto &thread : merge_threads) {
+      thread.join();
+    }
+  }
+  return true;
+}
+
+bool kudryashova_i_radix_batcher_stl::TestTaskSTL::PreProcessingImpl() {
+  input_data_.resize(task_data->inputs_count[0]);
+  if (task_data->inputs[0] == nullptr || task_data->inputs_count[0] == 0) {
+    return false;
+  }
+  auto *tmp_ptr = reinterpret_cast<double *>(task_data->inputs[0]);
+  std::copy(tmp_ptr, tmp_ptr + task_data->inputs_count[0], input_data_.begin());
+  return true;
+}
+
+bool kudryashova_i_radix_batcher_stl::TestTaskSTL::ValidationImpl() {
+  return task_data->inputs_count[0] > 0 && task_data->outputs_count[0] == task_data->inputs_count[0];
+}
+
+bool kudryashova_i_radix_batcher_stl::TestTaskSTL::PostProcessingImpl() {
+  std::ranges::copy(input_data_, reinterpret_cast<double *>(task_data->outputs[0]));
+  return true;
+}


### PR DESCRIPTION
Данная реализация демонстрирует поразрядную сортировку и чётно-нечётное слияние Бэтчера с использованием std::thread. 
Входной массив разделяется на блоки, размер которых вычисляется на основе количества доступных потоков. Каждый блок обрабатывается отдельным потоком, вызывающим _RadixDoubleSort_, который преобразует числа в битовое представление uint64_t, корректирует знак (инвертируя отрицательные значения) и выполняет LSD-сортировку по байтам, используя подсчет с префиксными суммами для перестановки элементов. 
Далее отсортированные блоки данных иерархически объединяются: на каждой итерации размер сливаемых групп удваивается, а сами группы распределяются между потоками. Каждый поток обрабатывает диапазон групп, внутри которого вызывает _BatcherMerge_, попеременно сравнивая элементы из левого и правого подмассивов с чередованием четных и нечетных шагов