### PR TITLE
Созонов Илья. Вариант 26. Технология STL. Линейная фильтрация изображений (блочное разбиение). Ядро Гаусса 3x3.

### DIFF
--- a/tasks/stl/sozonov_i_image_filtering_block_partitioning/func_tests/main.cpp
+++ b/tasks/stl/sozonov_i_image_filtering_block_partitioning/func_tests/main.cpp
@@ -24,6 +24,28 @@ std::vector<double> ZeroEdges(std::vector<double> img, int wdth, int hght) {
 }
 }  // namespace sozonov_i_image_filtering_block_partitioning_stl
 
+TEST(sozonov_i_image_filtering_block_partitioning_stl, test_empty_image) {
+  const int width = 0;
+  const int height = 0;
+
+  // Create data
+  std::vector<double> in;
+  std::vector<double> out;
+
+  // Create task_data
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_stl->inputs_count.emplace_back(in.size());
+  task_data_stl->inputs_count.emplace_back(width);
+  task_data_stl->inputs_count.emplace_back(height);
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_block_partitioning_stl::TestTaskSTL test_task_stl(task_data_stl);
+  ASSERT_FALSE(test_task_stl.Validation());
+}
+
 TEST(sozonov_i_image_filtering_block_partitioning_stl, test_image_less_than_3x3) {
   const int width = 2;
   const int height = 2;

--- a/tasks/stl/sozonov_i_image_filtering_block_partitioning/func_tests/main.cpp
+++ b/tasks/stl/sozonov_i_image_filtering_block_partitioning/func_tests/main.cpp
@@ -1,0 +1,296 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <numeric>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "stl/sozonov_i_image_filtering_block_partitioning/include/ops_stl.hpp"
+
+namespace sozonov_i_image_filtering_block_partitioning_stl {
+
+std::vector<double> ZeroEdges(std::vector<double> img, int wdth, int hght) {
+  for (int i = 0; i < wdth; ++i) {
+    img[i] = 0;
+    img[((hght - 1) * wdth) + i] = 0;
+  }
+  for (int i = 1; i < hght - 1; ++i) {
+    img[i * wdth] = 0;
+    img[(i * wdth) + wdth - 1] = 0;
+  }
+
+  return img;
+}
+}  // namespace sozonov_i_image_filtering_block_partitioning_stl
+
+TEST(sozonov_i_image_filtering_block_partitioning_stl, test_image_less_than_3x3) {
+  const int width = 2;
+  const int height = 2;
+
+  // Create data
+  std::vector<double> in = {4, 6, 8, 24};
+  std::vector<double> out(width * height, 0);
+
+  // Create task_data
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_stl->inputs_count.emplace_back(in.size());
+  task_data_stl->inputs_count.emplace_back(width);
+  task_data_stl->inputs_count.emplace_back(height);
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_block_partitioning_stl::TestTaskSTL test_task_stl(task_data_stl);
+  ASSERT_FALSE(test_task_stl.Validation());
+}
+
+TEST(sozonov_i_image_filtering_block_partitioning_stl, test_wrong_pixels) {
+  const int width = 5;
+  const int height = 3;
+
+  // Create data
+  std::vector<double> in = {143, 6, 853, -24, 31, -25, 1, 5, -7, 361, 28, 98, -45, 982, 461};
+  std::vector<double> out(width * height, 0);
+
+  // Create task_data
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_stl->inputs_count.emplace_back(in.size());
+  task_data_stl->inputs_count.emplace_back(width);
+  task_data_stl->inputs_count.emplace_back(height);
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_block_partitioning_stl::TestTaskSTL test_task_stl(task_data_stl);
+  ASSERT_FALSE(test_task_stl.Validation());
+}
+
+TEST(sozonov_i_image_filtering_block_partitioning_stl, test_3x3) {
+  const int width = 3;
+  const int height = 3;
+
+  // Create data
+  std::vector<double> in = {4, 6, 8, 24, 31, 25, 1, 5, 7};
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans = {0, 0, 0, 0, 16.5, 0, 0, 0, 0};
+
+  // Create task_data
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_stl->inputs_count.emplace_back(in.size());
+  task_data_stl->inputs_count.emplace_back(width);
+  task_data_stl->inputs_count.emplace_back(height);
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_block_partitioning_stl::TestTaskSTL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  test_task_stl.PreProcessing();
+  test_task_stl.Run();
+  test_task_stl.PostProcessing();
+  EXPECT_EQ(out, ans);
+}
+
+TEST(sozonov_i_image_filtering_block_partitioning_stl, test_5x3) {
+  const int width = 5;
+  const int height = 3;
+
+  // Create data
+  std::vector<double> in = {34, 24, 27, 67, 42, 48, 93, 26, 47, 2, 34, 13, 81, 24, 32};
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans = {0, 0, 0, 0, 0, 0, 48.125, 45.5, 38, 0, 0, 0, 0, 0, 0};
+
+  // Create task_data
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_stl->inputs_count.emplace_back(in.size());
+  task_data_stl->inputs_count.emplace_back(width);
+  task_data_stl->inputs_count.emplace_back(height);
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_block_partitioning_stl::TestTaskSTL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  test_task_stl.PreProcessing();
+  test_task_stl.Run();
+  test_task_stl.PostProcessing();
+  EXPECT_EQ(out, ans);
+}
+
+TEST(sozonov_i_image_filtering_block_partitioning_stl, test_5x5) {
+  const int width = 5;
+  const int height = 5;
+
+  // Create data
+  std::vector<double> in(width * height);
+  std::iota(in.begin(), in.end(), 0);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans = {0, 0, 0, 0, 0, 0, 6, 7, 8, 0, 0, 11, 12, 13, 0, 0, 16, 17, 18, 0, 0, 0, 0, 0, 0};
+
+  // Create task_data
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_stl->inputs_count.emplace_back(in.size());
+  task_data_stl->inputs_count.emplace_back(width);
+  task_data_stl->inputs_count.emplace_back(height);
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_block_partitioning_stl::TestTaskSTL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  test_task_stl.PreProcessing();
+  test_task_stl.Run();
+  test_task_stl.PostProcessing();
+  EXPECT_EQ(out, ans);
+}
+
+TEST(sozonov_i_image_filtering_block_partitioning_stl, test_5x7) {
+  const int width = 5;
+  const int height = 7;
+
+  // Create data
+  std::vector<double> in(width * height);
+  std::iota(in.begin(), in.end(), 0);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans = {0,  0, 0, 0,  0,  0,  6, 7, 8,  0,  0,  11, 12, 13, 0, 0, 16, 17,
+                             18, 0, 0, 21, 22, 23, 0, 0, 26, 27, 28, 0,  0,  0,  0, 0, 0};
+
+  // Create task_data
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_stl->inputs_count.emplace_back(in.size());
+  task_data_stl->inputs_count.emplace_back(width);
+  task_data_stl->inputs_count.emplace_back(height);
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_block_partitioning_stl::TestTaskSTL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  test_task_stl.PreProcessing();
+  test_task_stl.Run();
+  test_task_stl.PostProcessing();
+  EXPECT_EQ(out, ans);
+}
+
+TEST(sozonov_i_image_filtering_block_partitioning_stl, test_10x4) {
+  const int width = 10;
+  const int height = 4;
+
+  // Create data
+  std::vector<double> in(width * height);
+  std::iota(in.begin(), in.end(), 0);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans = {0, 0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 11, 12, 13, 14, 15, 16, 17, 18, 0,
+                             0, 21, 22, 23, 24, 25, 26, 27, 28, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0};
+
+  // Create task_data
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_stl->inputs_count.emplace_back(in.size());
+  task_data_stl->inputs_count.emplace_back(width);
+  task_data_stl->inputs_count.emplace_back(height);
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_block_partitioning_stl::TestTaskSTL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  test_task_stl.PreProcessing();
+  test_task_stl.Run();
+  test_task_stl.PostProcessing();
+  EXPECT_EQ(out, ans);
+}
+
+TEST(sozonov_i_image_filtering_block_partitioning_stl, test_100x100) {
+  const int width = 100;
+  const int height = 100;
+
+  // Create data
+  std::vector<double> in(width * height, 1);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans(width * height, 1);
+
+  ans = sozonov_i_image_filtering_block_partitioning_stl::ZeroEdges(ans, width, height);
+
+  // Create task_data
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_stl->inputs_count.emplace_back(in.size());
+  task_data_stl->inputs_count.emplace_back(width);
+  task_data_stl->inputs_count.emplace_back(height);
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_block_partitioning_stl::TestTaskSTL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  test_task_stl.PreProcessing();
+  test_task_stl.Run();
+  test_task_stl.PostProcessing();
+  EXPECT_EQ(out, ans);
+}
+
+TEST(sozonov_i_image_filtering_block_partitioning_stl, test_150x100) {
+  const int width = 150;
+  const int height = 100;
+
+  // Create data
+  std::vector<double> in(width * height, 1);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans(width * height, 1);
+
+  ans = sozonov_i_image_filtering_block_partitioning_stl::ZeroEdges(ans, width, height);
+
+  // Create task_data
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_stl->inputs_count.emplace_back(in.size());
+  task_data_stl->inputs_count.emplace_back(width);
+  task_data_stl->inputs_count.emplace_back(height);
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_block_partitioning_stl::TestTaskSTL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  test_task_stl.PreProcessing();
+  test_task_stl.Run();
+  test_task_stl.PostProcessing();
+  EXPECT_EQ(out, ans);
+}
+
+TEST(sozonov_i_image_filtering_block_partitioning_stl, test_120x200) {
+  const int width = 120;
+  const int height = 200;
+
+  // Create data
+  std::vector<double> in(width * height, 1);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans(width * height, 1);
+
+  ans = sozonov_i_image_filtering_block_partitioning_stl::ZeroEdges(ans, width, height);
+
+  // Create task_data
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_stl->inputs_count.emplace_back(in.size());
+  task_data_stl->inputs_count.emplace_back(width);
+  task_data_stl->inputs_count.emplace_back(height);
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  sozonov_i_image_filtering_block_partitioning_stl::TestTaskSTL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  test_task_stl.PreProcessing();
+  test_task_stl.Run();
+  test_task_stl.PostProcessing();
+  EXPECT_EQ(out, ans);
+}

--- a/tasks/stl/sozonov_i_image_filtering_block_partitioning/include/ops_stl.hpp
+++ b/tasks/stl/sozonov_i_image_filtering_block_partitioning/include/ops_stl.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace sozonov_i_image_filtering_block_partitioning_stl {
+
+class TestTaskSTL : public ppc::core::Task {
+ public:
+  explicit TestTaskSTL(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<double> image_, filtered_image_;
+  int width_{}, height_{};
+};
+
+}  // namespace sozonov_i_image_filtering_block_partitioning_stl

--- a/tasks/stl/sozonov_i_image_filtering_block_partitioning/include/ops_stl.hpp
+++ b/tasks/stl/sozonov_i_image_filtering_block_partitioning/include/ops_stl.hpp
@@ -7,6 +7,8 @@
 
 namespace sozonov_i_image_filtering_block_partitioning_stl {
 
+std::vector<double> ZeroEdges(std::vector<double> img, int wdth, int hght);
+
 class TestTaskSTL : public ppc::core::Task {
  public:
   explicit TestTaskSTL(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}

--- a/tasks/stl/sozonov_i_image_filtering_block_partitioning/perf_tests/main.cpp
+++ b/tasks/stl/sozonov_i_image_filtering_block_partitioning/perf_tests/main.cpp
@@ -1,0 +1,113 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "stl/sozonov_i_image_filtering_block_partitioning/include/ops_stl.hpp"
+
+namespace sozonov_i_image_filtering_block_partitioning_stl {
+
+std::vector<double> ZeroEdges(std::vector<double> img, int wdth, int hght) {
+  for (int i = 0; i < wdth; ++i) {
+    img[i] = 0;
+    img[((hght - 1) * wdth) + i] = 0;
+  }
+  for (int i = 1; i < hght - 1; ++i) {
+    img[i * wdth] = 0;
+    img[(i * wdth) + wdth - 1] = 0;
+  }
+
+  return img;
+}
+
+}  // namespace sozonov_i_image_filtering_block_partitioning_stl
+
+TEST(sozonov_i_image_filtering_block_partitioning_stl, test_pipeline_run) {
+  const int width = 5000;
+  const int height = 5000;
+
+  // Create data
+  std::vector<double> in(width * height, 1);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans(width * height, 1);
+
+  ans = sozonov_i_image_filtering_block_partitioning_stl::ZeroEdges(ans, width, height);
+
+  // Create task_data
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_stl->inputs_count.emplace_back(in.size());
+  task_data_stl->inputs_count.emplace_back(width);
+  task_data_stl->inputs_count.emplace_back(height);
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_stl = std::make_shared<sozonov_i_image_filtering_block_partitioning_stl::TestTaskSTL>(task_data_stl);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_stl);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(out, ans);
+}
+
+TEST(sozonov_i_image_filtering_block_partitioning_stl, test_task_run) {
+  const int width = 5000;
+  const int height = 5000;
+
+  // Create data
+  std::vector<double> in(width * height, 1);
+  std::vector<double> out(width * height, 0);
+  std::vector<double> ans(width * height, 1);
+
+  ans = sozonov_i_image_filtering_block_partitioning_stl::ZeroEdges(ans, width, height);
+
+  // Create task_data
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  task_data_stl->inputs_count.emplace_back(in.size());
+  task_data_stl->inputs_count.emplace_back(width);
+  task_data_stl->inputs_count.emplace_back(height);
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto test_task_stl = std::make_shared<sozonov_i_image_filtering_block_partitioning_stl::TestTaskSTL>(task_data_stl);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_stl);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(out, ans);
+}

--- a/tasks/stl/sozonov_i_image_filtering_block_partitioning/src/ops_stl.cpp
+++ b/tasks/stl/sozonov_i_image_filtering_block_partitioning/src/ops_stl.cpp
@@ -1,6 +1,7 @@
 #include "stl/sozonov_i_image_filtering_block_partitioning/include/ops_stl.hpp"
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <cstddef>
 #include <thread>
@@ -83,7 +84,7 @@ bool sozonov_i_image_filtering_block_partitioning_stl::TestTaskSTL::RunImpl() {
 
   for (int t = 0; t < num_threads; ++t) {
     threads[t] = std::thread([&]() {
-      int id;
+      int id = 0;
       while ((id = block_id.fetch_add(1)) < static_cast<int>(blocks.size())) {
         const auto &[i, j] = blocks[id];
         ProcessBlock(image_, filtered_image_, width_, height_, i, j, block_size);

--- a/tasks/stl/sozonov_i_image_filtering_block_partitioning/src/ops_stl.cpp
+++ b/tasks/stl/sozonov_i_image_filtering_block_partitioning/src/ops_stl.cpp
@@ -1,0 +1,98 @@
+#include "stl/sozonov_i_image_filtering_block_partitioning/include/ops_stl.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <thread>
+#include <vector>
+
+#include "core/util/include/util.hpp"
+
+namespace {
+
+std::vector<double> kernel = {0.0625, 0.125, 0.0625, 0.125, 0.25, 0.125, 0.0625, 0.125, 0.0625};
+
+void ProcessBlockSet(const std::vector<double> &image, std::vector<double> &filtered_image, int width, int height,
+                     int block_size, const std::vector<std::pair<int, int>> &blocks) {
+  for (auto [start_i, start_j] : blocks) {
+    int end_i = std::min(start_i + block_size, height - 1);
+    int end_j = std::min(start_j + block_size, width - 1);
+    for (int i = std::max(1, start_i); i < end_i; ++i) {
+      for (int j = std::max(1, start_j); j < end_j; ++j) {
+        double sum = 0;
+        for (int l = -1; l <= 1; ++l) {
+          for (int k = -1; k <= 1; ++k) {
+            sum += image[((i - l) * width) + (j - k)] * kernel[((l + 1) * 3) + (k + 1)];
+          }
+        }
+        filtered_image[(i * width) + j] = sum;
+      }
+    }
+  }
+}
+
+}  // namespace
+
+bool sozonov_i_image_filtering_block_partitioning_stl::TestTaskSTL::PreProcessingImpl() {
+  // Init image
+  image_ = std::vector<double>(task_data->inputs_count[0]);
+  auto *image_ptr = reinterpret_cast<double *>(task_data->inputs[0]);
+  std::ranges::copy(image_ptr, image_ptr + task_data->inputs_count[0], image_.begin());
+
+  width_ = static_cast<int>(task_data->inputs_count[1]);
+  height_ = static_cast<int>(task_data->inputs_count[2]);
+
+  // Init filtered image
+  filtered_image_ = std::vector<double>(width_ * height_, 0);
+  return true;
+}
+
+bool sozonov_i_image_filtering_block_partitioning_stl::TestTaskSTL::ValidationImpl() {
+  // Init image
+  image_ = std::vector<double>(task_data->inputs_count[0]);
+  auto *image_ptr = reinterpret_cast<double *>(task_data->inputs[0]);
+  std::ranges::copy(image_ptr, image_ptr + task_data->inputs_count[0], image_.begin());
+
+  size_t img_size = task_data->inputs_count[1] * task_data->inputs_count[2];
+
+  // Check pixels range from 0 to 255
+  for (size_t i = 0; i < img_size; ++i) {
+    if (image_[i] < 0 || image_[i] > 255) {
+      return false;
+    }
+  }
+
+  // Check size of image
+  return task_data->inputs_count[0] > 0 && task_data->inputs_count[0] == img_size &&
+         task_data->outputs_count[0] == img_size && task_data->inputs_count[1] >= 3 && task_data->inputs_count[2] >= 3;
+}
+
+bool sozonov_i_image_filtering_block_partitioning_stl::TestTaskSTL::RunImpl() {
+  int block_size = 64;
+  const int num_threads = ppc::util::GetPPCNumThreads();
+  std::vector<std::thread> threads(num_threads);
+  std::vector<std::vector<std::pair<int, int>>> thread_blocks(num_threads);
+
+  int block_id = 0;
+  for (int i = 0; i < height_; i += block_size) {
+    for (int j = 0; j < width_; j += block_size) {
+      thread_blocks[block_id % num_threads].emplace_back(i, j);
+      block_id++;
+    }
+  }
+
+  for (int t = 0; t < num_threads; ++t) {
+    threads[t] = std::thread(ProcessBlockSet, std::cref(image_), std::ref(filtered_image_), width_, height_, block_size,
+                             thread_blocks[t]);
+  }
+
+  for (auto &t : threads) t.join();
+
+  return true;
+}
+
+bool sozonov_i_image_filtering_block_partitioning_stl::TestTaskSTL::PostProcessingImpl() {
+  auto *out = reinterpret_cast<double *>(task_data->outputs[0]);
+  std::ranges::copy(filtered_image_.begin(), filtered_image_.end(), out);
+  return true;
+}

--- a/tasks/stl/sozonov_i_image_filtering_block_partitioning/src/ops_stl.cpp
+++ b/tasks/stl/sozonov_i_image_filtering_block_partitioning/src/ops_stl.cpp
@@ -3,7 +3,9 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <functional>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "core/util/include/util.hpp"
@@ -86,7 +88,9 @@ bool sozonov_i_image_filtering_block_partitioning_stl::TestTaskSTL::RunImpl() {
                              thread_blocks[t]);
   }
 
-  for (auto &t : threads) t.join();
+  for (auto &t : threads) {
+    t.join();
+  }
 
   return true;
 }


### PR DESCRIPTION
**Стандартная свертка Гаусса (3×3):**

Ядро Гаусса 3x3 (нормированное) для σ=1 имеет вид: 

![image](https://github.com/user-attachments/assets/b76da6d4-aeeb-4625-8cdf-225cb0bd479b)

Каждому пикселю изображения ставится в соответствие новая величина, полученная как сумма произведений значений пикселей из окрестности 3×3 на коэффициенты ядра Гаусса.

Например, если центральный пиксель изображения **𝐼(𝑥, 𝑦)**, то его новое значение **𝐼′(𝑥, 𝑦)** будет: 

![image](https://github.com/user-attachments/assets/ea99a373-c034-4981-888d-ce98fde24597)

**Параллельная реализация:**

Для ускорения вычислений разбиваем изображение на блоки и обрабатываем их параллельно с помощью `std::thread`.

**1. Разбиение на блоки**
-  Устанавливаем размер блока `block_size`.
- Делим изображение на прямоугольные участки (блоки).
- Формируем список координат всех блоков.

**2. Параллельная обработка**
- Запускаем потоки с использованием `std::thread`.
- Каждому потоку динамически назначаются свободные блоки (через `std::atomic`).
- Внутри каждого блока применяем свёртку Гаусса (3×3) к каждому пикселю, избегая краевых выходов.

**3. Запись результата**
- Каждый поток записывает результат в общий выходной массив `filtered_image`.
- После завершения обработки все потоки синхронизируются с помощью `join`.