### PR TITLE
Черных Андрей. Задача 5. Вариант 9. Технология MPI+OMP. Вычисление многомерных интегралов с использованием многошаговой схемы (метод прямоугольников).

### DIFF
--- a/tasks/all/chernykh_a_multidimensional_integral_rectangle/func_tests/main.cpp
+++ b/tasks/all/chernykh_a_multidimensional_integral_rectangle/func_tests/main.cpp
@@ -161,6 +161,44 @@ TEST(chernykh_a_multidimensional_integral_rectangle_all, trigonometric_exponenti
   RunValidTask(func, dims, want);
 }
 
+TEST(chernykh_a_multidimensional_integral_rectangle_all, linear_4d_integration) {
+  Function func = [](const Point& point) -> double { return point[0] + point[1] + point[2] + point[3]; };
+  std::vector<Dimension> dims = {
+      Dimension(0.0, 1.0, 10),
+      Dimension(0.0, 1.0, 10),
+      Dimension(0.0, 1.0, 10),
+      Dimension(0.0, 1.0, 10),
+  };
+  double want = 2.2000000000000006;
+  RunValidTask(func, dims, want);
+}
+
+TEST(chernykh_a_multidimensional_integral_rectangle_all, quadratic_4d_integration) {
+  Function func = [](const Point& point) -> double {
+    return std::pow(point[0], 2) + std::pow(point[1], 2) + std::pow(point[2], 2) + std::pow(point[3], 2);
+  };
+  std::vector<Dimension> dims = {
+      Dimension(0.0, 1.0, 10),
+      Dimension(0.0, 1.0, 10),
+      Dimension(0.0, 1.0, 10),
+      Dimension(0.0, 1.0, 10),
+  };
+  double want = 1.5399999999999965;
+  RunValidTask(func, dims, want);
+}
+
+TEST(chernykh_a_multidimensional_integral_rectangle_all, mixed_4d_integration) {
+  Function func = [](const Point& point) -> double { return (point[0] * point[1]) + (point[2] * point[3]); };
+  std::vector<Dimension> dims = {
+      Dimension(0.0, 1.0, 10),
+      Dimension(0.0, 1.0, 10),
+      Dimension(0.0, 1.0, 10),
+      Dimension(0.0, 1.0, 10),
+  };
+  double want = 0.6049999999999999;
+  RunValidTask(func, dims, want);
+}
+
 TEST(chernykh_a_multidimensional_integral_rectangle_all, one_step_integration) {
   Function func = [](const Point& point) -> double { return std::pow(point[0], 2) + std::pow(point[1], 2); };
   std::vector<Dimension> dims = {

--- a/tasks/all/chernykh_a_multidimensional_integral_rectangle/func_tests/main.cpp
+++ b/tasks/all/chernykh_a_multidimensional_integral_rectangle/func_tests/main.cpp
@@ -1,0 +1,198 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi.hpp>
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <numbers>
+#include <vector>
+
+#include "all/chernykh_a_multidimensional_integral_rectangle/include/ops_all.hpp"
+#include "core/task/include/task.hpp"
+
+namespace {
+
+using namespace chernykh_a_multidimensional_integral_rectangle_all;
+
+void RunValidTask(const Function& func, std::vector<Dimension>& dims, double want) {
+  auto world = boost::mpi::communicator();
+
+  double output = 0.0;
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(dims.data()));
+    task_data->inputs_count.emplace_back(dims.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(&output));
+    task_data->outputs_count.emplace_back(1);
+  }
+  auto task = AllTask(task_data, func);
+
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+  if (world.rank() == 0) {
+    EXPECT_NEAR(want, output, 1e-8);
+  }
+}
+
+void RunInvalidTask(const Function& func, std::vector<Dimension>& dims) {
+  auto world = boost::mpi::communicator();
+
+  double output = 0.0;
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(dims.data()));
+    task_data->inputs_count.emplace_back(dims.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(&output));
+    task_data->outputs_count.emplace_back(1);
+    auto task = AllTask(task_data, func);
+
+    ASSERT_FALSE(task.Validation());
+  }
+}
+
+TEST(chernykh_a_multidimensional_integral_rectangle_all, radical_2d_integration) {
+  Function func = [](const Point& point) -> double { return std::sqrt(point[0]) + std::sqrt(point[1]); };
+  std::vector<Dimension> dims = {
+      Dimension(0.0, 4.0, 10),
+      Dimension(0.0, 9.0, 10),
+  };
+  double want = 127.89168150722712;
+  RunValidTask(func, dims, want);
+}
+
+TEST(chernykh_a_multidimensional_integral_rectangle_all, absolute_2d_integration) {
+  Function func = [](const Point& point) -> double { return std::abs(point[0]) + std::abs(point[1]); };
+  std::vector<Dimension> dims = {
+      Dimension(-2.0, 2.0, 10),
+      Dimension(-3.0, 3.0, 15),
+  };
+  double want = 60.16000000000002;
+  RunValidTask(func, dims, want);
+}
+
+TEST(chernykh_a_multidimensional_integral_rectangle_all, trigonometric_2d_integration) {
+  Function func = [](const Point& point) -> double { return std::sin(point[0]) * std::cos(point[1]); };
+  std::vector<Dimension> dims = {
+      Dimension(0.0, std::numbers::pi, 100),
+      Dimension(0.0, std::numbers::pi / 2, 100),
+  };
+  double want = 1.9840877124304817;
+  RunValidTask(func, dims, want);
+}
+
+TEST(chernykh_a_multidimensional_integral_rectangle_all, polynomial_3d_integration) {
+  Function func = [](const Point& point) -> double {
+    return (point[0] * point[1]) + (point[1] * point[2]) + (point[0] * point[2]);
+  };
+  std::vector<Dimension> dims = {
+      Dimension(0.0, 100.0, 50),
+      Dimension(-100.0, 0.0, 50),
+      Dimension(-50.0, 50.0, 50),
+  };
+  double want = -2497000000.0;
+  RunValidTask(func, dims, want);
+}
+
+TEST(chernykh_a_multidimensional_integral_rectangle_all, exponential_1d_integration) {
+  Function func = [](const Point& point) -> double { return std::exp(point[0]); };
+  std::vector<Dimension> dims = {
+      Dimension(0.0, 1.0, 5),
+  };
+  double want = 1.8958338026286925;
+  RunValidTask(func, dims, want);
+}
+
+TEST(chernykh_a_multidimensional_integral_rectangle_all, trigonometric_3d_integration) {
+  Function func = [](const Point& point) -> double {
+    return std::sin(point[0]) * std::cos(point[1]) * std::tan(point[2]);
+  };
+  std::vector<Dimension> dims = {
+      Dimension(0.0, std::numbers::pi, 15),
+      Dimension(0.0, std::numbers::pi / 2, 10),
+      Dimension(0.0, std::numbers::pi / 4, 5),
+  };
+  double want = 0.782587506841825;
+  RunValidTask(func, dims, want);
+}
+
+TEST(chernykh_a_multidimensional_integral_rectangle_all, cubic_2d_integration) {
+  Function func = [](const Point& point) -> double { return std::pow(point[0], 3) + std::pow(point[1], 3); };
+  std::vector<Dimension> dims = {
+      Dimension(0.0, 1.0, 5),
+      Dimension(0.0, 2.0, 5),
+  };
+  double want = 6.480000000000001;
+  RunValidTask(func, dims, want);
+}
+
+TEST(chernykh_a_multidimensional_integral_rectangle_all, quadratic_2d_integration) {
+  Function func = [](const Point& point) -> double { return std::pow(point[0], 2) + std::pow(point[1], 2); };
+  std::vector<Dimension> dims = {
+      Dimension(0.0, 0.000002, 150),
+      Dimension(0.0, 0.000003, 150),
+  };
+  double want = 2.6260577777777697e-23;
+  RunValidTask(func, dims, want);
+}
+
+TEST(chernykh_a_multidimensional_integral_rectangle_all, exponential_3d_integration) {
+  Function func = [](const Point& point) -> double { return std::exp(point[0] + point[1] + point[2]); };
+  std::vector<Dimension> dims = {
+      Dimension(0.0, 0.005, 50),
+      Dimension(0.0, 0.005, 50),
+      Dimension(0.0, 0.005, 50),
+  };
+  double want = 1.2596031046900125e-07;
+  RunValidTask(func, dims, want);
+}
+
+TEST(chernykh_a_multidimensional_integral_rectangle_all, trigonometric_exponential_3d_integration) {
+  Function func = [](const Point& point) -> double {
+    return std::sin(point[0]) * std::cos(point[1]) * std::exp(point[2]);
+  };
+  std::vector<Dimension> dims = {
+      Dimension(0.0, std::numbers::pi, 30),
+      Dimension(0.0, std::numbers::pi / 2, 20),
+      Dimension(0.0, 1.0, 10),
+  };
+  double want = 3.4644155398722236;
+  RunValidTask(func, dims, want);
+}
+
+TEST(chernykh_a_multidimensional_integral_rectangle_all, one_step_integration) {
+  Function func = [](const Point& point) -> double { return std::pow(point[0], 2) + std::pow(point[1], 2); };
+  std::vector<Dimension> dims = {
+      Dimension(0.0, 1.0, 1),
+      Dimension(0.0, 1.0, 1),
+  };
+  double want = 2.0;
+  RunValidTask(func, dims, want);
+}
+
+TEST(chernykh_a_multidimensional_integral_rectangle_all, empty_dimensions_fails_validation) {
+  Function func = [](const Point& point) -> double { return std::sqrt(point[0]) + std::sqrt(point[1]); };
+  std::vector<Dimension> dims = {};
+  RunInvalidTask(func, dims);
+}
+
+TEST(chernykh_a_multidimensional_integral_rectangle_all, incorrect_bounds_fails_validation) {
+  Function func = [](const Point& point) -> double { return std::abs(point[0]) + std::abs(point[1]); };
+  std::vector<Dimension> dims = {
+      Dimension(2.0, -2.0, 10),
+      Dimension(-3.0, 3.0, 15),
+  };
+  RunInvalidTask(func, dims);
+}
+
+TEST(chernykh_a_multidimensional_integral_rectangle_all, incorrect_steps_count_fails_validation) {
+  Function func = [](const Point& point) -> double { return std::sin(point[0]) * std::cos(point[1]); };
+  std::vector<Dimension> dims = {
+      Dimension(0.0, std::numbers::pi, -100),
+      Dimension(0.0, std::numbers::pi / 2, 100),
+  };
+  RunInvalidTask(func, dims);
+}
+
+}  // namespace

