### PR TITLE
Борисов Сергей. Задача 1. Вариант 3. Технология STL. Умножение плотных матриц. Элементы типа double. Алгоритм Штрассена.

### DIFF
--- a/tasks/stl/borisov_s_strassen/func_tests/main.cpp
+++ b/tasks/stl/borisov_s_strassen/func_tests/main.cpp
@@ -40,7 +40,7 @@ std::vector<double> GenerateRandomMatrix(int rows, int cols, int seed, double mi
 
 }  // namespace
 
-TEST(borisov_s_strassen_seq, OneByOne) {
+TEST(borisov_s_strassen_stl, OneByOne) {
   std::vector<double> in_data = {1.0, 1.0, 1.0, 1.0, 7.5, 2.5};
 
   std::size_t output_count = 3;
@@ -53,7 +53,7 @@ TEST(borisov_s_strassen_seq, OneByOne) {
   task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
   task_data->outputs_count.push_back(output_count);
 
-  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+  borisov_s_strassen_stl::ParallelStrassenStl task(task_data);
 
   task.PreProcessingImpl();
   EXPECT_TRUE(task.ValidationImpl());
@@ -67,7 +67,7 @@ TEST(borisov_s_strassen_seq, OneByOne) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, TwoByTwo) {
+TEST(borisov_s_strassen_stl, TwoByTwo) {
   std::vector<double> a = {1.0, 2.5, 3.0, 4.0};
   std::vector<double> b = {1.5, 2.0, 0.5, 3.5};
   std::vector<double> c_expected = {2.75, 10.75, 6.5, 20.0};
@@ -86,7 +86,7 @@ TEST(borisov_s_strassen_seq, TwoByTwo) {
   task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
   task_data->outputs_count.push_back(output_count);
 
-  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+  borisov_s_strassen_stl::ParallelStrassenStl task(task_data);
 
   task.PreProcessingImpl();
   EXPECT_TRUE(task.ValidationImpl());
@@ -102,7 +102,7 @@ TEST(borisov_s_strassen_seq, TwoByTwo) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, Rectangular2x3_3x4) {
+TEST(borisov_s_strassen_stl, Rectangular2x3_3x4) {
   std::vector<double> a = {1.0, 2.5, 3.0, 4.0, 5.5, 6.0};
   std::vector<double> b = {0.5, 1.0, 2.0, 1.5, 2.0, 0.5, 1.0, 3.0, 4.0, 2.5, 0.5, 1.0};
 
@@ -122,7 +122,7 @@ TEST(borisov_s_strassen_seq, Rectangular2x3_3x4) {
   task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
   task_data->outputs_count.push_back(output_count);
 
-  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+  borisov_s_strassen_stl::ParallelStrassenStl task(task_data);
 
   task.PreProcessingImpl();
   EXPECT_TRUE(task.ValidationImpl());
@@ -145,7 +145,7 @@ TEST(borisov_s_strassen_seq, Rectangular2x3_3x4) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, Square5x5_Random) {
+TEST(borisov_s_strassen_stl, Square5x5_Random) {
   const int n = 5;
 
   std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
@@ -168,7 +168,7 @@ TEST(borisov_s_strassen_seq, Square5x5_Random) {
   task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
   task_data->outputs_count.push_back(output_count);
 
-  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+  borisov_s_strassen_stl::ParallelStrassenStl task(task_data);
 
   task.PreProcessingImpl();
   EXPECT_TRUE(task.ValidationImpl());
@@ -191,7 +191,7 @@ TEST(borisov_s_strassen_seq, Square5x5_Random) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, Square20x20_Random) {
+TEST(borisov_s_strassen_stl, Square20x20_Random) {
   const int n = 20;
 
   std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
@@ -214,7 +214,7 @@ TEST(borisov_s_strassen_seq, Square20x20_Random) {
   task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
   task_data->outputs_count.push_back(output_count);
 
-  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+  borisov_s_strassen_stl::ParallelStrassenStl task(task_data);
 
   task.PreProcessingImpl();
   EXPECT_TRUE(task.ValidationImpl());
@@ -237,7 +237,7 @@ TEST(borisov_s_strassen_seq, Square20x20_Random) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, Square32x32_Random) {
+TEST(borisov_s_strassen_stl, Square32x32_Random) {
   const int n = 32;
 
   std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
@@ -260,7 +260,7 @@ TEST(borisov_s_strassen_seq, Square32x32_Random) {
   task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
   task_data->outputs_count.push_back(output_count);
 
-  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+  borisov_s_strassen_stl::ParallelStrassenStl task(task_data);
 
   task.PreProcessingImpl();
   EXPECT_TRUE(task.ValidationImpl());
@@ -283,7 +283,7 @@ TEST(borisov_s_strassen_seq, Square32x32_Random) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, Square128x128_Random) {
+TEST(borisov_s_strassen_stl, Square128x128_Random) {
   const int n = 128;
 
   std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
@@ -306,7 +306,7 @@ TEST(borisov_s_strassen_seq, Square128x128_Random) {
   task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
   task_data->outputs_count.push_back(output_count);
 
-  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+  borisov_s_strassen_stl::ParallelStrassenStl task(task_data);
 
   task.PreProcessingImpl();
   EXPECT_TRUE(task.ValidationImpl());
@@ -329,7 +329,7 @@ TEST(borisov_s_strassen_seq, Square128x128_Random) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, Square128x128_IdentityMatrix) {
+TEST(borisov_s_strassen_stl, Square128x128_IdentityMatrix) {
   const int n = 128;
 
   std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
@@ -354,7 +354,7 @@ TEST(borisov_s_strassen_seq, Square128x128_IdentityMatrix) {
   task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
   task_data->outputs_count.push_back(output_count);
 
-  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+  borisov_s_strassen_stl::ParallelStrassenStl task(task_data);
 
   task.PreProcessingImpl();
   EXPECT_TRUE(task.ValidationImpl());
@@ -377,7 +377,7 @@ TEST(borisov_s_strassen_seq, Square128x128_IdentityMatrix) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, Square129x129_Random) {
+TEST(borisov_s_strassen_stl, Square129x129_Random) {
   const int n = 129;
 
   std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
@@ -400,7 +400,7 @@ TEST(borisov_s_strassen_seq, Square129x129_Random) {
   task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
   task_data->outputs_count.push_back(output_count);
 
-  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+  borisov_s_strassen_stl::ParallelStrassenStl task(task_data);
 
   task.PreProcessingImpl();
   EXPECT_TRUE(task.ValidationImpl());
@@ -423,7 +423,7 @@ TEST(borisov_s_strassen_seq, Square129x129_Random) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, Square240x240_Random) {
+TEST(borisov_s_strassen_stl, Square240x240_Random) {
   const int n = 240;
 
   std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
@@ -446,7 +446,7 @@ TEST(borisov_s_strassen_seq, Square240x240_Random) {
   task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
   task_data->outputs_count.push_back(output_count);
 
-  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+  borisov_s_strassen_stl::ParallelStrassenStl task(task_data);
 
   task.PreProcessingImpl();
   EXPECT_TRUE(task.ValidationImpl());
@@ -469,7 +469,99 @@ TEST(borisov_s_strassen_seq, Square240x240_Random) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, ValidCase) {
+TEST(borisov_s_strassen_stl, Square512x512_Random) {
+  const int n = 512;
+
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_stl::ParallelStrassenStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+  std::vector<double> c_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_stl, Square600x600_Random) {
+  const int n = 600;
+
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_stl::ParallelStrassenStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+  std::vector<double> c_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_stl, ValidCase) {
   std::vector<double> input_data = {2.0, 3.0, 3.0, 2.0};
   input_data.insert(input_data.end(), {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
   input_data.insert(input_data.end(), {7.0, 8.0, 9.0, 10.0, 11.0, 12.0});
@@ -481,14 +573,14 @@ TEST(borisov_s_strassen_seq, ValidCase) {
   task_data->outputs.push_back(nullptr);
   task_data->outputs_count.push_back(0);
 
-  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+  borisov_s_strassen_stl::ParallelStrassenStl task(task_data);
 
   task.PreProcessingImpl();
 
   EXPECT_TRUE(task.ValidationImpl());
 }
 
-TEST(borisov_s_strassen_seq, MismatchCase) {
+TEST(borisov_s_strassen_stl, MismatchCase) {
   std::vector<double> input_data = {
       2.0,
       2.0,
@@ -505,13 +597,13 @@ TEST(borisov_s_strassen_seq, MismatchCase) {
   task_data->outputs.push_back(nullptr);
   task_data->outputs_count.push_back(0);
 
-  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+  borisov_s_strassen_stl::ParallelStrassenStl task(task_data);
 
   task.PreProcessingImpl();
   EXPECT_FALSE(task.ValidationImpl());
 }
 
-TEST(borisov_s_strassen_seq, NotEnoughDataCase) {
+TEST(borisov_s_strassen_stl, NotEnoughDataCase) {
   std::vector<double> input_data = {2.0, 2.0, 2.0, 2.0};
   input_data.insert(input_data.end(), {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
 
@@ -522,14 +614,14 @@ TEST(borisov_s_strassen_seq, NotEnoughDataCase) {
   task_data->outputs.push_back(nullptr);
   task_data->outputs_count.push_back(0);
 
-  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+  borisov_s_strassen_stl::ParallelStrassenStl task(task_data);
 
   task.PreProcessingImpl();
 
   EXPECT_FALSE(task.ValidationImpl());
 }
 
-TEST(borisov_s_strassen_seq, Rectangular16x17_Random) {
+TEST(borisov_s_strassen_stl, Rectangular16x17_Random) {
   const int rows_a = 16;
   const int cols_a = 17;
   const int cols_b = 18;
@@ -554,7 +646,7 @@ TEST(borisov_s_strassen_seq, Rectangular16x17_Random) {
   task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
   task_data->outputs_count.push_back(output_count);
 
-  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+  borisov_s_strassen_stl::ParallelStrassenStl task(task_data);
 
   task.PreProcessingImpl();
   EXPECT_TRUE(task.ValidationImpl());
@@ -577,7 +669,7 @@ TEST(borisov_s_strassen_seq, Rectangular16x17_Random) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, Rectangular19x23_Random) {
+TEST(borisov_s_strassen_stl, Rectangular19x23_Random) {
   const int rows_a = 19;
   const int cols_a = 23;
   const int cols_b = 21;
@@ -602,7 +694,7 @@ TEST(borisov_s_strassen_seq, Rectangular19x23_Random) {
   task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
   task_data->outputs_count.push_back(output_count);
 
-  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+  borisov_s_strassen_stl::ParallelStrassenStl task(task_data);
 
   task.PreProcessingImpl();
   EXPECT_TRUE(task.ValidationImpl());
@@ -625,7 +717,7 @@ TEST(borisov_s_strassen_seq, Rectangular19x23_Random) {
   delete[] out_ptr;
 }
 
-TEST(borisov_s_strassen_seq, Rectangular32x64_Random) {
+TEST(borisov_s_strassen_stl, Rectangular32x64_Random) {
   const int rows_a = 32;
   const int cols_a = 64;
   const int cols_b = 32;
@@ -650,7 +742,7 @@ TEST(borisov_s_strassen_seq, Rectangular32x64_Random) {
   task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
   task_data->outputs_count.push_back(output_count);
 
-  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+  borisov_s_strassen_stl::ParallelStrassenStl task(task_data);
 
   task.PreProcessingImpl();
   EXPECT_TRUE(task.ValidationImpl());

--- a/tasks/stl/borisov_s_strassen/func_tests/main.cpp
+++ b/tasks/stl/borisov_s_strassen/func_tests/main.cpp
@@ -1,0 +1,674 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "stl/borisov_s_strassen/include/ops_stl.hpp"
+
+namespace {
+
+std::vector<double> MultiplyNaiveDouble(const std::vector<double>& a, const std::vector<double>& b, int rows_a,
+                                        int cols_a, int cols_b) {
+  std::vector<double> c(rows_a * cols_b, 0.0);
+  for (int i = 0; i < rows_a; ++i) {
+    for (int j = 0; j < cols_b; ++j) {
+      double sum = 0.0;
+      for (int k = 0; k < cols_a; ++k) {
+        sum += a[(i * cols_a) + k] * b[(k * cols_b) + j];
+      }
+      c[(i * cols_b) + j] = sum;
+    }
+  }
+  return c;
+}
+
+std::vector<double> GenerateRandomMatrix(int rows, int cols, int seed, double min_val = -50.0, double max_val = 50.0) {
+  std::mt19937 rng(seed);
+
+  std::uniform_real_distribution<double> dist(min_val, max_val);
+  std::vector<double> matrix(rows * cols);
+  for (double& x : matrix) {
+    x = dist(rng);
+  }
+  return matrix;
+}
+
+}  // namespace
+
+TEST(borisov_s_strassen_seq, OneByOne) {
+  std::vector<double> in_data = {1.0, 1.0, 1.0, 1.0, 7.5, 2.5};
+
+  std::size_t output_count = 3;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], 1.0);
+  EXPECT_DOUBLE_EQ(out_ptr[1], 1.0);
+  EXPECT_DOUBLE_EQ(out_ptr[2], 18.75);
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, TwoByTwo) {
+  std::vector<double> a = {1.0, 2.5, 3.0, 4.0};
+  std::vector<double> b = {1.5, 2.0, 0.5, 3.5};
+  std::vector<double> c_expected = {2.75, 10.75, 6.5, 20.0};
+
+  std::vector<double> in_data = {2.0, 2.0, 2.0, 2.0};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + 4;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], 2.0);
+  EXPECT_DOUBLE_EQ(out_ptr[1], 2.0);
+  for (int i = 0; i < 4; ++i) {
+    EXPECT_NEAR(out_ptr[2 + i], c_expected[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Rectangular2x3_3x4) {
+  std::vector<double> a = {1.0, 2.5, 3.0, 4.0, 5.5, 6.0};
+  std::vector<double> b = {0.5, 1.0, 2.0, 1.5, 2.0, 0.5, 1.0, 3.0, 4.0, 2.5, 0.5, 1.0};
+
+  auto c_expected = MultiplyNaiveDouble(a, b, 2, 3, 4);
+
+  std::vector<double> in_data = {2.0, 3.0, 3.0, 4.0};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + (2 * 4);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], 2.0);
+  EXPECT_DOUBLE_EQ(out_ptr[1], 4.0);
+
+  std::vector<double> c_result(2 * 4);
+  for (int i = 0; i < 2 * 4; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Square5x5_Random) {
+  const int n = 5;
+
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+  std::vector<double> c_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Square20x20_Random) {
+  const int n = 20;
+
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+  std::vector<double> c_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Square32x32_Random) {
+  const int n = 32;
+
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+  std::vector<double> c_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Square128x128_Random) {
+  const int n = 128;
+
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+  std::vector<double> c_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Square128x128_IdentityMatrix) {
+  const int n = 128;
+
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+
+  std::vector<double> e(n * n, 0.0);
+  for (int i = 0; i < n; ++i) {
+    e[(i * n) + i] = 1.0;
+  }
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), e.begin(), e.end());
+
+  std::size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+  std::vector<double> c_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(a.size(), c_result.size());
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    EXPECT_NEAR(a[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Square129x129_Random) {
+  const int n = 129;
+
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+  std::vector<double> c_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Square240x240_Random) {
+  const int n = 240;
+
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + (n * n);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+  std::vector<double> c_result(n * n);
+  for (int i = 0; i < n * n; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, ValidCase) {
+  std::vector<double> input_data = {2.0, 3.0, 3.0, 2.0};
+  input_data.insert(input_data.end(), {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
+  input_data.insert(input_data.end(), {7.0, 8.0, 9.0, 10.0, 11.0, 12.0});
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(input_data.data()));
+  task_data->inputs_count.push_back(input_data.size());
+
+  task_data->outputs.push_back(nullptr);
+  task_data->outputs_count.push_back(0);
+
+  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+
+  task.PreProcessingImpl();
+
+  EXPECT_TRUE(task.ValidationImpl());
+}
+
+TEST(borisov_s_strassen_seq, MismatchCase) {
+  std::vector<double> input_data = {
+      2.0,
+      2.0,
+      3.0,
+      3.0,
+  };
+  input_data.insert(input_data.end(), {1.0, 2.0, 3.0, 4.0});
+  input_data.insert(input_data.end(), {5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0});
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(input_data.data()));
+  task_data->inputs_count.push_back(input_data.size());
+
+  task_data->outputs.push_back(nullptr);
+  task_data->outputs_count.push_back(0);
+
+  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_FALSE(task.ValidationImpl());
+}
+
+TEST(borisov_s_strassen_seq, NotEnoughDataCase) {
+  std::vector<double> input_data = {2.0, 2.0, 2.0, 2.0};
+  input_data.insert(input_data.end(), {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(input_data.data()));
+  task_data->inputs_count.push_back(input_data.size());
+
+  task_data->outputs.push_back(nullptr);
+  task_data->outputs_count.push_back(0);
+
+  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+
+  task.PreProcessingImpl();
+
+  EXPECT_FALSE(task.ValidationImpl());
+}
+
+TEST(borisov_s_strassen_seq, Rectangular16x17_Random) {
+  const int rows_a = 16;
+  const int cols_a = 17;
+  const int cols_b = 18;
+
+  std::vector<double> a = GenerateRandomMatrix(rows_a, cols_a, 7777);
+  std::vector<double> b = GenerateRandomMatrix(cols_a, cols_b, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, rows_a, cols_a, cols_b);
+
+  std::vector<double> in_data = {static_cast<double>(rows_a), static_cast<double>(cols_a), static_cast<double>(cols_a),
+                                 static_cast<double>(cols_b)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + (rows_a * cols_b);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(rows_a));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(cols_b));
+
+  std::vector<double> c_result(rows_a * cols_b);
+  for (int i = 0; i < rows_a * cols_b; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Rectangular19x23_Random) {
+  const int rows_a = 19;
+  const int cols_a = 23;
+  const int cols_b = 21;
+
+  std::vector<double> a = GenerateRandomMatrix(rows_a, cols_a, 7777);
+  std::vector<double> b = GenerateRandomMatrix(cols_a, cols_b, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, rows_a, cols_a, cols_b);
+
+  std::vector<double> in_data = {static_cast<double>(rows_a), static_cast<double>(cols_a), static_cast<double>(cols_a),
+                                 static_cast<double>(cols_b)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + (rows_a * cols_b);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(rows_a));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(cols_b));
+
+  std::vector<double> c_result(rows_a * cols_b);
+  for (int i = 0; i < rows_a * cols_b; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}
+
+TEST(borisov_s_strassen_seq, Rectangular32x64_Random) {
+  const int rows_a = 32;
+  const int cols_a = 64;
+  const int cols_b = 32;
+
+  std::vector<double> a = GenerateRandomMatrix(rows_a, cols_a, 7777);
+  std::vector<double> b = GenerateRandomMatrix(cols_a, cols_b, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, rows_a, cols_a, cols_b);
+
+  std::vector<double> in_data = {static_cast<double>(rows_a), static_cast<double>(cols_a), static_cast<double>(cols_a),
+                                 static_cast<double>(cols_b)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + (rows_a * cols_b);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_stl::SequentialStrassenStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(rows_a));
+  EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(cols_b));
+
+  std::vector<double> c_result(rows_a * cols_b);
+  for (int i = 0; i < rows_a * cols_b; ++i) {
+    c_result[i] = out_ptr[2 + i];
+  }
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
+
+  delete[] out_ptr;
+}

--- a/tasks/stl/borisov_s_strassen/include/ops_stl.hpp
+++ b/tasks/stl/borisov_s_strassen/include/ops_stl.hpp
@@ -7,9 +7,9 @@
 
 namespace borisov_s_strassen_stl {
 
-class SequentialStrassenStl : public ppc::core::Task {
+class ParallelStrassenStl : public ppc::core::Task {
  public:
-  explicit SequentialStrassenStl(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  explicit ParallelStrassenStl(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
 
   bool PreProcessingImpl() override;
   bool ValidationImpl() override;

--- a/tasks/stl/borisov_s_strassen/include/ops_stl.hpp
+++ b/tasks/stl/borisov_s_strassen/include/ops_stl.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace borisov_s_strassen_stl {
+
+class SequentialStrassenStl : public ppc::core::Task {
+ public:
+  explicit SequentialStrassenStl(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<double> input_;
+
+  std::vector<double> output_;
+
+  int rowsA_ = 0;
+  int colsA_ = 0;
+  int rowsB_ = 0;
+  int colsB_ = 0;
+};
+
+}  // namespace borisov_s_strassen_stl

--- a/tasks/stl/borisov_s_strassen/perf_tests/main.cpp
+++ b/tasks/stl/borisov_s_strassen/perf_tests/main.cpp
@@ -25,7 +25,7 @@ void GenerateRandomMatrix(int rows, int cols, std::vector<double>& matrix) {
 
 }  // namespace
 
-TEST(borisov_s_strassen_perf_seq, test_pipeline_run) {
+TEST(borisov_s_strassen_perf_stl, test_pipeline_run) {
   constexpr int kRowsA = 1024;
   constexpr int kColsA = 512;
   constexpr int kRowsB = 512;
@@ -44,13 +44,13 @@ TEST(borisov_s_strassen_perf_seq, test_pipeline_run) {
   size_t output_count = 2 + (kRowsA * kColsB);
   std::vector<double> out(output_count, 0.0);
 
-  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
-  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(in_data.data()));
-  task_data_seq->inputs_count.emplace_back(in_data.size());
-  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
-  task_data_seq->outputs_count.emplace_back(out.size());
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data_stl->inputs_count.emplace_back(in_data.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
 
-  auto test_task_sequential = std::make_shared<borisov_s_strassen_stl::SequentialStrassenStl>(task_data_seq);
+  auto test_task_parallel = std::make_shared<borisov_s_strassen_stl::ParallelStrassenStl>(task_data_stl);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;
@@ -63,12 +63,12 @@ TEST(borisov_s_strassen_perf_seq, test_pipeline_run) {
 
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
 
-  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_parallel);
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 }
 
-TEST(borisov_s_strassen_perf_seq, test_task_run) {
+TEST(borisov_s_strassen_perf_stl, test_task_run) {
   constexpr int kRowsA = 1024;
   constexpr int kColsA = 512;
   constexpr int kRowsB = 512;
@@ -87,13 +87,13 @@ TEST(borisov_s_strassen_perf_seq, test_task_run) {
   size_t output_count = 2 + (kRowsA * kColsB);
   std::vector<double> out(output_count, 0.0);
 
-  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
-  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(in_data.data()));
-  task_data_seq->inputs_count.emplace_back(in_data.size());
-  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
-  task_data_seq->outputs_count.emplace_back(out.size());
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data_stl->inputs_count.emplace_back(in_data.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
 
-  auto test_task_sequential = std::make_shared<borisov_s_strassen_stl::SequentialStrassenStl>(task_data_seq);
+  auto test_task_parallel = std::make_shared<borisov_s_strassen_stl::ParallelStrassenStl>(task_data_stl);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;
@@ -106,7 +106,7 @@ TEST(borisov_s_strassen_perf_seq, test_task_run) {
 
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
 
-  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_parallel);
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 }

--- a/tasks/stl/borisov_s_strassen/perf_tests/main.cpp
+++ b/tasks/stl/borisov_s_strassen/perf_tests/main.cpp
@@ -13,6 +13,21 @@
 
 namespace {
 
+std::vector<double> MultiplyNaiveDouble(const std::vector<double>& a, const std::vector<double>& b, int rows_a,
+                                        int cols_a, int cols_b) {
+  std::vector<double> c(rows_a * cols_b, 0.0);
+  for (int i = 0; i < rows_a; ++i) {
+    for (int j = 0; j < cols_b; ++j) {
+      double sum = 0.0;
+      for (int k = 0; k < cols_a; ++k) {
+        sum += a[(i * cols_a) + k] * b[(k * cols_b) + j];
+      }
+      c[(i * cols_b) + j] = sum;
+    }
+  }
+  return c;
+}
+
 void GenerateRandomMatrix(int rows, int cols, std::vector<double>& matrix) {
   std::random_device rd;
   std::mt19937 rng(rd());
@@ -66,6 +81,14 @@ TEST(borisov_s_strassen_perf_stl, test_pipeline_run) {
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_parallel);
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  std::vector<double> c_expected = MultiplyNaiveDouble(a, b, kRowsA, kColsA, kColsB);
+  std::vector<double> c_result(out.begin() + 2, out.end());
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    ASSERT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
 }
 
 TEST(borisov_s_strassen_perf_stl, test_task_run) {
@@ -109,4 +132,12 @@ TEST(borisov_s_strassen_perf_stl, test_task_run) {
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_parallel);
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  std::vector<double> c_expected = MultiplyNaiveDouble(a, b, kRowsA, kColsA, kColsB);
+  std::vector<double> c_result(out.begin() + 2, out.end());
+
+  ASSERT_EQ(c_expected.size(), c_result.size());
+  for (std::size_t i = 0; i < c_expected.size(); ++i) {
+    ASSERT_NEAR(c_expected[i], c_result[i], 1e-9);
+  }
 }

--- a/tasks/stl/borisov_s_strassen/perf_tests/main.cpp
+++ b/tasks/stl/borisov_s_strassen/perf_tests/main.cpp
@@ -87,7 +87,7 @@ TEST(borisov_s_strassen_perf_stl, test_pipeline_run) {
 
   ASSERT_EQ(c_expected.size(), c_result.size());
   for (std::size_t i = 0; i < c_expected.size(); ++i) {
-    ASSERT_NEAR(c_expected[i], c_result[i], 1e-9);
+    ASSERT_NEAR(c_expected[i], c_result[i], 1e-8);
   }
 }
 
@@ -138,6 +138,6 @@ TEST(borisov_s_strassen_perf_stl, test_task_run) {
 
   ASSERT_EQ(c_expected.size(), c_result.size());
   for (std::size_t i = 0; i < c_expected.size(); ++i) {
-    ASSERT_NEAR(c_expected[i], c_result[i], 1e-9);
+    ASSERT_NEAR(c_expected[i], c_result[i], 1e-8);
   }
 }

--- a/tasks/stl/borisov_s_strassen/perf_tests/main.cpp
+++ b/tasks/stl/borisov_s_strassen/perf_tests/main.cpp
@@ -1,0 +1,112 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "stl/borisov_s_strassen/include/ops_stl.hpp"
+
+namespace {
+
+void GenerateRandomMatrix(int rows, int cols, std::vector<double>& matrix) {
+  std::random_device rd;
+  std::mt19937 rng(rd());
+  std::uniform_real_distribution<double> dist(-50.0, 50.0);
+  matrix.resize(rows * cols);
+  for (auto& value : matrix) {
+    value = dist(rng);
+  }
+}
+
+}  // namespace
+
+TEST(borisov_s_strassen_perf_seq, test_pipeline_run) {
+  constexpr int kRowsA = 1024;
+  constexpr int kColsA = 512;
+  constexpr int kRowsB = 512;
+  constexpr int kColsB = 1024;
+
+  std::vector<double> a;
+  std::vector<double> b;
+  GenerateRandomMatrix(kRowsA, kColsA, a);
+  GenerateRandomMatrix(kRowsB, kColsB, b);
+
+  std::vector<double> in_data = {static_cast<double>(kRowsA), static_cast<double>(kColsA), static_cast<double>(kRowsB),
+                                 static_cast<double>(kColsB)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  size_t output_count = 2 + (kRowsA * kColsB);
+  std::vector<double> out(output_count, 0.0);
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data_seq->inputs_count.emplace_back(in_data.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  auto test_task_sequential = std::make_shared<borisov_s_strassen_stl::SequentialStrassenStl>(task_data_seq);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}
+
+TEST(borisov_s_strassen_perf_seq, test_task_run) {
+  constexpr int kRowsA = 1024;
+  constexpr int kColsA = 512;
+  constexpr int kRowsB = 512;
+  constexpr int kColsB = 1024;
+
+  std::vector<double> a;
+  std::vector<double> b;
+  GenerateRandomMatrix(kRowsA, kColsA, a);
+  GenerateRandomMatrix(kRowsB, kColsB, b);
+
+  std::vector<double> in_data = {static_cast<double>(kRowsA), static_cast<double>(kColsA), static_cast<double>(kRowsB),
+                                 static_cast<double>(kColsB)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  size_t output_count = 2 + (kRowsA * kColsB);
+  std::vector<double> out(output_count, 0.0);
+
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+  task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data_seq->inputs_count.emplace_back(in_data.size());
+  task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_seq->outputs_count.emplace_back(out.size());
+
+  auto test_task_sequential = std::make_shared<borisov_s_strassen_stl::SequentialStrassenStl>(task_data_seq);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+}

--- a/tasks/stl/borisov_s_strassen/src/ops_stl.cpp
+++ b/tasks/stl/borisov_s_strassen/src/ops_stl.cpp
@@ -26,7 +26,7 @@ std::vector<double> MultiplyNaive(const std::vector<double> &a, const std::vecto
 std::vector<double> AddMatr(const std::vector<double> &a, const std::vector<double> &b, int n) {
   std::vector<double> c(n * n);
   const int size = n * n;
-  const int thread_threshold = 512 * 512;
+  const int thread_threshold = 256 * 256;
 
   if (size < thread_threshold) {
     for (int i = 0; i < size; ++i) {
@@ -98,18 +98,14 @@ std::vector<double> SubMatr(const std::vector<double> &a, const std::vector<doub
 std::vector<double> SubMatrix(const std::vector<double> &m, int n, int row, int col, int size) {
   std::vector<double> sub(size * size);
   for (int i = 0; i < size; ++i) {
-    for (int j = 0; j < size; ++j) {
-      sub[(i * size) + j] = m[((row + i) * n) + (col + j)];
-    }
+    std::copy(m.begin() + (row + i) * n + col, m.begin() + (row + i) * n + col + size, sub.begin() + i * size);
   }
   return sub;
 }
 
 void SetSubMatrix(std::vector<double> &m, const std::vector<double> &sub, int n, int row, int col, int size) {
   for (int i = 0; i < size; ++i) {
-    for (int j = 0; j < size; ++j) {
-      m[((row + i) * n) + (col + j)] = sub[(i * size) + j];
-    }
+    std::copy(sub.begin() + i * size, sub.begin() + (i + 1) * size, m.begin() + (row + i) * n + col);
   }
 }
 
@@ -190,7 +186,7 @@ int NextPowerOfTwo(int n) {
 
 }  // namespace
 
-bool SequentialStrassenStl::PreProcessingImpl() {
+bool ParallelStrassenStl::PreProcessingImpl() {
   size_t input_count = task_data->inputs_count[0];
   auto *double_ptr = reinterpret_cast<double *>(task_data->inputs[0]);
   input_.assign(double_ptr, double_ptr + input_count);
@@ -210,7 +206,7 @@ bool SequentialStrassenStl::PreProcessingImpl() {
   return true;
 }
 
-bool SequentialStrassenStl::ValidationImpl() {
+bool ParallelStrassenStl::ValidationImpl() {
   if (colsA_ != rowsB_) {
     return false;
   }
@@ -220,7 +216,7 @@ bool SequentialStrassenStl::ValidationImpl() {
   return input_.size() >= needed;
 }
 
-bool SequentialStrassenStl::RunImpl() {
+bool ParallelStrassenStl::RunImpl() {
   size_t offset = 4;
   std::vector<double> a(rowsA_ * colsA_);
   for (int i = 0; i < rowsA_ * colsA_; ++i) {
@@ -268,7 +264,7 @@ bool SequentialStrassenStl::RunImpl() {
   return true;
 }
 
-bool SequentialStrassenStl::PostProcessingImpl() {
+bool ParallelStrassenStl::PostProcessingImpl() {
   auto *out_ptr = reinterpret_cast<double *>(task_data->outputs[0]);
   for (size_t i = 0; i < output_.size(); ++i) {
     out_ptr[i] = output_[i];

--- a/tasks/stl/borisov_s_strassen/src/ops_stl.cpp
+++ b/tasks/stl/borisov_s_strassen/src/ops_stl.cpp
@@ -27,73 +27,17 @@ std::vector<double> MultiplyNaive(const std::vector<double> &a, const std::vecto
 
 std::vector<double> AddMatr(const std::vector<double> &a, const std::vector<double> &b, int n) {
   std::vector<double> c(n * n);
-  const int size = n * n;
-  const int thread_threshold = 256 * 256;
-
-  if (size < thread_threshold) {
-    for (int i = 0; i < size; ++i) {
-      c[i] = a[i] + b[i];
-    }
-  } else {
-    unsigned int hw_threads = ppc::util::GetPPCNumThreads();
-    const int num_threads = static_cast<int>(hw_threads > 0 ? hw_threads : 1);
-    std::vector<std::thread> threads;
-    auto worker = [&](int start, int end) {
-      for (int i = start; i < end; ++i) {
-        c[i] = a[i] + b[i];
-      }
-    };
-
-    int chunk = size / num_threads;
-    int remainder = size % num_threads;
-    int start = 0;
-    for (int t = 0; t < num_threads; ++t) {
-      int end = start + chunk + (t < remainder ? 1 : 0);
-      threads.emplace_back(worker, start, end);
-      start = end;
-    }
-
-    for (auto &th : threads) {
-      th.join();
-    }
+  for (int i = 0; i < n * n; ++i) {
+    c[i] = a[i] + b[i];
   }
-
   return c;
 }
 
 std::vector<double> SubMatr(const std::vector<double> &a, const std::vector<double> &b, int n) {
   std::vector<double> c(n * n);
-  const int size = n * n;
-  const int thread_threshold = 512 * 512;
-
-  if (size < thread_threshold) {
-    for (int i = 0; i < size; ++i) {
-      c[i] = a[i] - b[i];
-    }
-  } else {
-    unsigned int hw_threads = ppc::util::GetPPCNumThreads();
-    const int num_threads = static_cast<int>(hw_threads > 0 ? hw_threads : 1);
-    std::vector<std::thread> threads;
-    auto worker = [&](int start, int end) {
-      for (int i = start; i < end; ++i) {
-        c[i] = a[i] - b[i];
-      }
-    };
-
-    int chunk = size / num_threads;
-    int remainder = size % num_threads;
-    int start = 0;
-    for (int t = 0; t < num_threads; ++t) {
-      int end = start + chunk + (t < remainder ? 1 : 0);
-      threads.emplace_back(worker, start, end);
-      start = end;
-    }
-
-    for (auto &th : threads) {
-      th.join();
-    }
+  for (int i = 0; i < n * n; ++i) {
+    c[i] = a[i] - b[i];
   }
-
   return c;
 }
 

--- a/tasks/stl/borisov_s_strassen/src/ops_stl.cpp
+++ b/tasks/stl/borisov_s_strassen/src/ops_stl.cpp
@@ -5,6 +5,8 @@
 #include <thread>
 #include <vector>
 
+#include "core/util/include/util.hpp"
+
 namespace borisov_s_strassen_stl {
 
 namespace {
@@ -33,7 +35,7 @@ std::vector<double> AddMatr(const std::vector<double> &a, const std::vector<doub
       c[i] = a[i] + b[i];
     }
   } else {
-    unsigned int hw_threads = std::thread::hardware_concurrency();
+    unsigned int hw_threads = ppc::util::GetPPCNumThreads();
     const int num_threads = static_cast<int>(hw_threads > 0 ? hw_threads : 1);
     std::vector<std::thread> threads;
     auto worker = [&](int start, int end) {
@@ -69,7 +71,7 @@ std::vector<double> SubMatr(const std::vector<double> &a, const std::vector<doub
       c[i] = a[i] - b[i];
     }
   } else {
-    unsigned int hw_threads = std::thread::hardware_concurrency();
+    unsigned int hw_threads = ppc::util::GetPPCNumThreads();
     const int num_threads = static_cast<int>(hw_threads > 0 ? hw_threads : 1);
     std::vector<std::thread> threads;
     auto worker = [&](int start, int end) {

--- a/tasks/stl/borisov_s_strassen/src/ops_stl.cpp
+++ b/tasks/stl/borisov_s_strassen/src/ops_stl.cpp
@@ -1,0 +1,279 @@
+#include "stl/borisov_s_strassen/include/ops_stl.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <thread>
+#include <vector>
+
+namespace borisov_s_strassen_stl {
+
+namespace {
+
+std::vector<double> MultiplyNaive(const std::vector<double> &a, const std::vector<double> &b, int n) {
+  std::vector<double> c(n * n, 0.0);
+  for (int i = 0; i < n; ++i) {
+    for (int j = 0; j < n; ++j) {
+      double sum = 0.0;
+      for (int k = 0; k < n; ++k) {
+        sum += a[(i * n) + k] * b[(k * n) + j];
+      }
+      c[(i * n) + j] = sum;
+    }
+  }
+  return c;
+}
+
+std::vector<double> AddMatr(const std::vector<double> &a, const std::vector<double> &b, int n) {
+  std::vector<double> c(n * n);
+  const int size = n * n;
+  const int thread_threshold = 512 * 512;
+
+  if (size < thread_threshold) {
+    for (int i = 0; i < size; ++i) {
+      c[i] = a[i] + b[i];
+    }
+  } else {
+    unsigned int hw_threads = std::thread::hardware_concurrency();
+    const int num_threads = static_cast<int>(hw_threads > 0 ? hw_threads : 1);
+    std::vector<std::thread> threads;
+    auto worker = [&](int start, int end) {
+      for (int i = start; i < end; ++i) {
+        c[i] = a[i] + b[i];
+      }
+    };
+
+    int chunk = size / num_threads;
+    int remainder = size % num_threads;
+    int start = 0;
+    for (int t = 0; t < num_threads; ++t) {
+      int end = start + chunk + (t < remainder ? 1 : 0);
+      threads.emplace_back(worker, start, end);
+      start = end;
+    }
+
+    for (auto &th : threads) {
+      th.join();
+    }
+  }
+
+  return c;
+}
+
+std::vector<double> SubMatr(const std::vector<double> &a, const std::vector<double> &b, int n) {
+  std::vector<double> c(n * n);
+  const int size = n * n;
+  const int thread_threshold = 512 * 512;
+
+  if (size < thread_threshold) {
+    for (int i = 0; i < size; ++i) {
+      c[i] = a[i] - b[i];
+    }
+  } else {
+    unsigned int hw_threads = std::thread::hardware_concurrency();
+    const int num_threads = static_cast<int>(hw_threads > 0 ? hw_threads : 1);
+    std::vector<std::thread> threads;
+    auto worker = [&](int start, int end) {
+      for (int i = start; i < end; ++i) {
+        c[i] = a[i] - b[i];
+      }
+    };
+
+    int chunk = size / num_threads;
+    int remainder = size % num_threads;
+    int start = 0;
+    for (int t = 0; t < num_threads; ++t) {
+      int end = start + chunk + (t < remainder ? 1 : 0);
+      threads.emplace_back(worker, start, end);
+      start = end;
+    }
+
+    for (auto &th : threads) {
+      th.join();
+    }
+  }
+
+  return c;
+}
+
+std::vector<double> SubMatrix(const std::vector<double> &m, int n, int row, int col, int size) {
+  std::vector<double> sub(size * size);
+  for (int i = 0; i < size; ++i) {
+    for (int j = 0; j < size; ++j) {
+      sub[(i * size) + j] = m[((row + i) * n) + (col + j)];
+    }
+  }
+  return sub;
+}
+
+void SetSubMatrix(std::vector<double> &m, const std::vector<double> &sub, int n, int row, int col, int size) {
+  for (int i = 0; i < size; ++i) {
+    for (int j = 0; j < size; ++j) {
+      m[((row + i) * n) + (col + j)] = sub[(i * size) + j];
+    }
+  }
+}
+
+std::vector<double> StrassenRecursive(const std::vector<double> &a, const std::vector<double> &b, int n,
+                                      int depth = 0) {
+  const int parallel_depth = 2;
+
+  if (n <= 64) {
+    return MultiplyNaive(a, b, n);
+  }
+  int k = n / 2;
+  auto a11 = SubMatrix(a, n, 0, 0, k);
+  auto a12 = SubMatrix(a, n, 0, k, k);
+  auto a21 = SubMatrix(a, n, k, 0, k);
+  auto a22 = SubMatrix(a, n, k, k, k);
+
+  auto b11 = SubMatrix(b, n, 0, 0, k);
+  auto b12 = SubMatrix(b, n, 0, k, k);
+  auto b21 = SubMatrix(b, n, k, 0, k);
+  auto b22 = SubMatrix(b, n, k, k, k);
+
+  std::vector<double> m1;
+  std::vector<double> m2;
+  std::vector<double> m3;
+  std::vector<double> m4;
+  std::vector<double> m5;
+  std::vector<double> m6;
+  std::vector<double> m7;
+
+  if (depth < parallel_depth) {
+    std::thread t1([&] { m1 = StrassenRecursive(AddMatr(a11, a22, k), AddMatr(b11, b22, k), k, depth + 1); });
+    std::thread t2([&] { m2 = StrassenRecursive(AddMatr(a21, a22, k), b11, k, depth + 1); });
+    std::thread t3([&] { m3 = StrassenRecursive(a11, SubMatr(b12, b22, k), k, depth + 1); });
+    std::thread t4([&] { m4 = StrassenRecursive(a22, SubMatr(b21, b11, k), k, depth + 1); });
+    std::thread t5([&] { m5 = StrassenRecursive(AddMatr(a11, a12, k), b22, k, depth + 1); });
+    std::thread t6([&] { m6 = StrassenRecursive(SubMatr(a21, a11, k), AddMatr(b11, b12, k), k, depth + 1); });
+    std::thread t7([&] { m7 = StrassenRecursive(SubMatr(a12, a22, k), AddMatr(b21, b22, k), k, depth + 1); });
+
+    t1.join();
+    t2.join();
+    t3.join();
+    t4.join();
+    t5.join();
+    t6.join();
+    t7.join();
+  } else {
+    m1 = StrassenRecursive(AddMatr(a11, a22, k), AddMatr(b11, b22, k), k, depth + 1);
+    m2 = StrassenRecursive(AddMatr(a21, a22, k), b11, k, depth + 1);
+    m3 = StrassenRecursive(a11, SubMatr(b12, b22, k), k, depth + 1);
+    m4 = StrassenRecursive(a22, SubMatr(b21, b11, k), k, depth + 1);
+    m5 = StrassenRecursive(AddMatr(a11, a12, k), b22, k, depth + 1);
+    m6 = StrassenRecursive(SubMatr(a21, a11, k), AddMatr(b11, b12, k), k, depth + 1);
+    m7 = StrassenRecursive(SubMatr(a12, a22, k), AddMatr(b21, b22, k), k, depth + 1);
+  }
+
+  std::vector<double> c(n * n, 0.0);
+
+  auto c11 = AddMatr(SubMatr(AddMatr(m1, m4, k), m5, k), m7, k);
+  auto c12 = AddMatr(m3, m5, k);
+  auto c21 = AddMatr(m2, m4, k);
+  auto c22 = AddMatr(AddMatr(SubMatr(m1, m2, k), m3, k), m6, k);
+
+  SetSubMatrix(c, c11, n, 0, 0, k);
+  SetSubMatrix(c, c12, n, 0, k, k);
+  SetSubMatrix(c, c21, n, k, 0, k);
+  SetSubMatrix(c, c22, n, k, k, k);
+
+  return c;
+}
+
+int NextPowerOfTwo(int n) {
+  int r = 1;
+  while (r < n) {
+    r <<= 1;
+  }
+  return r;
+}
+
+}  // namespace
+
+bool SequentialStrassenStl::PreProcessingImpl() {
+  size_t input_count = task_data->inputs_count[0];
+  auto *double_ptr = reinterpret_cast<double *>(task_data->inputs[0]);
+  input_.assign(double_ptr, double_ptr + input_count);
+
+  size_t output_count = task_data->outputs_count[0];
+  output_.resize(output_count, 0.0);
+
+  if (input_.size() < 4) {
+    return false;
+  }
+
+  rowsA_ = static_cast<int>(input_[0]);
+  colsA_ = static_cast<int>(input_[1]);
+  rowsB_ = static_cast<int>(input_[2]);
+  colsB_ = static_cast<int>(input_[3]);
+
+  return true;
+}
+
+bool SequentialStrassenStl::ValidationImpl() {
+  if (colsA_ != rowsB_) {
+    return false;
+  }
+
+  size_t needed = 4 + (static_cast<size_t>(rowsA_) * colsA_) + (static_cast<size_t>(rowsB_) * colsB_);
+
+  return input_.size() >= needed;
+}
+
+bool SequentialStrassenStl::RunImpl() {
+  size_t offset = 4;
+  std::vector<double> a(rowsA_ * colsA_);
+  for (int i = 0; i < rowsA_ * colsA_; ++i) {
+    a[i] = input_[offset + i];
+  }
+  offset += static_cast<size_t>(rowsA_ * colsA_);
+
+  std::vector<double> b(rowsB_ * colsB_);
+  for (int i = 0; i < rowsB_ * colsB_; ++i) {
+    b[i] = input_[offset + i];
+  }
+
+  int max_dim = std::max({rowsA_, colsA_, colsB_});
+  int m = NextPowerOfTwo(max_dim);
+
+  std::vector<double> a_exp(m * m, 0.0);
+  std::vector<double> b_exp(m * m, 0.0);
+
+  for (int i = 0; i < rowsA_; ++i) {
+    for (int j = 0; j < colsA_; ++j) {
+      a_exp[(i * m) + j] = a[(i * colsA_) + j];
+    }
+  }
+  for (int i = 0; i < rowsB_; ++i) {
+    for (int j = 0; j < colsB_; ++j) {
+      b_exp[(i * m) + j] = b[(i * colsB_) + j];
+    }
+  }
+
+  auto c_exp = StrassenRecursive(a_exp, b_exp, m);
+
+  std::vector<double> c(rowsA_ * colsB_, 0.0);
+  for (int i = 0; i < rowsA_; ++i) {
+    for (int j = 0; j < colsB_; ++j) {
+      c[(i * colsB_) + j] = c_exp[(i * m) + j];
+    }
+  }
+
+  output_[0] = static_cast<double>(rowsA_);
+  output_[1] = static_cast<double>(colsB_);
+  for (int i = 0; i < rowsA_ * colsB_; ++i) {
+    output_[2 + i] = c[i];
+  }
+
+  return true;
+}
+
+bool SequentialStrassenStl::PostProcessingImpl() {
+  auto *out_ptr = reinterpret_cast<double *>(task_data->outputs[0]);
+  for (size_t i = 0; i < output_.size(); ++i) {
+    out_ptr[i] = output_[i];
+  }
+  return true;
+}
+
+}  // namespace borisov_s_strassen_stl

--- a/tasks/stl/borisov_s_strassen/src/ops_stl.cpp
+++ b/tasks/stl/borisov_s_strassen/src/ops_stl.cpp
@@ -5,8 +5,6 @@
 #include <thread>
 #include <vector>
 
-#include "core/util/include/util.hpp"
-
 namespace borisov_s_strassen_stl {
 
 namespace {


### PR DESCRIPTION
Реализована STL-версия алгоритма Штрассена для умножения плотных матриц с элементами типа double. Аналогично другим реализациям, поддерживается работа с прямоугольными матрицами: если размерность не является степенью двойки, исходные матрицы дополняются нулями до ближайшей степени двойки. При малых размерностях (n ≤ 64) используется классическое умножение со сложностью O(n³), тогда как при больших — применяется рекурсивный алгоритм Штрассена со сложностью O(n^log₂7) ≈ O(n^2.8074), что обеспечивает ускорение на крупных входных данных.

В STL-версии параллелизация реализована с использованием std::thread. На каждой рекурсивной итерации алгоритма Штрассена одновременно вычисляются семь независимых подматриц (M1..M7), каждая из которых запускается в отдельном потоке при глубине рекурсии меньше заданного порога (depth ≤ 2). Это позволяет избежать чрезмерного создания потоков и контролировать накладные расходы.