### PR TITLE
Сарафанов Максим. Вариант 1. Технология MPI + OMP. Умножение плотных матриц. Элементы типа double. Блочная схема, алгоритм Кэннона

### DIFF
--- a/tasks/all/sarafanov_m_CanonMatMul/func_tests/main.cpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/func_tests/main.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <boost/mpi/communicator.hpp>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -8,15 +9,15 @@
 #include <random>
 #include <vector>
 
-#include "core/task/include/task.hpp"
 #include "all/sarafanov_m_CanonMatMul/include/ops_all.hpp"
+#include "core/task/include/task.hpp"
 
 namespace {
 std::vector<double> GenerateRandomData(int size) {
   std::vector<double> matrix(size);
   std::random_device dev;
   std::mt19937 gen(dev());
-  std::uniform_int_distribution<> dist(-500, 10000);
+  std::uniform_int_distribution<> dist(-10000, 10000);
   for (auto i = 0; i < size; ++i) {
     matrix[i] = static_cast<double>(dist(gen));
   }
@@ -37,210 +38,238 @@ std::vector<double> GenerateSingleMatrix(int size) {
 }
 }  // namespace
 
-TEST(sarafanov_m_canon_mat_mul_seq, test_clear_matrix) {
-  constexpr size_t kCount = 0;
-  constexpr double kInaccuracy = 0.001;
-  std::vector<double> a_matrix;
-  std::vector<double> b_matrix;
-  std::vector<double> test_data;
-  std::vector<double> out(kCount, 0);
-  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
-  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
-  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(b_matrix.data()));
-  for (int i = 0; i < 4; ++i) {
-    task_data_stl->inputs_count.emplace_back(kCount);
-  }
-  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data_stl->outputs_count.emplace_back(kCount);
+ TEST(sarafanov_m_canon_mat_mul_all, test_clear_matrix) {
+   boost::mpi::communicator world;
+   constexpr size_t kCount = 0;
+   constexpr double kInaccuracy = 0.001;
+   std::vector<double> a_matrix;
+   std::vector<double> b_matrix;
+   std::vector<double> test_data;
+   std::vector<double> out(kCount, 0);
+   auto task_data_all = std::make_shared<ppc::core::TaskData>();
+   if (world.rank() == 0) {
+     task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
+     task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(b_matrix.data()));
+     for (int i = 0; i < 4; ++i) {
+       task_data_all->inputs_count.emplace_back(kCount);
+     }
+     task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+     task_data_all->outputs_count.emplace_back(kCount);
+   }
+   sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_all(task_data_all);
+   ASSERT_EQ(test_task_all.Validation(), true);
+   test_task_all.PreProcessing();
+   test_task_all.Run();
+   test_task_all.PostProcessing();
+   for (size_t i = 0; i < kCount; ++i) {
+     EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
+   }
+ }
 
-  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_stl(task_data_stl);
-  ASSERT_EQ(test_task_stl.Validation(), true);
-  test_task_stl.PreProcessing();
-  test_task_stl.Run();
-  test_task_stl.PostProcessing();
-  for (size_t i = 0; i < kCount; ++i) {
-    EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
-  }
-}
-
-TEST(sarafanov_m_canon_mat_mul_all, test_1x1_matrix) {
-  constexpr size_t kCount = 1;
-  constexpr double kInaccuracy = 0.001;
-  std::vector<double> a_matrix{18.0};
-  std::vector<double> b_matrix{18.0};
-  std::vector<double> test_data{324.0};
-  std::vector<double> out(kCount, 0);
-  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
-  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
-  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(b_matrix.data()));
-  for (int i = 0; i < 4; ++i) {
-    task_data_stl->inputs_count.emplace_back(kCount);
-  }
-  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data_stl->outputs_count.emplace_back(kCount);
-
-  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_stl(task_data_stl);
-  ASSERT_EQ(test_task_stl.Validation(), true);
-  test_task_stl.PreProcessing();
-  test_task_stl.Run();
-  test_task_stl.PostProcessing();
-  for (size_t i = 0; i < kCount; ++i) {
-    EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
-  }
-}
+ TEST(sarafanov_m_canon_mat_mul_all, test_1x1_matrix) {
+   boost::mpi::communicator world;
+   constexpr size_t kCount = 1;
+   constexpr double kInaccuracy = 0.001;
+   std::vector<double> a_matrix{18.0};
+   std::vector<double> b_matrix{18.0};
+   std::vector<double> test_data{324.0};
+   std::vector<double> out(kCount, 0);
+   auto task_data_all = std::make_shared<ppc::core::TaskData>();
+   if (world.rank() == 0) {
+     task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
+     task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(b_matrix.data()));
+     for (int i = 0; i < 4; ++i) {
+       task_data_all->inputs_count.emplace_back(kCount);
+     }
+     task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+     task_data_all->outputs_count.emplace_back(kCount);
+   }
+   sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_all(task_data_all);
+   ASSERT_EQ(test_task_all.Validation(), true);
+   test_task_all.PreProcessing();
+   test_task_all.Run();
+   test_task_all.PostProcessing();
+   for (size_t i = 0; i < kCount; ++i) {
+     EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
+   }
+ }
 
 TEST(sarafanov_m_canon_mat_mul_all, test_2x2_matrix) {
+  boost::mpi::communicator world;
   constexpr size_t kCount = 2;
   constexpr double kInaccuracy = 0.001;
   std::vector<double> a_matrix{5.0, 6.0, 6.0, 5.0};
   std::vector<double> b_matrix{10.0, 2.0, 2.0, 10.0};
-  std::vector<double> test_data{62.0, 70.0, 70.0, 62.0};
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
   std::vector<double> out(kCount * kCount, 0);
-  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
-  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
-  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(b_matrix.data()));
-  for (int i = 0; i < 4; ++i) {
-    task_data_stl->inputs_count.emplace_back(kCount);
+  if (world.rank() == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(b_matrix.data()));
+    for (int i = 0; i < 4; ++i) {
+      task_data_all->inputs_count.emplace_back(kCount);
+    }
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
   }
-  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data_stl->outputs_count.emplace_back(out.size());
-
-  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_stl(task_data_stl);
-  ASSERT_EQ(test_task_stl.Validation(), true);
-  test_task_stl.PreProcessing();
-  test_task_stl.Run();
-  test_task_stl.PostProcessing();
-  for (size_t i = 0; i < kCount * kCount; ++i) {
-    EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
+  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_all(task_data_all);
+  ASSERT_EQ(test_task_all.Validation(), true);
+  test_task_all.PreProcessing();
+  test_task_all.Run();
+  test_task_all.PostProcessing();
+  if (world.rank() == 0) {
+    std::vector<double> test_data{62.0, 70.0, 70.0, 62.0};
+    for (size_t i = 0; i < kCount * kCount; ++i) {
+      EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
+    }
   }
 }
 
-TEST(sarafanov_m_canon_mat_mul_all, test_3x3_matrix) {
-  constexpr size_t kCount = 3;
-  constexpr double kInaccuracy = 0.001;
-  std::vector<double> a_matrix{1.0, 4.0, 8.0, 5.0, 6.0, 2.0, 2.0, 7.0, 7.0};
-  std::vector<double> b_matrix{9.0, 1.0, 10.0, 12.0, 5.0, 2.0, 9.0, 7.0, 1.0};
-  std::vector<double> test_data{129.0, 77.0, 26.0, 135.0, 49.0, 64.0, 165.0, 86.0, 41.0};
-  std::vector<double> out(kCount * kCount, 0);
-  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
-  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
-  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(b_matrix.data()));
-  for (int i = 0; i < 4; ++i) {
-    task_data_stl->inputs_count.emplace_back(kCount);
-  }
-  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data_stl->outputs_count.emplace_back(out.size());
-
-  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_stl(task_data_stl);
-  ASSERT_EQ(test_task_stl.Validation(), true);
-  test_task_stl.PreProcessing();
-  test_task_stl.Run();
-  test_task_stl.PostProcessing();
-  for (size_t i = 0; i < kCount * kCount; ++i) {
-    EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
-  }
-}
+ TEST(sarafanov_m_canon_mat_mul_all, test_3x3_matrix) {
+   boost::mpi::communicator world;
+   constexpr size_t kCount = 3;
+   constexpr double kInaccuracy = 0.001;
+   std::vector<double> a_matrix{1.0, 4.0, 8.0, 5.0, 6.0, 2.0, 2.0, 7.0, 7.0};
+   std::vector<double> b_matrix{9.0, 1.0, 10.0, 12.0, 5.0, 2.0, 9.0, 7.0, 1.0};
+   std::vector<double> test_data{129.0, 77.0, 26.0, 135.0, 49.0, 64.0, 165.0, 86.0, 41.0};
+   std::vector<double> out(kCount * kCount, 0);
+   auto task_data_all = std::make_shared<ppc::core::TaskData>();
+   if (world.rank() == 0) {
+     task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
+     task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(b_matrix.data()));
+     for (int i = 0; i < 4; ++i) {
+       task_data_all->inputs_count.emplace_back(kCount);
+     }
+     task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+     task_data_all->outputs_count.emplace_back(out.size());
+   }
+   sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_all(task_data_all);
+   ASSERT_EQ(test_task_all.Validation(), true);
+   test_task_all.PreProcessing();
+   test_task_all.Run();
+   test_task_all.PostProcessing();
+   if (world.rank() == 0) {
+     for (size_t i = 0; i < kCount * kCount; ++i) {
+       EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
+     }
+   }
+ }
 
 TEST(sarafanov_m_canon_mat_mul_all, test_random_5x5_matrix) {
+  boost::mpi::communicator world;
   constexpr size_t kCount = 5;
   constexpr double kInaccuracy = 0.001;
   auto a_matrix = GenerateRandomData(static_cast<int>(kCount * kCount));
   auto single_matrix = GenerateSingleMatrix(static_cast<int>(kCount * kCount));
   std::vector<double> out(kCount * kCount, 0);
-  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
-  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
-  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(single_matrix.data()));
-  for (int i = 0; i < 4; ++i) {
-    task_data_stl->inputs_count.emplace_back(kCount);
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(single_matrix.data()));
+    for (int i = 0; i < 4; ++i) {
+      task_data_all->inputs_count.emplace_back(kCount);
+    }
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
   }