--- a/tasks/all/chernykh_a_multidimensional_integral_rectangle/func_tests/main.cpp
+++ b/tasks/all/chernykh_a_multidimensional_integral_rectangle/func_tests/main.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include <boost/mpi.hpp>
+#include <boost/mpi/communicator.hpp>
 #include <cmath>
 #include <cstdint>
 #include <memory>

--- a/tasks/all/chernykh_a_multidimensional_integral_rectangle/include/ops_all.hpp
+++ b/tasks/all/chernykh_a_multidimensional_integral_rectangle/include/ops_all.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <boost/mpi.hpp>
+#include <boost/mpi/communicator.hpp>
 #include <boost/serialization/access.hpp>
 #include <functional>
 #include <utility>
@@ -31,7 +31,7 @@ class Dimension {
 
   friend class boost::serialization::access;
   template <class Archive>
-  void serialize(Archive &archive, unsigned version) {
+  void serialize(Archive &archive, unsigned version) {  // NOLINT(readability-identifier-naming)
     archive & lower_bound_;
     archive & upper_bound_;
     archive & steps_count_;

--- a/tasks/all/chernykh_a_multidimensional_integral_rectangle/include/ops_all.hpp
+++ b/tasks/all/chernykh_a_multidimensional_integral_rectangle/include/ops_all.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <boost/mpi.hpp>
+#include <boost/serialization/access.hpp>
+#include <functional>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace chernykh_a_multidimensional_integral_rectangle_all {
+
+using Point = std::vector<double>;
+using Function = std::function<double(const Point &)>;
+
+class Dimension {
+ public:
+  Dimension() = default;
+  explicit Dimension(double lower_bound, double upper_bound, int steps_count)
+      : lower_bound_(lower_bound), upper_bound_(upper_bound), steps_count_(steps_count) {}
+  [[nodiscard]] double GetLowerBound() const;
+  [[nodiscard]] double GetUpperBound() const;
+  [[nodiscard]] int GetStepsCount() const;
+  [[nodiscard]] double GetStepSize() const;
+  [[nodiscard]] bool IsValid() const;
+
+ private:
+  double lower_bound_{};
+  double upper_bound_{};
+  int steps_count_{};
+
+  friend class boost::serialization::access;
+  template <class Archive>
+  void serialize(Archive &archive, unsigned version) {
+    archive & lower_bound_;
+    archive & upper_bound_;
+    archive & steps_count_;
+  }
+};
+
+class AllTask final : public ppc::core::Task {
+ public:
+  explicit AllTask(ppc::core::TaskDataPtr task_data, Function func)
+      : Task(std::move(task_data)), func_(std::move(func)) {}
+  bool ValidationImpl() override;
+  bool PreProcessingImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  Function func_;
+  std::vector<Dimension> dims_;
+  double result_{};
+  boost::mpi::communicator world_;
+
+  void FillPoint(int index, Point &point) const;
+  [[nodiscard]] int GetTotalPoints() const;
+  [[nodiscard]] double GetScalingFactor() const;
+};
+
+}  // namespace chernykh_a_multidimensional_integral_rectangle_all

--- a/tasks/all/chernykh_a_multidimensional_integral_rectangle/perf_tests/main.cpp
+++ b/tasks/all/chernykh_a_multidimensional_integral_rectangle/perf_tests/main.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include <boost/mpi.hpp>
+#include <boost/mpi/communicator.hpp>
 #include <chrono>
 #include <cmath>
 #include <cstdint>

--- a/tasks/all/chernykh_a_multidimensional_integral_rectangle/perf_tests/main.cpp
+++ b/tasks/all/chernykh_a_multidimensional_integral_rectangle/perf_tests/main.cpp
@@ -1,0 +1,86 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi.hpp>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <numbers>
+#include <vector>
+
+#include "all/chernykh_a_multidimensional_integral_rectangle/include/ops_all.hpp"
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+
+namespace {
+
+using namespace chernykh_a_multidimensional_integral_rectangle_all;
+
+enum class RunType : uint8_t { kTask, kPipeline };
+
+void RunTask(const RunType run_type, const Function& func, std::vector<Dimension>& dims, double want) {
+  auto world = boost::mpi::communicator();
+
+  double output = 0.0;
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(dims.data()));
+    task_data->inputs_count.emplace_back(dims.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(&output));
+    task_data->outputs_count.emplace_back(1);
+  }
+  auto task = std::make_shared<AllTask>(task_data, func);
+
+  auto perf_attributes = std::make_shared<ppc::core::PerfAttr>();
+  perf_attributes->num_running = 10;
+  auto start = std::chrono::high_resolution_clock::now();
+  perf_attributes->current_timer = [&]() -> double {
+    auto current = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current - start).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(task);
+
+  switch (run_type) {
+    case RunType::kPipeline:
+      perf_analyzer->PipelineRun(perf_attributes, perf_results);
+      break;
+    case RunType::kTask:
+      perf_analyzer->TaskRun(perf_attributes, perf_results);
+      break;
+  }
+
+  if (world.rank() == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
+    EXPECT_NEAR(want, output, 1e-4);
+  }
+}
+
+TEST(chernykh_a_multidimensional_integral_rectangle_all, test_pipeline_run) {
+  Function func = [](const Point& point) -> double {
+    return std::exp(-point[0] - point[1] - point[2]) * std::sin(point[0]) * std::sin(point[1]) * std::sin(point[2]);
+  };
+  std::vector<Dimension> dims = {
+      Dimension(0.0, std::numbers::pi, 150),
+      Dimension(0.0, std::numbers::pi, 150),
+      Dimension(0.0, std::numbers::pi, 150),
+  };
+  double want = std::pow((1.0 + std::exp(-std::numbers::pi)) / 2.0, 3);
+  RunTask(RunType::kPipeline, func, dims, want);
+}
+
+TEST(chernykh_a_multidimensional_integral_rectangle_all, test_task_run) {
+  Function func = [](const Point& point) -> double {
+    return std::exp(-point[0] - point[1] - point[2]) * std::sin(point[0]) * std::sin(point[1]) * std::sin(point[2]);
+  };
+  std::vector<Dimension> dims = {
+      Dimension(0.0, std::numbers::pi, 150),
+      Dimension(0.0, std::numbers::pi, 150),
+      Dimension(0.0, std::numbers::pi, 150),
+  };
+  double want = std::pow((1.0 + std::exp(-std::numbers::pi)) / 2.0, 3);
+  RunTask(RunType::kTask, func, dims, want);
+}
+
+}  // namespace