-  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data_stl->outputs_count.emplace_back(out.size());
-
-  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_stl(task_data_stl);
-  ASSERT_EQ(test_task_stl.Validation(), true);
-  test_task_stl.PreProcessing();
-  test_task_stl.Run();
-  test_task_stl.PostProcessing();
-  for (size_t i = 0; i < kCount * kCount; ++i) {
-    EXPECT_NEAR(out[i], a_matrix[i], kInaccuracy);
+  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_all(task_data_all);
+  ASSERT_EQ(test_task_all.Validation(), true);
+  test_task_all.PreProcessing();
+  test_task_all.Run();
+  test_task_all.PostProcessing();
+  if (world.rank() == 0) {
+    for (size_t i = 0; i < kCount * kCount; ++i) {
+      EXPECT_NEAR(out[i], a_matrix[i], kInaccuracy);
+    }
   }
 }
 
 TEST(sarafanov_m_canon_mat_mul_all, test_random_30x30_matrix) {
+  boost::mpi::communicator world;
   constexpr size_t kCount = 30;
   constexpr double kInaccuracy = 0.001;
   auto a_matrix = GenerateRandomData(static_cast<int>(kCount * kCount));
   auto single_matrix = GenerateSingleMatrix(static_cast<int>(kCount * kCount));
   std::vector<double> out(kCount * kCount, 0);
-  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
-  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
-  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(single_matrix.data()));
-  for (int i = 0; i < 4; ++i) {
-    task_data_stl->inputs_count.emplace_back(kCount);
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(single_matrix.data()));
+    for (int i = 0; i < 4; ++i) {
+      task_data_all->inputs_count.emplace_back(kCount);
+    }
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
   }
-  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data_stl->outputs_count.emplace_back(out.size());
-
-  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_stl(task_data_stl);
-  ASSERT_EQ(test_task_stl.Validation(), true);
-  test_task_stl.PreProcessing();
-  test_task_stl.Run();
-  test_task_stl.PostProcessing();
-  for (size_t i = 0; i < kCount * kCount; ++i) {
-    EXPECT_NEAR(out[i], a_matrix[i], kInaccuracy);
+  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_all(task_data_all);
+  ASSERT_EQ(test_task_all.Validation(), true);
+  test_task_all.PreProcessing();
+  test_task_all.Run();
+  test_task_all.PostProcessing();
+  if (world.rank() == 0) {
+    for (size_t i = 0; i < kCount * kCount; ++i) {
+      EXPECT_NEAR(out[i], a_matrix[i], kInaccuracy);
+    }
   }
 }
 
 TEST(sarafanov_m_canon_mat_mul_all, test_3x2_matrix) {
+  boost::mpi::communicator world;
   constexpr double kInaccuracy = 0.001;
   std::vector<double> a_matrix{1.0, 4.0, 8.0, 5.0, 6.0, 2.0};
   std::vector<double> b_matrix{9.0, 1.0, 10.0, 12.0, 5.0, 2.0};
   std::vector<double> test_data{57.0, 21.0, 18.0, 132.0, 33.0, 90.0, 78.0, 16.0, 64.0};
   std::vector<double> out(9, 0);
-  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
-  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
-  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(b_matrix.data()));
-  task_data_stl->inputs_count.emplace_back(3);
-  task_data_stl->inputs_count.emplace_back(2);
-  task_data_stl->inputs_count.emplace_back(2);
-  task_data_stl->inputs_count.emplace_back(3);
-  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data_stl->outputs_count.emplace_back(9);
-
-  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_stl(task_data_stl);
-  ASSERT_EQ(test_task_stl.Validation(), true);
-  test_task_stl.PreProcessing();
-  test_task_stl.Run();
-  test_task_stl.PostProcessing();
-  for (size_t i = 0; i < out.size(); ++i) {
-    EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(b_matrix.data()));
+    task_data_all->inputs_count.emplace_back(3);
+    task_data_all->inputs_count.emplace_back(2);
+    task_data_all->inputs_count.emplace_back(2);
+    task_data_all->inputs_count.emplace_back(3);
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(9);
+  }
+  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_all(task_data_all);
+  ASSERT_EQ(test_task_all.Validation(), true);
+  test_task_all.PreProcessing();
+  test_task_all.Run();
+  test_task_all.PostProcessing();
+  if (world.rank() == 0) {
+    for (size_t i = 0; i < out.size(); ++i) {
+      EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
+    }
   }
 }
 
 TEST(sarafanov_m_canon_mat_mul_all, test_random_17x23_matrix) {
+  boost::mpi::communicator world;
   constexpr int kRowsCount = 17;
   constexpr int kColumnsCount = 23;
   constexpr int kMaxSize = std::max(kRowsCount, kColumnsCount);
   constexpr double kInaccuracy = 0.001;
   auto a_matrix = GenerateRandomData(17 * 23);
-  auto single_matrix = GenerateSingleMatrix(kMaxSize * kMaxSize);
   std::vector<double> out(kMaxSize * kMaxSize, 0);
-  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
-  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
-  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(single_matrix.data()));
-  task_data_stl->inputs_count.emplace_back(kRowsCount);
-  task_data_stl->inputs_count.emplace_back(kColumnsCount);
-  task_data_stl->inputs_count.emplace_back(kMaxSize);
-  task_data_stl->inputs_count.emplace_back(kMaxSize);
-  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data_stl->outputs_count.emplace_back(out.size());
-
-  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_stl(task_data_stl);
-  ASSERT_EQ(test_task_stl.Validation(), true);
-  test_task_stl.PreProcessing();
-  test_task_stl.Run();
-  test_task_stl.PostProcessing();
-  for (size_t i = 0; i < kRowsCount * kColumnsCount; ++i) {
-    EXPECT_NEAR(out[i], a_matrix[i], kInaccuracy);
+  auto single_matrix = GenerateSingleMatrix(kMaxSize * kMaxSize);
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(single_matrix.data()));
+    task_data_all->inputs_count.emplace_back(kRowsCount);
+    task_data_all->inputs_count.emplace_back(kColumnsCount);
+    task_data_all->inputs_count.emplace_back(kMaxSize);
+    task_data_all->inputs_count.emplace_back(kMaxSize);
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
+  }
+  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_all(task_data_all);
+  ASSERT_EQ(test_task_all.Validation(), true);
+  test_task_all.PreProcessing();
+  test_task_all.Run();
+  test_task_all.PostProcessing();
+  if (world.rank() == 0) {
+    for (size_t i = 0; i < kRowsCount * kColumnsCount; ++i) {
+      EXPECT_NEAR(out[i], a_matrix[i], kInaccuracy);
+    }
   }
 }

--- a/tasks/all/sarafanov_m_CanonMatMul/func_tests/main.cpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/func_tests/main.cpp
@@ -38,61 +38,61 @@ std::vector<double> GenerateSingleMatrix(int size) {
 }
 }  // namespace
 
- TEST(sarafanov_m_canon_mat_mul_all, test_clear_matrix) {
-   boost::mpi::communicator world;
-   constexpr size_t kCount = 0;
-   constexpr double kInaccuracy = 0.001;
-   std::vector<double> a_matrix;
-   std::vector<double> b_matrix;
-   std::vector<double> test_data;
-   std::vector<double> out(kCount, 0);
-   auto task_data_all = std::make_shared<ppc::core::TaskData>();
-   if (world.rank() == 0) {
-     task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
-     task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(b_matrix.data()));
-     for (int i = 0; i < 4; ++i) {
-       task_data_all->inputs_count.emplace_back(kCount);
-     }
-     task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-     task_data_all->outputs_count.emplace_back(kCount);
-   }
-   sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_all(task_data_all);
-   ASSERT_EQ(test_task_all.Validation(), true);
-   test_task_all.PreProcessing();
-   test_task_all.Run();
-   test_task_all.PostProcessing();
-   for (size_t i = 0; i < kCount; ++i) {
-     EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
-   }
- }
+TEST(sarafanov_m_canon_mat_mul_all, test_clear_matrix) {
+  boost::mpi::communicator world;
+  constexpr size_t kCount = 0;
+  constexpr double kInaccuracy = 0.001;
+  std::vector<double> a_matrix;
+  std::vector<double> b_matrix;
+  std::vector<double> test_data;
+  std::vector<double> out(kCount, 0);
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(b_matrix.data()));
+    for (int i = 0; i < 4; ++i) {
+      task_data_all->inputs_count.emplace_back(kCount);
+    }
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(kCount);
+  }
+  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_all(task_data_all);
+  ASSERT_EQ(test_task_all.Validation(), true);
+  test_task_all.PreProcessing();
+  test_task_all.Run();
+  test_task_all.PostProcessing();
+  for (size_t i = 0; i < kCount; ++i) {
+    EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
+  }
+}
 
- TEST(sarafanov_m_canon_mat_mul_all, test_1x1_matrix) {
-   boost::mpi::communicator world;
-   constexpr size_t kCount = 1;
-   constexpr double kInaccuracy = 0.001;
-   std::vector<double> a_matrix{18.0};
-   std::vector<double> b_matrix{18.0};
-   std::vector<double> test_data{324.0};
-   std::vector<double> out(kCount, 0);
-   auto task_data_all = std::make_shared<ppc::core::TaskData>();
-   if (world.rank() == 0) {
-     task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
-     task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(b_matrix.data()));
-     for (int i = 0; i < 4; ++i) {
-       task_data_all->inputs_count.emplace_back(kCount);
-     }
-     task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-     task_data_all->outputs_count.emplace_back(kCount);
-   }
-   sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_all(task_data_all);
-   ASSERT_EQ(test_task_all.Validation(), true);
-   test_task_all.PreProcessing();
-   test_task_all.Run();
-   test_task_all.PostProcessing();
-   for (size_t i = 0; i < kCount; ++i) {
-     EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
-   }
- }
+TEST(sarafanov_m_canon_mat_mul_all, test_1x1_matrix) {
+  boost::mpi::communicator world;
+  constexpr size_t kCount = 1;
+  constexpr double kInaccuracy = 0.001;
+  std::vector<double> a_matrix{18.0};
+  std::vector<double> b_matrix{18.0};
+  std::vector<double> test_data{324.0};
+  std::vector<double> out(kCount, 0);
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(b_matrix.data()));
+    for (int i = 0; i < 4; ++i) {
+      task_data_all->inputs_count.emplace_back(kCount);
+    }
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(kCount);
+  }
+  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_all(task_data_all);
+  ASSERT_EQ(test_task_all.Validation(), true);
+  test_task_all.PreProcessing();
+  test_task_all.Run();
+  test_task_all.PostProcessing();
+  for (size_t i = 0; i < kCount; ++i) {
+    EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
+  }
+}
 
 TEST(sarafanov_m_canon_mat_mul_all, test_2x2_matrix) {
   boost::mpi::communicator world;
@@ -124,35 +124,35 @@ TEST(sarafanov_m_canon_mat_mul_all, test_2x2_matrix) {
   }
 }
 
- TEST(sarafanov_m_canon_mat_mul_all, test_3x3_matrix) {
-   boost::mpi::communicator world;
-   constexpr size_t kCount = 3;
-   constexpr double kInaccuracy = 0.001;
-   std::vector<double> a_matrix{1.0, 4.0, 8.0, 5.0, 6.0, 2.0, 2.0, 7.0, 7.0};
-   std::vector<double> b_matrix{9.0, 1.0, 10.0, 12.0, 5.0, 2.0, 9.0, 7.0, 1.0};
-   std::vector<double> test_data{129.0, 77.0, 26.0, 135.0, 49.0, 64.0, 165.0, 86.0, 41.0};
-   std::vector<double> out(kCount * kCount, 0);
-   auto task_data_all = std::make_shared<ppc::core::TaskData>();
-   if (world.rank() == 0) {
-     task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
-     task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(b_matrix.data()));
-     for (int i = 0; i < 4; ++i) {
-       task_data_all->inputs_count.emplace_back(kCount);
-     }
-     task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-     task_data_all->outputs_count.emplace_back(out.size());
-   }
-   sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_all(task_data_all);
-   ASSERT_EQ(test_task_all.Validation(), true);
-   test_task_all.PreProcessing();
-   test_task_all.Run();
-   test_task_all.PostProcessing();
-   if (world.rank() == 0) {
-     for (size_t i = 0; i < kCount * kCount; ++i) {
-       EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
-     }
-   }
- }
+TEST(sarafanov_m_canon_mat_mul_all, test_3x3_matrix) {
+  boost::mpi::communicator world;
+  constexpr size_t kCount = 3;
+  constexpr double kInaccuracy = 0.001;
+  std::vector<double> a_matrix{1.0, 4.0, 8.0, 5.0, 6.0, 2.0, 2.0, 7.0, 7.0};
+  std::vector<double> b_matrix{9.0, 1.0, 10.0, 12.0, 5.0, 2.0, 9.0, 7.0, 1.0};
+  std::vector<double> test_data{129.0, 77.0, 26.0, 135.0, 49.0, 64.0, 165.0, 86.0, 41.0};
+  std::vector<double> out(kCount * kCount, 0);
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(b_matrix.data()));
+    for (int i = 0; i < 4; ++i) {
+      task_data_all->inputs_count.emplace_back(kCount);
+    }
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
+  }
+  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_all(task_data_all);
+  ASSERT_EQ(test_task_all.Validation(), true);
+  test_task_all.PreProcessing();
+  test_task_all.Run();
+  test_task_all.PostProcessing();
+  if (world.rank() == 0) {
+    for (size_t i = 0; i < kCount * kCount; ++i) {
+      EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
+    }
+  }
+}
 
 TEST(sarafanov_m_canon_mat_mul_all, test_random_5x5_matrix) {
   boost::mpi::communicator world;

--- a/tasks/all/sarafanov_m_CanonMatMul/func_tests/main.cpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/func_tests/main.cpp
@@ -1,0 +1,246 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "all/sarafanov_m_CanonMatMul/include/ops_all.hpp"
+
+namespace {
+std::vector<double> GenerateRandomData(int size) {
+  std::vector<double> matrix(size);
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  std::uniform_int_distribution<> dist(-500, 10000);
+  for (auto i = 0; i < size; ++i) {
+    matrix[i] = static_cast<double>(dist(gen));
+  }
+  return matrix;
+}
+
+std::vector<double> GenerateSingleMatrix(int size) {
+  std::vector<double> matrix(size, 0.0);
+  int sqrt_size = static_cast<int>(std::sqrt(size));
+  for (int i = 0; i < sqrt_size; ++i) {
+    for (int j = 0; j < sqrt_size; ++j) {
+      if (i == j) {
+        matrix[(sqrt_size * i) + j] = 1.0;
+      }
+    }
+  }
+  return matrix;
+}
+}  // namespace
+
+TEST(sarafanov_m_canon_mat_mul_seq, test_clear_matrix) {
+  constexpr size_t kCount = 0;
+  constexpr double kInaccuracy = 0.001;
+  std::vector<double> a_matrix;
+  std::vector<double> b_matrix;
+  std::vector<double> test_data;
+  std::vector<double> out(kCount, 0);
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(b_matrix.data()));
+  for (int i = 0; i < 4; ++i) {
+    task_data_stl->inputs_count.emplace_back(kCount);
+  }
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(kCount);
+
+  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  test_task_stl.PreProcessing();
+  test_task_stl.Run();
+  test_task_stl.PostProcessing();
+  for (size_t i = 0; i < kCount; ++i) {
+    EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
+  }
+}
+
+TEST(sarafanov_m_canon_mat_mul_all, test_1x1_matrix) {
+  constexpr size_t kCount = 1;
+  constexpr double kInaccuracy = 0.001;
+  std::vector<double> a_matrix{18.0};
+  std::vector<double> b_matrix{18.0};
+  std::vector<double> test_data{324.0};
+  std::vector<double> out(kCount, 0);
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(b_matrix.data()));
+  for (int i = 0; i < 4; ++i) {
+    task_data_stl->inputs_count.emplace_back(kCount);
+  }
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(kCount);
+
+  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  test_task_stl.PreProcessing();
+  test_task_stl.Run();
+  test_task_stl.PostProcessing();
+  for (size_t i = 0; i < kCount; ++i) {
+    EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
+  }
+}
+
+TEST(sarafanov_m_canon_mat_mul_all, test_2x2_matrix) {
+  constexpr size_t kCount = 2;
+  constexpr double kInaccuracy = 0.001;
+  std::vector<double> a_matrix{5.0, 6.0, 6.0, 5.0};
+  std::vector<double> b_matrix{10.0, 2.0, 2.0, 10.0};
+  std::vector<double> test_data{62.0, 70.0, 70.0, 62.0};
+  std::vector<double> out(kCount * kCount, 0);
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(b_matrix.data()));
+  for (int i = 0; i < 4; ++i) {
+    task_data_stl->inputs_count.emplace_back(kCount);
+  }
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  test_task_stl.PreProcessing();
+  test_task_stl.Run();
+  test_task_stl.PostProcessing();
+  for (size_t i = 0; i < kCount * kCount; ++i) {
+    EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
+  }
+}
+
+TEST(sarafanov_m_canon_mat_mul_all, test_3x3_matrix) {
+  constexpr size_t kCount = 3;
+  constexpr double kInaccuracy = 0.001;
+  std::vector<double> a_matrix{1.0, 4.0, 8.0, 5.0, 6.0, 2.0, 2.0, 7.0, 7.0};
+  std::vector<double> b_matrix{9.0, 1.0, 10.0, 12.0, 5.0, 2.0, 9.0, 7.0, 1.0};
+  std::vector<double> test_data{129.0, 77.0, 26.0, 135.0, 49.0, 64.0, 165.0, 86.0, 41.0};
+  std::vector<double> out(kCount * kCount, 0);
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(b_matrix.data()));
+  for (int i = 0; i < 4; ++i) {
+    task_data_stl->inputs_count.emplace_back(kCount);
+  }
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  test_task_stl.PreProcessing();
+  test_task_stl.Run();
+  test_task_stl.PostProcessing();
+  for (size_t i = 0; i < kCount * kCount; ++i) {
+    EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
+  }
+}
+
+TEST(sarafanov_m_canon_mat_mul_all, test_random_5x5_matrix) {
+  constexpr size_t kCount = 5;
+  constexpr double kInaccuracy = 0.001;
+  auto a_matrix = GenerateRandomData(static_cast<int>(kCount * kCount));
+  auto single_matrix = GenerateSingleMatrix(static_cast<int>(kCount * kCount));
+  std::vector<double> out(kCount * kCount, 0);
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(single_matrix.data()));
+  for (int i = 0; i < 4; ++i) {
+    task_data_stl->inputs_count.emplace_back(kCount);
+  }
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  test_task_stl.PreProcessing();
+  test_task_stl.Run();
+  test_task_stl.PostProcessing();
+  for (size_t i = 0; i < kCount * kCount; ++i) {
+    EXPECT_NEAR(out[i], a_matrix[i], kInaccuracy);
+  }
+}
+
+TEST(sarafanov_m_canon_mat_mul_all, test_random_30x30_matrix) {
+  constexpr size_t kCount = 30;
+  constexpr double kInaccuracy = 0.001;
+  auto a_matrix = GenerateRandomData(static_cast<int>(kCount * kCount));
+  auto single_matrix = GenerateSingleMatrix(static_cast<int>(kCount * kCount));
+  std::vector<double> out(kCount * kCount, 0);
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(single_matrix.data()));
+  for (int i = 0; i < 4; ++i) {
+    task_data_stl->inputs_count.emplace_back(kCount);
+  }
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  test_task_stl.PreProcessing();
+  test_task_stl.Run();
+  test_task_stl.PostProcessing();
+  for (size_t i = 0; i < kCount * kCount; ++i) {
+    EXPECT_NEAR(out[i], a_matrix[i], kInaccuracy);
+  }
+}
+
+TEST(sarafanov_m_canon_mat_mul_all, test_3x2_matrix) {
+  constexpr double kInaccuracy = 0.001;
+  std::vector<double> a_matrix{1.0, 4.0, 8.0, 5.0, 6.0, 2.0};
+  std::vector<double> b_matrix{9.0, 1.0, 10.0, 12.0, 5.0, 2.0};
+  std::vector<double> test_data{57.0, 21.0, 18.0, 132.0, 33.0, 90.0, 78.0, 16.0, 64.0};
+  std::vector<double> out(9, 0);
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(b_matrix.data()));
+  task_data_stl->inputs_count.emplace_back(3);
+  task_data_stl->inputs_count.emplace_back(2);
+  task_data_stl->inputs_count.emplace_back(2);
+  task_data_stl->inputs_count.emplace_back(3);
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(9);
+
+  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  test_task_stl.PreProcessing();
+  test_task_stl.Run();
+  test_task_stl.PostProcessing();
+  for (size_t i = 0; i < out.size(); ++i) {
+    EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
+  }
+}
+
+TEST(sarafanov_m_canon_mat_mul_all, test_random_17x23_matrix) {
+  constexpr int kRowsCount = 17;
+  constexpr int kColumnsCount = 23;
+  constexpr int kMaxSize = std::max(kRowsCount, kColumnsCount);
+  constexpr double kInaccuracy = 0.001;
+  auto a_matrix = GenerateRandomData(17 * 23);
+  auto single_matrix = GenerateSingleMatrix(kMaxSize * kMaxSize);
+  std::vector<double> out(kMaxSize * kMaxSize, 0);
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(single_matrix.data()));
+  task_data_stl->inputs_count.emplace_back(kRowsCount);
+  task_data_stl->inputs_count.emplace_back(kColumnsCount);
+  task_data_stl->inputs_count.emplace_back(kMaxSize);
+  task_data_stl->inputs_count.emplace_back(kMaxSize);
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  sarafanov_m_canon_mat_mul_all::CanonMatMulALL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  test_task_stl.PreProcessing();
+  test_task_stl.Run();
+  test_task_stl.PostProcessing();
+  for (size_t i = 0; i < kRowsCount * kColumnsCount; ++i) {
+    EXPECT_NEAR(out[i], a_matrix[i], kInaccuracy);
+  }
+}