--- a/tasks/all/chernykh_a_multidimensional_integral_rectangle/src/ops_all.cpp
+++ b/tasks/all/chernykh_a_multidimensional_integral_rectangle/src/ops_all.cpp
@@ -3,8 +3,9 @@
 #include <omp.h>
 
 #include <algorithm>
-#include <boost/mpi.hpp>
-#include <boost/serialization/vector.hpp>
+#include <boost/mpi/collectives/broadcast.hpp>
+#include <boost/mpi/collectives/reduce.hpp>
+#include <boost/serialization/vector.hpp>  // NOLINT(misc-include-cleaner)
 #include <cstddef>
 #include <cstdint>
 #include <functional>


### PR DESCRIPTION
Задача **вычисления многомерного интеграла методом правых прямоугольников** направлена на численное определение значения интеграла функции нескольких переменных на заданных границах.

## Описание задачи

1. **Инициализация**:
    - Устанавливаются параметры интегрирования: границы для каждого измерения и количество шагов.
    - MPI-процесс с рангом 0 проверяет корректность входных данных: левая граница для каждого измерения должна быть меньше правой, а количество шагов по каждому измерению должно быть положительным.
    - Остальным MPI-процессам данные передаются с помощью функции `boost::mpi::broadcast`.

2. **Интегрирование**:
    - Вычисляется общее количество точек многомерной сетки.
    - Сетка делится на части, и каждая часть обрабатывается отдельным MPI-процессом.
    - Внутри каждого MPI-процесса параллельно выполняется вычисление значений подынтегральной функции `func_` для соответствующей части сетки с использованием директивы `#pragma omp for`.
    - Для каждого MPI-процесса вычисляется частичная сумма значений функции, которая аккумулируется в переменной `chunk_sum`.
    - После выполнения всех вычислений, MPI-процессы с помощью `boost::mpi::reduce` объединяют частичные суммы в процессе с рангом 0.

3. **Масштабирование результата**:
    - Сумма значений функции умножается на коэффициент, полученный как произведение размеров шагов по каждому измерению.

4. **Результат**:
    - Возвращается значение многомерного интеграла, которое сохраняется в выходном параметре. Это значение доступно только для процесса с рангом 0.