--- a/tasks/all/sarafanov_m_CanonMatMul/func_tests/main.cpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/func_tests/main.cpp
@@ -89,8 +89,10 @@ TEST(sarafanov_m_canon_mat_mul_all, test_1x1_matrix) {
   test_task_all.PreProcessing();
   test_task_all.Run();
   test_task_all.PostProcessing();
-  for (size_t i = 0; i < kCount; ++i) {
-    EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
+  if (world.rank() == 0) {
+    for (size_t i = 0; i < kCount; ++i) {
+      EXPECT_NEAR(out[i], test_data[i], kInaccuracy);
+    }
   }
 }
 

--- a/tasks/all/sarafanov_m_CanonMatMul/include/CanonMatrix.hpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/include/CanonMatrix.hpp
@@ -8,6 +8,7 @@ enum class MatrixType : char { kRowMatrix, kColumnMatrix };
 namespace sarafanov_m_canon_mat_mul_all {
 class CanonMatrix {
   std::vector<double> matrix_;
+  size_t sqrt_size_ = 0;
   size_t size_ = 0;
 
   void CalculateSize(size_t s);
@@ -15,6 +16,12 @@ class CanonMatrix {
   [[nodiscard]] size_t GetColumnIndex(size_t index, size_t column_index, size_t offset) const;
 
  public:
+  template <typename Archive>
+  void serialize(Archive& archive, const unsigned int) {
+    archive & matrix_;
+    archive & size_;
+    archive & sqrt_size_;
+  }
   CanonMatrix() = default;
   CanonMatrix(const std::vector<double>& initial_vector);
   void SetBaseMatrix(std::vector<double>&& initial_vector);
@@ -23,9 +30,10 @@ class CanonMatrix {
   void PreRoutine(MatrixType type);
   [[nodiscard]] const std::vector<double>& GetMatrix() const;
   [[nodiscard]] size_t GetSize() const;
+  [[nodiscard]] size_t GetSqrtSize() const;
   [[nodiscard]] bool IsEmpty() const;
   CanonMatrix MultiplicateMatrix(const CanonMatrix& canon_matrix, size_t offset);
   void operator+=(const CanonMatrix& canon_matrix);
   void ClearMatrix();
 };
-}  // namespace sarafanov_m_canon_mat_mul_stl
+}  // namespace sarafanov_m_canon_mat_mul_all

--- a/tasks/all/sarafanov_m_CanonMatMul/include/CanonMatrix.hpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/include/CanonMatrix.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+enum class MatrixType : char { kRowMatrix, kColumnMatrix };
+
+namespace sarafanov_m_canon_mat_mul_all {
+class CanonMatrix {
+  std::vector<double> matrix_;
+  size_t size_ = 0;
+
+  void CalculateSize(size_t s);
+  [[nodiscard]] size_t GetRowIndex(size_t index, size_t row_number) const;
+  [[nodiscard]] size_t GetColumnIndex(size_t index, size_t column_index, size_t offset) const;
+
+ public:
+  CanonMatrix() = default;
+  CanonMatrix(const std::vector<double>& initial_vector);
+  void SetBaseMatrix(std::vector<double>&& initial_vector);
+  void Transpose();
+  void StairShift();
+  void PreRoutine(MatrixType type);
+  [[nodiscard]] const std::vector<double>& GetMatrix() const;
+  [[nodiscard]] size_t GetSize() const;
+  [[nodiscard]] bool IsEmpty() const;
+  CanonMatrix MultiplicateMatrix(const CanonMatrix& canon_matrix, size_t offset);
+  void operator+=(const CanonMatrix& canon_matrix);
+  void ClearMatrix();
+};
+}  // namespace sarafanov_m_canon_mat_mul_stl

--- a/tasks/all/sarafanov_m_CanonMatMul/include/CanonMatrix.hpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/include/CanonMatrix.hpp
@@ -17,6 +17,7 @@ class CanonMatrix {
 
  public:
   template <typename Archive>
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void serialize(Archive& archive, const unsigned int) {
     archive & matrix_;
     archive & size_;

--- a/tasks/all/sarafanov_m_CanonMatMul/include/ops_all.hpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/include/ops_all.hpp
@@ -11,7 +11,8 @@ namespace sarafanov_m_canon_mat_mul_all {
 struct IndexesPair {
   int first_ = 0;
   int second_ = 0;
-  IndexesPair(int first, int second) : first_(first), second_(second) {}
+  IndexesPair() = default;
+  IndexesPair(int first, int second);
   template <typename Archive>
   void serialize(Archive& archive, const unsigned int) {
     archive & first_;

--- a/tasks/all/sarafanov_m_CanonMatMul/include/ops_all.hpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/include/ops_all.hpp
@@ -9,12 +9,13 @@
 
 namespace sarafanov_m_canon_mat_mul_all {
 struct IndexesPair {
-  int first = 0;
-  int second = 0;
+  int first_ = 0;
+  int second_ = 0;
+  IndexesPair(int first, int second) : first_(first), second_(second) {}
   template <typename Archive>
   void serialize(Archive& archive, const unsigned int) {
-    archive & first;
-    archive & second;
+    archive & first_;
+    archive & second_;
   }
 };
 class CanonMatMulALL : public ppc::core::Task {

--- a/tasks/all/sarafanov_m_CanonMatMul/include/ops_all.hpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/include/ops_all.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "all/sarafanov_m_CanonMatMul/include/CanonMatrix.hpp"
+#include "core/task/include/task.hpp"
+namespace sarafanov_m_canon_mat_mul_all {
+class CanonMatMulALL : public ppc::core::Task {
+  CanonMatrix a_matrix_;
+  CanonMatrix b_matrix_;
+  CanonMatrix c_matrix_;
+  static constexpr double kInaccuracy = 0.001;
+
+ public:
+  explicit CanonMatMulALL(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+  bool CheckSquareSize(int number);
+  static std::vector<double> ConvertToSquareMatrix(int need_size, MatrixType type, const std::vector<double>& matrx);
+};
+}  // namespace sarafanov_m_canon_mat_mul_all

--- a/tasks/all/sarafanov_m_CanonMatMul/include/ops_all.hpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/include/ops_all.hpp
@@ -1,16 +1,29 @@
 #pragma once
 
+#include <boost/mpi/communicator.hpp>
 #include <utility>
 #include <vector>
 
 #include "all/sarafanov_m_CanonMatMul/include/CanonMatrix.hpp"
 #include "core/task/include/task.hpp"
+
 namespace sarafanov_m_canon_mat_mul_all {
+struct IndexesPair {
+  int first = 0;
+  int second = 0;
+  template <typename Archive>
+  void serialize(Archive& archive, const unsigned int) {
+    archive & first;
+    archive & second;
+  }
+};
 class CanonMatMulALL : public ppc::core::Task {
   CanonMatrix a_matrix_;
   CanonMatrix b_matrix_;
   CanonMatrix c_matrix_;
-  static constexpr double kInaccuracy = 0.001;
+  CanonMatrix matrix_sum_on_process_;
+  boost::mpi::communicator world_;
+  std::vector<IndexesPair> indexes_;
 
  public:
   explicit CanonMatMulALL(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
@@ -19,6 +32,7 @@ class CanonMatMulALL : public ppc::core::Task {
   bool RunImpl() override;
   bool PostProcessingImpl() override;
   bool CheckSquareSize(int number);
+  void CalculateIndexes();
   static std::vector<double> ConvertToSquareMatrix(int need_size, MatrixType type, const std::vector<double>& matrx);
 };
 }  // namespace sarafanov_m_canon_mat_mul_all

--- a/tasks/all/sarafanov_m_CanonMatMul/include/ops_all.hpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/include/ops_all.hpp
@@ -9,14 +9,15 @@
 
 namespace sarafanov_m_canon_mat_mul_all {
 struct IndexesPair {
-  int first_ = 0;
-  int second_ = 0;
+  int first = 0;
+  int second = 0;
   IndexesPair() = default;
   IndexesPair(int first, int second);
   template <typename Archive>
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void serialize(Archive& archive, const unsigned int) {
-    archive & first_;
-    archive & second_;
+    archive & first;
+    archive & second;
   }
 };
 class CanonMatMulALL : public ppc::core::Task {

--- a/tasks/all/sarafanov_m_CanonMatMul/perf_tests/main.cpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/perf_tests/main.cpp
@@ -1,0 +1,109 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "all/sarafanov_m_CanonMatMul/include/ops_all.hpp"
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+
+namespace {
+std::vector<double> GenerateRandomData(int size) {
+  std::vector<double> matrix(size);
+  std::random_device dev;
+  std::mt19937 gen(dev());
+  std::uniform_int_distribution<> dist(-500, 10000);
+  for (auto i = 0; i < size; ++i) {
+    matrix[i] = static_cast<double>(dist(gen));
+  }
+  return matrix;
+}
+
+std::vector<double> GenerateSingleMatrix(int size) {
+  std::vector<double> matrix(size, 0.0);
+  int sqrt_size = static_cast<int>(std::sqrt(size));
+  for (int i = 0; i < sqrt_size; ++i) {
+    for (int j = 0; j < sqrt_size; ++j) {
+      if (i == j) {
+        matrix[(sqrt_size * i) + j] = 1.0;
+      }
+    }
+  }
+  return matrix;
+}
+}  // namespace
+
+TEST(sarafanov_m_canon_mat_mul_all, test_pipeline_run) {
+  constexpr size_t kCount = 250;
+  constexpr double kInaccuracy = 0.001;
+  auto a_matrix = GenerateRandomData(static_cast<int>(kCount * kCount));
+  auto single_matrix = GenerateSingleMatrix(static_cast<int>(kCount * kCount));
+  std::vector<double> out(kCount * kCount, 0);
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(single_matrix.data()));
+  for (int i = 0; i < 4; ++i) {
+    task_data_stl->inputs_count.emplace_back(kCount);
+  }
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+  auto test_task_stl = std::make_shared<sarafanov_m_canon_mat_mul_all::CanonMatMulALL>(task_data_stl);
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_stl);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  for (size_t i = 0; i < kCount * kCount; ++i) {
+    EXPECT_NEAR(out[i], a_matrix[i], kInaccuracy);
+  }
+}
+
+TEST(sarafanov_m_canon_mat_mul_all, test_task_run) {
+  constexpr size_t kCount = 250;
+  constexpr double kInaccuracy = 0.001;
+  auto a_matrix = GenerateRandomData(static_cast<int>(kCount * kCount));
+  auto single_matrix = GenerateSingleMatrix(static_cast<int>(kCount * kCount));
+  std::vector<double> out(kCount * kCount, 0);
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(a_matrix.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(single_matrix.data()));
+  for (int i = 0; i < 4; ++i) {
+    task_data_stl->inputs_count.emplace_back(kCount);
+  }
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  auto test_task_stl = std::make_shared<sarafanov_m_canon_mat_mul_all::CanonMatMulALL>(task_data_stl);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_stl);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  for (size_t i = 0; i < kCount * kCount; ++i) {
+    EXPECT_NEAR(out[i], a_matrix[i], kInaccuracy);
+  }
+}

--- a/tasks/all/sarafanov_m_CanonMatMul/src/CanonMatrix.cpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/src/CanonMatrix.cpp
@@ -1,0 +1,104 @@
+#include "all/sarafanov_m_CanonMatMul/include/CanonMatrix.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+#include "utility"
+
+namespace sarafanov_m_canon_mat_mul_all {
+CanonMatrix::CanonMatrix(const std::vector<double>& initial_vector) : matrix_(initial_vector) {
+  CalculateSize(initial_vector.size());
+}
+void CanonMatrix::CalculateSize(size_t s) { size_ = static_cast<int>(std::sqrt(s)); }
+
+void CanonMatrix::PreRoutine(MatrixType type) {
+  if (type == MatrixType::kColumnMatrix) {
+    Transpose();
+  }
+  StairShift();
+}
+
+void CanonMatrix::SetBaseMatrix(std::vector<double>&& initial_vector) {
+  if (matrix_.empty()) {
+    CalculateSize(initial_vector.size());
+    matrix_ = std::move(initial_vector);
+  }
+}
+
+size_t CanonMatrix::GetRowIndex(size_t index, size_t row_number) const {
+  if (index < size_ * row_number) {
+    return index;
+  }
+  auto shift = index - (size_ * row_number);
+  return (row_number * size_) - size_ + shift;
+}
+
+size_t CanonMatrix::GetColumnIndex(size_t index, size_t column_index, size_t offset) const {
+  if (index + offset < size_ * column_index) {
+    return index + offset;
+  }
+  auto shift = index + offset - (size_ * column_index);
+  return (size_ * (column_index - 1)) + shift;
+}
+
+void CanonMatrix::StairShift() {
+  std::vector<double> new_matrix(matrix_.size());
+  std::copy(matrix_.begin(), matrix_.begin() + static_cast<int>(size_), new_matrix.begin());
+  int s_size = static_cast<int>(size_);
+  for (int i = 1; i < s_size; ++i) {
+    std::copy(matrix_.begin() + s_size * i + i, matrix_.begin() + s_size * (i + 1), new_matrix.begin() + s_size * i);
+    for (int j = s_size * i; j < s_size * i + i; ++j) {
+      new_matrix[j + s_size - i] = matrix_[j];
+    }
+  }
+  matrix_ = std::move(new_matrix);
+}
+
+const std::vector<double>& CanonMatrix::GetMatrix() const { return matrix_; }
+
+CanonMatrix CanonMatrix::MultiplicateMatrix(const CanonMatrix& canon_matrix, size_t offset) {
+  std::vector<double> c_matrix(size_ * size_);
+  const auto& b_matrix = canon_matrix.GetMatrix();
+  for (size_t i = 0; i < size_; ++i) {
+    for (size_t j = 0; j < size_; ++j) {
+      c_matrix[(i * size_) + j] = matrix_[GetRowIndex((i * size_) + j + offset, i + 1)] *
+                                  b_matrix[GetColumnIndex((j * size_) + i, j + 1, offset)];
+    }
+  }
+  return {c_matrix};
+}
+
+size_t CanonMatrix::GetSize() const { return size_; }
+
+void CanonMatrix::operator+=(const CanonMatrix& canon_matrix) {
+  if (matrix_.empty()) {
+    size_ = canon_matrix.GetSize();
+    matrix_.resize(size_ * size_);
+  }
+  for (size_t i = 0; i != size_; ++i) {
+    for (size_t j = 0; j != size_; ++j) {
+      matrix_[(i * size_) + j] += canon_matrix.GetMatrix()[(j * size_) + i];
+    }
+  }
+}
+
+void CanonMatrix::Transpose() {
+  std::vector<double> new_matrix(size_ * size_);
+  for (size_t i = 0; i < size_; ++i) {
+    for (size_t j = 0; j < size_; ++j) {
+      new_matrix[(i * size_) + j] = matrix_[(j * size_) + i];
+    }
+  }
+  matrix_ = std::move(new_matrix);
+}
+
+void CanonMatrix::ClearMatrix() {
+  matrix_.clear();
+  size_ = 0;
+}
+
+bool CanonMatrix::IsEmpty() const { return matrix_.empty(); }
+
+}  // namespace sarafanov_m_canon_mat_mul_all

--- a/tasks/all/sarafanov_m_CanonMatMul/src/CanonMatrix.cpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/src/CanonMatrix.cpp
@@ -11,7 +11,10 @@ namespace sarafanov_m_canon_mat_mul_all {
 CanonMatrix::CanonMatrix(const std::vector<double>& initial_vector) : matrix_(initial_vector) {
   CalculateSize(initial_vector.size());
 }
-void CanonMatrix::CalculateSize(size_t s) { size_ = static_cast<int>(std::sqrt(s)); }
+void CanonMatrix::CalculateSize(size_t s) {
+  size_ = s;
+  sqrt_size_ = static_cast<int>(std::sqrt(s));
+}
 
 void CanonMatrix::PreRoutine(MatrixType type) {
   if (type == MatrixType::kColumnMatrix) {
@@ -28,25 +31,25 @@ void CanonMatrix::SetBaseMatrix(std::vector<double>&& initial_vector) {
 }
 
 size_t CanonMatrix::GetRowIndex(size_t index, size_t row_number) const {
-  if (index < size_ * row_number) {
+  if (index < sqrt_size_ * row_number) {
     return index;
   }
-  auto shift = index - (size_ * row_number);
-  return (row_number * size_) - size_ + shift;
+  auto shift = index - (sqrt_size_ * row_number);
+  return (row_number * sqrt_size_) - sqrt_size_ + shift;
 }
 
 size_t CanonMatrix::GetColumnIndex(size_t index, size_t column_index, size_t offset) const {
-  if (index + offset < size_ * column_index) {
+  if (index + offset < sqrt_size_ * column_index) {
     return index + offset;
   }
-  auto shift = index + offset - (size_ * column_index);
-  return (size_ * (column_index - 1)) + shift;
+  auto shift = index + offset - (sqrt_size_ * column_index);
+  return (sqrt_size_ * (column_index - 1)) + shift;
 }
 
 void CanonMatrix::StairShift() {
   std::vector<double> new_matrix(matrix_.size());
-  std::copy(matrix_.begin(), matrix_.begin() + static_cast<int>(size_), new_matrix.begin());
-  int s_size = static_cast<int>(size_);
+  std::copy(matrix_.begin(), matrix_.begin() + static_cast<int>(sqrt_size_), new_matrix.begin());
+  int s_size = static_cast<int>(sqrt_size_);
   for (int i = 1; i < s_size; ++i) {
     std::copy(matrix_.begin() + s_size * i + i, matrix_.begin() + s_size * (i + 1), new_matrix.begin() + s_size * i);
     for (int j = s_size * i; j < s_size * i + i; ++j) {
@@ -59,12 +62,12 @@ void CanonMatrix::StairShift() {
 const std::vector<double>& CanonMatrix::GetMatrix() const { return matrix_; }
 
 CanonMatrix CanonMatrix::MultiplicateMatrix(const CanonMatrix& canon_matrix, size_t offset) {
-  std::vector<double> c_matrix(size_ * size_);
+  std::vector<double> c_matrix(size_);
   const auto& b_matrix = canon_matrix.GetMatrix();
-  for (size_t i = 0; i < size_; ++i) {
-    for (size_t j = 0; j < size_; ++j) {
-      c_matrix[(i * size_) + j] = matrix_[GetRowIndex((i * size_) + j + offset, i + 1)] *
-                                  b_matrix[GetColumnIndex((j * size_) + i, j + 1, offset)];
+  for (size_t i = 0; i < sqrt_size_; ++i) {
+    for (size_t j = 0; j < sqrt_size_; ++j) {
+      c_matrix[(i * sqrt_size_) + j] = matrix_[GetRowIndex((i * sqrt_size_) + j + offset, i + 1)] *
+                                       b_matrix[GetColumnIndex((j * sqrt_size_) + i, j + 1, offset)];
     }
   }
   return {c_matrix};
@@ -72,23 +75,26 @@ CanonMatrix CanonMatrix::MultiplicateMatrix(const CanonMatrix& canon_matrix, siz
 
 size_t CanonMatrix::GetSize() const { return size_; }
 
+size_t CanonMatrix::GetSqrtSize() const { return sqrt_size_; }
+
 void CanonMatrix::operator+=(const CanonMatrix& canon_matrix) {
   if (matrix_.empty()) {
+    sqrt_size_ = canon_matrix.GetSqrtSize();
     size_ = canon_matrix.GetSize();
-    matrix_.resize(size_ * size_);
+    matrix_.resize(size_);
   }
-  for (size_t i = 0; i != size_; ++i) {
-    for (size_t j = 0; j != size_; ++j) {
-      matrix_[(i * size_) + j] += canon_matrix.GetMatrix()[(j * size_) + i];
+  for (size_t i = 0; i != sqrt_size_; ++i) {
+    for (size_t j = 0; j != sqrt_size_; ++j) {
+      matrix_[(i * sqrt_size_) + j] += canon_matrix.GetMatrix()[(j * sqrt_size_) + i];
     }
   }
 }
 
 void CanonMatrix::Transpose() {
-  std::vector<double> new_matrix(size_ * size_);
-  for (size_t i = 0; i < size_; ++i) {
-    for (size_t j = 0; j < size_; ++j) {
-      new_matrix[(i * size_) + j] = matrix_[(j * size_) + i];
+  std::vector<double> new_matrix(size_);
+  for (size_t i = 0; i < sqrt_size_; ++i) {
+    for (size_t j = 0; j < sqrt_size_; ++j) {
+      new_matrix[(i * sqrt_size_) + j] = matrix_[(j * sqrt_size_) + i];
     }
   }
   matrix_ = std::move(new_matrix);
@@ -96,6 +102,7 @@ void CanonMatrix::Transpose() {
 
 void CanonMatrix::ClearMatrix() {
   matrix_.clear();
+  sqrt_size_ = 0;
   size_ = 0;
 }
 

--- a/tasks/all/sarafanov_m_CanonMatMul/src/ops_all.cpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/src/ops_all.cpp
@@ -14,15 +14,16 @@
 #include "all/sarafanov_m_CanonMatMul/include/CanonMatrix.hpp"
 #include "core/util/include/util.hpp"
 
+sarafanov_m_canon_mat_mul_all::IndexesPair::IndexesPair(int first, int second) : first_(first), second_(second) {}
+
 void sarafanov_m_canon_mat_mul_all::CanonMatMulALL::CalculateIndexes() {
-  auto part = a_matrix_.GetSqrtSize() / world_.size();
-  auto balance = a_matrix_.GetSqrtSize() % world_.size();
+  int part = a_matrix_.GetSqrtSize() / world_.size();
+  int balance = a_matrix_.GetSqrtSize() % world_.size();
   for (int i = 0; i < world_.size(); ++i) {
     if (i == 0) {
-      indexes_.emplace_back(0, part);
+      indexes_.push_back(IndexesPair(0, part));
     } else {
-      indexes_.emplace_back(static_cast<int>(indexes_[i - 1].second_),
-                            static_cast<int>(indexes_[i - 1].second_ + part));
+      indexes_.push_back(IndexesPair(indexes_[i - 1].second_, indexes_[i - 1].second_ + part));
     }
     if (balance != 0) {
       indexes_[i].second_++;

--- a/tasks/all/sarafanov_m_CanonMatMul/src/ops_all.cpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/src/ops_all.cpp
@@ -21,9 +21,9 @@ void sarafanov_m_canon_mat_mul_all::CanonMatMulALL::CalculateIndexes() {
   int balance = static_cast<int>(a_matrix_.GetSqrtSize()) % world_.size();
   for (int i = 0; i < world_.size(); ++i) {
     if (i == 0) {
-      indexes_.emplace_back(IndexesPair(0, part));
+      indexes_.emplace_back(0, part);
     } else {
-      indexes_.emplace_back(IndexesPair(indexes_[i - 1].second, indexes_[i - 1].second + part));
+      indexes_.emplace_back(indexes_[i - 1].second, indexes_[i - 1].second + part);
     }
     if (balance != 0) {
       indexes_[i].second++;
@@ -135,7 +135,7 @@ bool sarafanov_m_canon_mat_mul_all::CanonMatMulALL::RunImpl() {
   }
   if (world_.rank() == 0) {
     std::vector<double> intermediate_values(a_matrix_.GetSize() * world_.size());
-    auto sizes = std::vector<int>(world_.size(), a_matrix_.GetSize());
+    auto sizes = std::vector<int>(world_.size(), static_cast<int>(a_matrix_.GetSize()));
     boost::mpi::gatherv(world_, matrix_sum_on_process_.GetMatrix(), intermediate_values.data(), sizes, 0);
     std::vector<double> answer(a_matrix_.GetSize());
     for (int i = 0; i < static_cast<int>(answer.size()); ++i) {

--- a/tasks/all/sarafanov_m_CanonMatMul/src/ops_all.cpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/src/ops_all.cpp
@@ -21,10 +21,10 @@ void sarafanov_m_canon_mat_mul_all::CanonMatMulALL::CalculateIndexes() {
     if (i == 0) {
       indexes_.emplace_back(0, part);
     } else {
-      indexes_.emplace_back(static_cast<int>(indexes_[i - 1].second), static_cast<int>(indexes_[i - 1].second + part));
+      indexes_.emplace_back(static_cast<int>(indexes_[i - 1].second_), static_cast<int>(indexes_[i - 1].second_ + part));
     }
     if (balance != 0) {
-      indexes_[i].second++;
+      indexes_[i].second_++;
       balance--;
     }
   }
@@ -119,7 +119,7 @@ bool sarafanov_m_canon_mat_mul_all::CanonMatMulALL::RunImpl() {
 #pragma omp parallel
   {
 #pragma omp for
-    for (int i = indexes_[world_.rank()].first; i < indexes_[world_.rank()].second; ++i) {
+    for (int i = indexes_[world_.rank()].first_; i < indexes_[world_.rank()].second_; ++i) {
       mul_results[omp_get_thread_num()] += a_matrix_.MultiplicateMatrix(b_matrix_, i);
     }
   }

--- a/tasks/all/sarafanov_m_CanonMatMul/src/ops_all.cpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/src/ops_all.cpp
@@ -21,7 +21,8 @@ void sarafanov_m_canon_mat_mul_all::CanonMatMulALL::CalculateIndexes() {
     if (i == 0) {
       indexes_.emplace_back(0, part);
     } else {
-      indexes_.emplace_back(static_cast<int>(indexes_[i - 1].second_), static_cast<int>(indexes_[i - 1].second_ + part));
+      indexes_.emplace_back(static_cast<int>(indexes_[i - 1].second_),
+                            static_cast<int>(indexes_[i - 1].second_ + part));
     }
     if (balance != 0) {
       indexes_[i].second_++;

--- a/tasks/all/sarafanov_m_CanonMatMul/src/ops_all.cpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/src/ops_all.cpp
@@ -152,10 +152,7 @@ bool sarafanov_m_canon_mat_mul_all::CanonMatMulALL::RunImpl() {
 
 bool sarafanov_m_canon_mat_mul_all::CanonMatMulALL::PostProcessingImpl() {
   if (world_.rank() == 0) {
-    auto matrix = c_matrix_.GetMatrix();
-    for (size_t i = 0; i < matrix.size(); i++) {
-      reinterpret_cast<double *>(task_data->outputs[0])[i] = matrix[i];
-    }
+    std::ranges::copy(c_matrix_.GetMatrix(), reinterpret_cast<double *>(task_data->outputs[0]));
   }
   return true;
 }

--- a/tasks/all/sarafanov_m_CanonMatMul/src/ops_all.cpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/src/ops_all.cpp
@@ -1,46 +1,66 @@
 #include "all/sarafanov_m_CanonMatMul/include/ops_all.hpp"
 
+#include <omp.h>
+
 #include <algorithm>
+#include <boost/mpi/collectives/broadcast.hpp>
+#include <boost/mpi/collectives/gatherv.hpp>
+#include <boost/serialization/vector.hpp>
 #include <cmath>
 #include <cstddef>
-#include <thread>
 #include <utility>
 #include <vector>
 
 #include "all/sarafanov_m_CanonMatMul/include/CanonMatrix.hpp"
 #include "core/util/include/util.hpp"
 
-sarafanov_m_canon_mat_mul_all::ThreadDataAmount::ThreadDataAmount(int threads_count, int matrix_size) {
-  step_size = (matrix_size - (matrix_size % threads_count)) / threads_count;
-  residual_data_amount = matrix_size % threads_count;
+void sarafanov_m_canon_mat_mul_all::CanonMatMulALL::CalculateIndexes() {
+  auto part = a_matrix_.GetSqrtSize() / world_.size();
+  auto balance = a_matrix_.GetSqrtSize() % world_.size();
+  for (int i = 0; i < world_.size(); ++i) {
+    if (i == 0) {
+      indexes_.emplace_back(0, part);
+    } else {
+      indexes_.emplace_back(indexes_[i - 1].second, indexes_[i - 1].second + part);
+    }
+    if (balance != 0) {
+      indexes_[i].second++;
+      balance--;
+    }
+  }
 }
 
 bool sarafanov_m_canon_mat_mul_all::CanonMatMulALL::PreProcessingImpl() {
   a_matrix_.ClearMatrix();
   b_matrix_.ClearMatrix();
   c_matrix_.ClearMatrix();
-  int rows = static_cast<int>(task_data->inputs_count[0]);
-  int columns = static_cast<int>(task_data->inputs_count[1]);
-  std::vector<double> matrix_a(rows * columns);
-  auto *in = reinterpret_cast<double *>(task_data->inputs[0]);
-  std::copy(in, in + matrix_a.size(), matrix_a.begin());
-  if (!CheckSquareSize(0)) {
-    matrix_a = ConvertToSquareMatrix(std::max(rows, columns),
-                                     rows > columns ? MatrixType::kRowMatrix : MatrixType::kColumnMatrix, matrix_a);
+  indexes_.clear();
+  matrix_sum_on_process_.ClearMatrix();
+  if (world_.rank() == 0) {
+    int rows = static_cast<int>(task_data->inputs_count[0]);
+    int columns = static_cast<int>(task_data->inputs_count[1]);
+    std::vector<double> matrix_a(rows * columns);
+    auto *in = reinterpret_cast<double *>(task_data->inputs[0]);
+    std::copy(in, in + matrix_a.size(), matrix_a.begin());
+    if (!CheckSquareSize(0)) {
+      matrix_a = ConvertToSquareMatrix(std::max(rows, columns),
+                                       rows > columns ? MatrixType::kRowMatrix : MatrixType::kColumnMatrix, matrix_a);
+    }
+    a_matrix_.SetBaseMatrix(std::move(matrix_a));
+    a_matrix_.PreRoutine(MatrixType::kRowMatrix);
+    rows = static_cast<int>(task_data->inputs_count[2]);
+    columns = static_cast<int>(task_data->inputs_count[3]);
+    std::vector<double> matrix_b(rows * columns);
+    in = reinterpret_cast<double *>(task_data->inputs[1]);
+    std::copy(in, in + matrix_b.size(), matrix_b.begin());
+    if (!CheckSquareSize(2)) {
+      matrix_b = ConvertToSquareMatrix(std::max(rows, columns),
+                                       rows > columns ? MatrixType::kRowMatrix : MatrixType::kColumnMatrix, matrix_b);
+    }
+    b_matrix_.SetBaseMatrix(std::move(matrix_b));
+    b_matrix_.PreRoutine(MatrixType::kColumnMatrix);
+    CalculateIndexes();
   }
-  a_matrix_.SetBaseMatrix(std::move(matrix_a));
-  a_matrix_.PreRoutine(MatrixType::kRowMatrix);
-  rows = static_cast<int>(task_data->inputs_count[2]);
-  columns = static_cast<int>(task_data->inputs_count[3]);
-  std::vector<double> matrix_b(rows * columns);
-  in = reinterpret_cast<double *>(task_data->inputs[1]);
-  std::copy(in, in + matrix_b.size(), matrix_b.begin());
-  if (!CheckSquareSize(2)) {
-    matrix_b = ConvertToSquareMatrix(std::max(rows, columns),
-                                     rows > columns ? MatrixType::kRowMatrix : MatrixType::kColumnMatrix, matrix_b);
-  }
-  b_matrix_.SetBaseMatrix(std::move(matrix_b));
-  b_matrix_.PreRoutine(MatrixType::kColumnMatrix);
   return true;
 }
 
@@ -82,31 +102,58 @@ bool sarafanov_m_canon_mat_mul_all::CanonMatMulALL::CheckSquareSize(int number) 
 }
 
 bool sarafanov_m_canon_mat_mul_all::CanonMatMulALL::ValidationImpl() {
-  return std::max(task_data->inputs_count[0], task_data->inputs_count[1]) *
-             std::max(task_data->inputs_count[2], task_data->inputs_count[3]) ==
-         task_data->outputs_count[0];
+  if (world_.rank() == 0) {
+    return std::max(task_data->inputs_count[0], task_data->inputs_count[1]) *
+               std::max(task_data->inputs_count[2], task_data->inputs_count[3]) ==
+           task_data->outputs_count[0];
+  }
+  return true;
 }
 
 bool sarafanov_m_canon_mat_mul_all::CanonMatMulALL::RunImpl() {
   c_matrix_.ClearMatrix();
+  boost::mpi::broadcast(world_, a_matrix_, 0);
+  boost::mpi::broadcast(world_, b_matrix_, 0);
+  boost::mpi::broadcast(world_, indexes_, 0);
   std::vector<CanonMatrix> mul_results(ppc::util::GetPPCNumThreads());
-  // auto multiplicator = [&](int start_index, int end_index, size_t thread_index) {
-  //   for (int i = start_index; i < end_index; ++i) {
-  //     mul_results[thread_index] += a_matrix_.MultiplicateMatrix(b_matrix_, i);
-  //   }
-  // };
-  std::ranges::for_each(mul_results, [&](const auto &vector) {
-    if (!vector.IsEmpty()) {
-      c_matrix_ += vector;
+#pragma omp parallel
+  {
+#pragma omp for
+    for (int i = indexes_[world_.rank()].first; i < indexes_[world_.rank()].second; ++i) {
+      mul_results[omp_get_thread_num()] += a_matrix_.MultiplicateMatrix(b_matrix_, i);
+    }
+  }
+  std::ranges::for_each(mul_results, [&](auto &matrix) {
+    if (!matrix.IsEmpty()) {
+      matrix_sum_on_process_ += matrix;
     }
   });
+  if (matrix_sum_on_process_.IsEmpty()) {
+    matrix_sum_on_process_.SetBaseMatrix(std::vector<double>(a_matrix_.GetSize()));
+  }
+  if (world_.rank() == 0) {
+    std::vector<double> intermediate_values(a_matrix_.GetSize() * world_.size());
+    auto sizes = std::vector<int>(world_.size(), a_matrix_.GetSize());
+    boost::mpi::gatherv(world_, matrix_sum_on_process_.GetMatrix(), intermediate_values.data(), sizes, 0);
+    std::vector<double> answer(a_matrix_.GetSize());
+    for (int i = 0; i < static_cast<int>(answer.size()); ++i) {
+      for (int j = 0; j < world_.size(); ++j) {
+        answer[i] += intermediate_values[i + j * a_matrix_.GetSize()];
+      }
+    }
+    c_matrix_ = std::move(CanonMatrix(answer));
+  } else {
+    boost::mpi::gatherv(world_, matrix_sum_on_process_.GetMatrix(), 0);
+  }
   return true;
 }
 
 bool sarafanov_m_canon_mat_mul_all::CanonMatMulALL::PostProcessingImpl() {
-  auto matrix = c_matrix_.GetMatrix();
-  for (size_t i = 0; i < matrix.size(); i++) {
-    reinterpret_cast<double *>(task_data->outputs[0])[i] = matrix[i];
+  if (world_.rank() == 0) {
+    auto matrix = c_matrix_.GetMatrix();
+    for (size_t i = 0; i < matrix.size(); i++) {
+      reinterpret_cast<double *>(task_data->outputs[0])[i] = matrix[i];
+    }
   }
   return true;
 }

--- a/tasks/all/sarafanov_m_CanonMatMul/src/ops_all.cpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/src/ops_all.cpp
@@ -7,7 +7,6 @@
 #include <boost/mpi/collectives/gatherv.hpp>
 #include <boost/serialization/vector.hpp>  // NOLINT(*-include-cleaner)
 #include <cmath>
-#include <cstddef>
 #include <utility>
 #include <vector>
 

--- a/tasks/all/sarafanov_m_CanonMatMul/src/ops_all.cpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/src/ops_all.cpp
@@ -21,7 +21,7 @@ void sarafanov_m_canon_mat_mul_all::CanonMatMulALL::CalculateIndexes() {
     if (i == 0) {
       indexes_.emplace_back(0, part);
     } else {
-      indexes_.emplace_back(indexes_[i - 1].second, indexes_[i - 1].second + part);
+      indexes_.emplace_back(static_cast<int>(indexes_[i - 1].second), static_cast<int>(indexes_[i - 1].second + part));
     }
     if (balance != 0) {
       indexes_[i].second++;
@@ -141,7 +141,7 @@ bool sarafanov_m_canon_mat_mul_all::CanonMatMulALL::RunImpl() {
         answer[i] += intermediate_values[i + j * a_matrix_.GetSize()];
       }
     }
-    c_matrix_ = std::move(CanonMatrix(answer));
+    c_matrix_.SetBaseMatrix(std::move(answer));
   } else {
     boost::mpi::gatherv(world_, matrix_sum_on_process_.GetMatrix(), 0);
   }

--- a/tasks/all/sarafanov_m_CanonMatMul/src/ops_all.cpp
+++ b/tasks/all/sarafanov_m_CanonMatMul/src/ops_all.cpp
@@ -1,0 +1,112 @@
+#include "all/sarafanov_m_CanonMatMul/include/ops_all.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "all/sarafanov_m_CanonMatMul/include/CanonMatrix.hpp"
+#include "core/util/include/util.hpp"
+
+sarafanov_m_canon_mat_mul_all::ThreadDataAmount::ThreadDataAmount(int threads_count, int matrix_size) {
+  step_size = (matrix_size - (matrix_size % threads_count)) / threads_count;
+  residual_data_amount = matrix_size % threads_count;
+}
+
+bool sarafanov_m_canon_mat_mul_all::CanonMatMulALL::PreProcessingImpl() {
+  a_matrix_.ClearMatrix();
+  b_matrix_.ClearMatrix();
+  c_matrix_.ClearMatrix();
+  int rows = static_cast<int>(task_data->inputs_count[0]);
+  int columns = static_cast<int>(task_data->inputs_count[1]);
+  std::vector<double> matrix_a(rows * columns);
+  auto *in = reinterpret_cast<double *>(task_data->inputs[0]);
+  std::copy(in, in + matrix_a.size(), matrix_a.begin());
+  if (!CheckSquareSize(0)) {
+    matrix_a = ConvertToSquareMatrix(std::max(rows, columns),
+                                     rows > columns ? MatrixType::kRowMatrix : MatrixType::kColumnMatrix, matrix_a);
+  }
+  a_matrix_.SetBaseMatrix(std::move(matrix_a));
+  a_matrix_.PreRoutine(MatrixType::kRowMatrix);
+  rows = static_cast<int>(task_data->inputs_count[2]);
+  columns = static_cast<int>(task_data->inputs_count[3]);
+  std::vector<double> matrix_b(rows * columns);
+  in = reinterpret_cast<double *>(task_data->inputs[1]);
+  std::copy(in, in + matrix_b.size(), matrix_b.begin());
+  if (!CheckSquareSize(2)) {
+    matrix_b = ConvertToSquareMatrix(std::max(rows, columns),
+                                     rows > columns ? MatrixType::kRowMatrix : MatrixType::kColumnMatrix, matrix_b);
+  }
+  b_matrix_.SetBaseMatrix(std::move(matrix_b));
+  b_matrix_.PreRoutine(MatrixType::kColumnMatrix);
+  return true;
+}
+
+std::vector<double> sarafanov_m_canon_mat_mul_all::CanonMatMulALL::ConvertToSquareMatrix(
+    int need_size, MatrixType type, const std::vector<double> &matrx) {
+  std::vector<double> matrix;
+  int rows_counter = 0;
+  int zero_columns = 0;
+  switch (type) {
+    case MatrixType::kRowMatrix:
+      rows_counter = 1;
+      zero_columns = need_size - (static_cast<int>(matrx.size()) / need_size);
+      for (int i = 0; i < static_cast<int>(matrx.size()); ++i) {
+        if ((need_size - zero_columns) * rows_counter - i == 0) {
+          rows_counter++;
+          for (int j = 0; j < zero_columns; ++j) {
+            matrix.emplace_back(0.0);
+          }
+        }
+        matrix.emplace_back(matrx[i]);
+      }
+      for (int i = 0; i < zero_columns; ++i) {
+        matrix.emplace_back(0.0);
+      }
+      break;
+    case MatrixType::kColumnMatrix:
+      matrix = matrx;
+      int zero_rows = need_size - (static_cast<int>(matrx.size()) / need_size);
+      for (int i = 0; i < zero_rows * need_size; ++i) {
+        matrix.emplace_back(0.0);
+      }
+      break;
+  }
+  return matrix;
+}
+
+bool sarafanov_m_canon_mat_mul_all::CanonMatMulALL::CheckSquareSize(int number) {
+  return task_data->inputs_count[number] == task_data->inputs_count[number + 1];
+}
+
+bool sarafanov_m_canon_mat_mul_all::CanonMatMulALL::ValidationImpl() {
+  return std::max(task_data->inputs_count[0], task_data->inputs_count[1]) *
+             std::max(task_data->inputs_count[2], task_data->inputs_count[3]) ==
+         task_data->outputs_count[0];
+}
+
+bool sarafanov_m_canon_mat_mul_all::CanonMatMulALL::RunImpl() {
+  c_matrix_.ClearMatrix();
+  std::vector<CanonMatrix> mul_results(ppc::util::GetPPCNumThreads());
+  // auto multiplicator = [&](int start_index, int end_index, size_t thread_index) {
+  //   for (int i = start_index; i < end_index; ++i) {
+  //     mul_results[thread_index] += a_matrix_.MultiplicateMatrix(b_matrix_, i);
+  //   }
+  // };
+  std::ranges::for_each(mul_results, [&](const auto &vector) {
+    if (!vector.IsEmpty()) {
+      c_matrix_ += vector;
+    }
+  });
+  return true;
+}
+
+bool sarafanov_m_canon_mat_mul_all::CanonMatMulALL::PostProcessingImpl() {
+  auto matrix = c_matrix_.GetMatrix();
+  for (size_t i = 0; i < matrix.size(); i++) {
+    reinterpret_cast<double *>(task_data->outputs[0])[i] = matrix[i];
+  }
+  return true;
+}


### PR DESCRIPTION
Структурные изменения: создана функция CalculateIndexes, определяющая границы итераций для каждого из процессов, также реализована структура IndexesPair, в которой перегружена сериализация. Благодаря этому объекты данной структуры можно передавать с помощью broadcast. 
Распараллеливание с помощью OMP и MPI: разделение итерируемого интервала между потоками происходит с помощью директивы # omp parallel for, что касается использования MPI, распараллеливание происходит в 2 этапа: исходные матрицы распределяются между всеми процессами с помощью broadcast, после чего выполняется необходимое количество умножение элементов и сдвигов матриц. Результаты умножения матриц после сдвигов суммируются в единственную переменную mul_results, которая передается на корневой процесс благодаря gatherv. Так как размеры всех матриц изначально одинаковые, передается минимальное возможное количество данных, что положительно складывается на производительности. После сбора всех матриц на корневом процессе, происходит их суммирование и последующая запись результатов в ответ. 
 Совместное использование MPI и OMP в оптимальном соотношение дает прирост производительности в 4-5 раз