### PR TITLE
Бессонов Егор. Вариант 19. Технология STL. Поразрядная сортировка для вещественных чисел (тип double) с простым слиянием.

### DIFF
--- a/tasks/stl/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
+++ b/tasks/stl/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
@@ -13,23 +13,23 @@
 #include "stl/bessonov_e_radix_sort_simple_merging/include/ops_stl.hpp"
 
 namespace {
-  std::vector<double> GenerateVector(std::size_t n, double first, double last) {
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_real_distribution<double> dist(first, last);
+std::vector<double> GenerateVector(std::size_t n, double first, double last) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<double> dist(first, last);
 
-    std::vector<double> result(n);
-    for (std::size_t i = 0; i < n; ++i) {
-      result[i] = dist(gen);
-    }
-    return result;
+  std::vector<double> result(n);
+  for (std::size_t i = 0; i < n; ++i) {
+    result[i] = dist(gen);
   }
+  return result;
+}
 }  // namespace
 
 TEST(bessonov_e_radix_sort_simple_merging_stl, FirstTest) {
-  std::vector<double> input_vector = { 3.4, 1.2, 0.5, 7.8, 2.3, 4.5, 6.7, 8.9, 1.0, 0.2, 5.6, 4.3, 9.1, 1.5, 3.0 };
+  std::vector<double> input_vector = {3.4, 1.2, 0.5, 7.8, 2.3, 4.5, 6.7, 8.9, 1.0, 0.2, 5.6, 4.3, 9.1, 1.5, 3.0};
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = { 0.2, 0.5, 1.0, 1.2, 1.5, 2.3, 3.0, 3.4, 4.3, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1 };
+  std::vector<double> result_vector = {0.2, 0.5, 1.0, 1.2, 1.5, 2.3, 3.0, 3.4, 4.3, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1};
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
@@ -47,9 +47,9 @@ TEST(bessonov_e_radix_sort_simple_merging_stl, FirstTest) {
 }
 
 TEST(bessonov_e_radix_sort_simple_merging_stl, SingleElementTest) {
-  std::vector<double> input_vector = { 42.0 };
+  std::vector<double> input_vector = {42.0};
   std::vector<double> output_vector(1, 0.0);
-  std::vector<double> result_vector = { 42.0 };
+  std::vector<double> result_vector = {42.0};
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
@@ -67,9 +67,9 @@ TEST(bessonov_e_radix_sort_simple_merging_stl, SingleElementTest) {
 }
 
 TEST(bessonov_e_radix_sort_simple_merging_stl, NegativeAndPositiveTest) {
-  std::vector<double> input_vector = { -3.2, 1.1, -7.5, 0.0, 4.4, -2.2, 3.3 };
+  std::vector<double> input_vector = {-3.2, 1.1, -7.5, 0.0, 4.4, -2.2, 3.3};
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = { -7.5, -3.2, -2.2, 0.0, 1.1, 3.3, 4.4 };
+  std::vector<double> result_vector = {-7.5, -3.2, -2.2, 0.0, 1.1, 3.3, 4.4};
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
@@ -110,9 +110,9 @@ TEST(bessonov_e_radix_sort_simple_merging_stl, RandomVectorTest) {
 }
 
 TEST(bessonov_e_radix_sort_simple_merging_stl, AllSameElementsTest) {
-  std::vector<double> input_vector = { 3.14, 3.14, 3.14, 3.14 };
+  std::vector<double> input_vector = {3.14, 3.14, 3.14, 3.14};
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = { 3.14, 3.14, 3.14, 3.14 };
+  std::vector<double> result_vector = {3.14, 3.14, 3.14, 3.14};
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
@@ -130,11 +130,11 @@ TEST(bessonov_e_radix_sort_simple_merging_stl, AllSameElementsTest) {
 }
 
 TEST(bessonov_e_radix_sort_simple_merging_stl, ExtremeValuesTest) {
-  std::vector<double> input_vector = { std::numeric_limits<double>::max(), std::numeric_limits<double>::lowest(), 0.0,
-                                    -42.5, 100.0 };
+  std::vector<double> input_vector = {std::numeric_limits<double>::max(), std::numeric_limits<double>::lowest(), 0.0,
+                                      -42.5, 100.0};
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = { std::numeric_limits<double>::lowest(), -42.5, 0.0, 100.0,
-                                     std::numeric_limits<double>::max() };
+  std::vector<double> result_vector = {std::numeric_limits<double>::lowest(), -42.5, 0.0, 100.0,
+                                       std::numeric_limits<double>::max()};
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
@@ -152,9 +152,9 @@ TEST(bessonov_e_radix_sort_simple_merging_stl, ExtremeValuesTest) {
 }
 
 TEST(bessonov_e_radix_sort_simple_merging_stl, TinyNumbersTest) {
-  std::vector<double> input_vector = { 1e-10, -1e-10, 1e-20, -1e-20 };
+  std::vector<double> input_vector = {1e-10, -1e-10, 1e-20, -1e-20};
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = { -1e-10, -1e-20, 1e-20, 1e-10 };
+  std::vector<double> result_vector = {-1e-10, -1e-20, 1e-20, 1e-10};
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
@@ -172,9 +172,9 @@ TEST(bessonov_e_radix_sort_simple_merging_stl, TinyNumbersTest) {
 }
 
 TEST(bessonov_e_radix_sort_simple_merging_stl, ReverseOrderTest) {
-  std::vector<double> input_vector = { 9.1, 8.9, 7.8, 6.7, 5.6, 4.5, 4.3, 3.4, 3.0, 2.3, 1.5, 1.2, 1.0, 0.5, 0.2 };
+  std::vector<double> input_vector = {9.1, 8.9, 7.8, 6.7, 5.6, 4.5, 4.3, 3.4, 3.0, 2.3, 1.5, 1.2, 1.0, 0.5, 0.2};
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = { 0.2, 0.5, 1.0, 1.2, 1.5, 2.3, 3.0, 3.4, 4.3, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1 };
+  std::vector<double> result_vector = {0.2, 0.5, 1.0, 1.2, 1.5, 2.3, 3.0, 3.4, 4.3, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1};
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));

--- a/tasks/stl/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
+++ b/tasks/stl/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
@@ -171,6 +171,26 @@ TEST(bessonov_e_radix_sort_simple_merging_stl, TinyNumbersTest) {
   ASSERT_EQ(output_vector, result_vector);
 }
 
+TEST(bessonov_e_radix_sort_simple_merging_stl, DenormalNumbersTest) {
+  std::vector<double> input_vector = {1e-310, -1e-310, 0.0};
+  std::vector<double> output_vector(input_vector.size(), 0.0);
+  std::vector<double> result_vector = {-1e-310, 0.0, 1e-310};
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL test_task(task_data);
+  ASSERT_TRUE(test_task.Validation());
+  test_task.PreProcessing();
+  test_task.Run();
+  test_task.PostProcessing();
+
+  ASSERT_EQ(output_vector, result_vector);
+}
+
 TEST(bessonov_e_radix_sort_simple_merging_stl, ReverseOrderTest) {
   std::vector<double> input_vector = {9.1, 8.9, 7.8, 6.7, 5.6, 4.5, 4.3, 3.4, 3.0, 2.3, 1.5, 1.2, 1.0, 0.5, 0.2};
   std::vector<double> output_vector(input_vector.size(), 0.0);

--- a/tasks/stl/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
+++ b/tasks/stl/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
@@ -1,0 +1,219 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "stl/bessonov_e_radix_sort_simple_merging/include/ops_stl.hpp"
+
+namespace {
+std::vector<double> GenerateVector(std::size_t n, double first, double last) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<double> dist(first, last);
+
+  std::vector<double> result(n);
+  for (std::size_t i = 0; i < n; ++i) {
+    result[i] = dist(gen);
+  }
+  return result;
+}
+}  // namespace
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, FirstTest) {
+  std::vector<double> input_vector = {3.4, 1.2, 0.5, 7.8, 2.3, 4.5, 6.7, 8.9, 1.0, 0.2, 5.6, 4.3, 9.1, 1.5, 3.0};
+  std::vector<double> output_vector(input_vector.size(), 0.0);
+  std::vector<double> result_vector = {0.2, 0.5, 1.0, 1.2, 1.5, 2.3, 3.0, 3.4, 4.3, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1};
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  ASSERT_TRUE(test_task.Validation());
+  test_task.PreProcessing();
+  test_task.Run();
+  test_task.PostProcessing();
+
+  ASSERT_EQ(output_vector, result_vector);
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, SingleElementTest) {
+  std::vector<double> input_vector = {42.0};
+  std::vector<double> output_vector(1, 0.0);
+  std::vector<double> result_vector = {42.0};
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  ASSERT_TRUE(test_task.Validation());
+  test_task.PreProcessing();
+  test_task.Run();
+  test_task.PostProcessing();
+
+  ASSERT_EQ(output_vector, result_vector);
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, NegativeAndPositiveTest) {
+  std::vector<double> input_vector = {-3.2, 1.1, -7.5, 0.0, 4.4, -2.2, 3.3};
+  std::vector<double> output_vector(input_vector.size(), 0.0);
+  std::vector<double> result_vector = {-7.5, -3.2, -2.2, 0.0, 1.1, 3.3, 4.4};
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  ASSERT_TRUE(test_task.Validation());
+  test_task.PreProcessing();
+  test_task.Run();
+  test_task.PostProcessing();
+
+  ASSERT_EQ(output_vector, result_vector);
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, RandomVectorTest) {
+  const std::size_t n = 1000;
+  std::vector<double> input_vector = GenerateVector(n, -1000.0, 1000.0);
+  std::vector<double> output_vector(n, 0.0);
+
+  std::vector<double> result_vector = input_vector;
+  std::ranges::sort(result_vector);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  ASSERT_TRUE(test_task.Validation());
+  test_task.PreProcessing();
+  test_task.Run();
+  test_task.PostProcessing();
+
+  ASSERT_EQ(output_vector, result_vector);
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, AllSameElementsTest) {
+  std::vector<double> input_vector = {3.14, 3.14, 3.14, 3.14};
+  std::vector<double> output_vector(input_vector.size(), 0.0);
+  std::vector<double> result_vector = {3.14, 3.14, 3.14, 3.14};
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  ASSERT_TRUE(test_task.Validation());
+  test_task.PreProcessing();
+  test_task.Run();
+  test_task.PostProcessing();
+
+  ASSERT_EQ(output_vector, result_vector);
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, ExtremeValuesTest) {
+  std::vector<double> input_vector = {std::numeric_limits<double>::max(), std::numeric_limits<double>::lowest(), 0.0,
+                                      -42.5, 100.0};
+  std::vector<double> output_vector(input_vector.size(), 0.0);
+  std::vector<double> result_vector = {std::numeric_limits<double>::lowest(), -42.5, 0.0, 100.0,
+                                       std::numeric_limits<double>::max()};
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  ASSERT_TRUE(test_task.Validation());
+  test_task.PreProcessing();
+  test_task.Run();
+  test_task.PostProcessing();
+
+  ASSERT_EQ(output_vector, result_vector);
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, TinyNumbersTest) {
+  std::vector<double> input_vector = {1e-10, -1e-10, 1e-20, -1e-20};
+  std::vector<double> output_vector(input_vector.size(), 0.0);
+  std::vector<double> result_vector = {-1e-10, -1e-20, 1e-20, 1e-10};
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  ASSERT_TRUE(test_task.Validation());
+  test_task.PreProcessing();
+  test_task.Run();
+  test_task.PostProcessing();
+
+  ASSERT_EQ(output_vector, result_vector);
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, InvalidInputOutputSizeTest) {
+  std::vector<double> input = {1.0, 2.0, 3.0};
+  std::vector<double> output(2, 0.0);
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  ASSERT_FALSE(test_task.Validation());
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, ValidationEmptyTest) {
+  std::vector<double> input_vector;
+  std::vector<double> output_vector;
+  std::vector<double> result_vector;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  ASSERT_FALSE(test_task.Validation());
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, ReverseOrderTest) {
+  std::vector<double> input_vector = {9.1, 8.9, 7.8, 6.7, 5.6, 4.5, 4.3, 3.4, 3.0, 2.3, 1.5, 1.2, 1.0, 0.5, 0.2};
+  std::vector<double> output_vector(input_vector.size(), 0.0);
+  std::vector<double> result_vector = {0.2, 0.5, 1.0, 1.2, 1.5, 2.3, 3.0, 3.4, 4.3, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1};
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  ASSERT_TRUE(test_task.Validation());
+  test_task.PreProcessing();
+  test_task.Run();
+  test_task.PostProcessing();
+
+  ASSERT_EQ(output_vector, result_vector);
+}

--- a/tasks/stl/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
+++ b/tasks/stl/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <climits>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -12,23 +13,23 @@
 #include "stl/bessonov_e_radix_sort_simple_merging/include/ops_stl.hpp"
 
 namespace {
-std::vector<double> GenerateVector(std::size_t n, double first, double last) {
-  std::random_device rd;
-  std::mt19937 gen(rd());
-  std::uniform_real_distribution<double> dist(first, last);
+  std::vector<double> GenerateVector(std::size_t n, double first, double last) {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_real_distribution<double> dist(first, last);
 
-  std::vector<double> result(n);
-  for (std::size_t i = 0; i < n; ++i) {
-    result[i] = dist(gen);
+    std::vector<double> result(n);
+    for (std::size_t i = 0; i < n; ++i) {
+      result[i] = dist(gen);
+    }
+    return result;
   }
-  return result;
-}
 }  // namespace
 
-TEST(bessonov_e_radix_sort_simple_merging_seq, FirstTest) {
-  std::vector<double> input_vector = {3.4, 1.2, 0.5, 7.8, 2.3, 4.5, 6.7, 8.9, 1.0, 0.2, 5.6, 4.3, 9.1, 1.5, 3.0};
+TEST(bessonov_e_radix_sort_simple_merging_stl, FirstTest) {
+  std::vector<double> input_vector = { 3.4, 1.2, 0.5, 7.8, 2.3, 4.5, 6.7, 8.9, 1.0, 0.2, 5.6, 4.3, 9.1, 1.5, 3.0 };
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = {0.2, 0.5, 1.0, 1.2, 1.5, 2.3, 3.0, 3.4, 4.3, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1};
+  std::vector<double> result_vector = { 0.2, 0.5, 1.0, 1.2, 1.5, 2.3, 3.0, 3.4, 4.3, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1 };
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
@@ -36,7 +37,7 @@ TEST(bessonov_e_radix_sort_simple_merging_seq, FirstTest) {
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
   task_data->outputs_count.emplace_back(output_vector.size());
 
-  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL test_task(task_data);
   ASSERT_TRUE(test_task.Validation());
   test_task.PreProcessing();
   test_task.Run();
@@ -45,10 +46,10 @@ TEST(bessonov_e_radix_sort_simple_merging_seq, FirstTest) {
   ASSERT_EQ(output_vector, result_vector);
 }
 
-TEST(bessonov_e_radix_sort_simple_merging_seq, SingleElementTest) {
-  std::vector<double> input_vector = {42.0};
+TEST(bessonov_e_radix_sort_simple_merging_stl, SingleElementTest) {
+  std::vector<double> input_vector = { 42.0 };
   std::vector<double> output_vector(1, 0.0);
-  std::vector<double> result_vector = {42.0};
+  std::vector<double> result_vector = { 42.0 };
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
@@ -56,7 +57,7 @@ TEST(bessonov_e_radix_sort_simple_merging_seq, SingleElementTest) {
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
   task_data->outputs_count.emplace_back(output_vector.size());
 
-  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL test_task(task_data);
   ASSERT_TRUE(test_task.Validation());
   test_task.PreProcessing();
   test_task.Run();
@@ -65,10 +66,10 @@ TEST(bessonov_e_radix_sort_simple_merging_seq, SingleElementTest) {
   ASSERT_EQ(output_vector, result_vector);
 }
 
-TEST(bessonov_e_radix_sort_simple_merging_seq, NegativeAndPositiveTest) {
-  std::vector<double> input_vector = {-3.2, 1.1, -7.5, 0.0, 4.4, -2.2, 3.3};
+TEST(bessonov_e_radix_sort_simple_merging_stl, NegativeAndPositiveTest) {
+  std::vector<double> input_vector = { -3.2, 1.1, -7.5, 0.0, 4.4, -2.2, 3.3 };
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = {-7.5, -3.2, -2.2, 0.0, 1.1, 3.3, 4.4};
+  std::vector<double> result_vector = { -7.5, -3.2, -2.2, 0.0, 1.1, 3.3, 4.4 };
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
@@ -76,7 +77,7 @@ TEST(bessonov_e_radix_sort_simple_merging_seq, NegativeAndPositiveTest) {
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
   task_data->outputs_count.emplace_back(output_vector.size());
 
-  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL test_task(task_data);
   ASSERT_TRUE(test_task.Validation());
   test_task.PreProcessing();
   test_task.Run();
@@ -85,7 +86,7 @@ TEST(bessonov_e_radix_sort_simple_merging_seq, NegativeAndPositiveTest) {
   ASSERT_EQ(output_vector, result_vector);
 }
 
-TEST(bessonov_e_radix_sort_simple_merging_seq, RandomVectorTest) {
+TEST(bessonov_e_radix_sort_simple_merging_stl, RandomVectorTest) {
   const std::size_t n = 1000;
   std::vector<double> input_vector = GenerateVector(n, -1000.0, 1000.0);
   std::vector<double> output_vector(n, 0.0);
@@ -99,7 +100,7 @@ TEST(bessonov_e_radix_sort_simple_merging_seq, RandomVectorTest) {
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
   task_data->outputs_count.emplace_back(output_vector.size());
 
-  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL test_task(task_data);
   ASSERT_TRUE(test_task.Validation());
   test_task.PreProcessing();
   test_task.Run();
@@ -108,10 +109,10 @@ TEST(bessonov_e_radix_sort_simple_merging_seq, RandomVectorTest) {
   ASSERT_EQ(output_vector, result_vector);
 }
 
-TEST(bessonov_e_radix_sort_simple_merging_seq, AllSameElementsTest) {
-  std::vector<double> input_vector = {3.14, 3.14, 3.14, 3.14};
+TEST(bessonov_e_radix_sort_simple_merging_stl, AllSameElementsTest) {
+  std::vector<double> input_vector = { 3.14, 3.14, 3.14, 3.14 };
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = {3.14, 3.14, 3.14, 3.14};
+  std::vector<double> result_vector = { 3.14, 3.14, 3.14, 3.14 };
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
@@ -119,7 +120,7 @@ TEST(bessonov_e_radix_sort_simple_merging_seq, AllSameElementsTest) {
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
   task_data->outputs_count.emplace_back(output_vector.size());
 
-  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL test_task(task_data);
   ASSERT_TRUE(test_task.Validation());
   test_task.PreProcessing();
   test_task.Run();
@@ -128,12 +129,12 @@ TEST(bessonov_e_radix_sort_simple_merging_seq, AllSameElementsTest) {
   ASSERT_EQ(output_vector, result_vector);
 }
 
-TEST(bessonov_e_radix_sort_simple_merging_seq, ExtremeValuesTest) {
-  std::vector<double> input_vector = {std::numeric_limits<double>::max(), std::numeric_limits<double>::lowest(), 0.0,
-                                      -42.5, 100.0};
+TEST(bessonov_e_radix_sort_simple_merging_stl, ExtremeValuesTest) {
+  std::vector<double> input_vector = { std::numeric_limits<double>::max(), std::numeric_limits<double>::lowest(), 0.0,
+                                    -42.5, 100.0 };
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = {std::numeric_limits<double>::lowest(), -42.5, 0.0, 100.0,
-                                       std::numeric_limits<double>::max()};
+  std::vector<double> result_vector = { std::numeric_limits<double>::lowest(), -42.5, 0.0, 100.0,
+                                     std::numeric_limits<double>::max() };
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
@@ -141,7 +142,7 @@ TEST(bessonov_e_radix_sort_simple_merging_seq, ExtremeValuesTest) {
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
   task_data->outputs_count.emplace_back(output_vector.size());
 
-  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL test_task(task_data);
   ASSERT_TRUE(test_task.Validation());
   test_task.PreProcessing();
   test_task.Run();
@@ -150,10 +151,10 @@ TEST(bessonov_e_radix_sort_simple_merging_seq, ExtremeValuesTest) {
   ASSERT_EQ(output_vector, result_vector);
 }
 
-TEST(bessonov_e_radix_sort_simple_merging_seq, TinyNumbersTest) {
-  std::vector<double> input_vector = {1e-10, -1e-10, 1e-20, -1e-20};
+TEST(bessonov_e_radix_sort_simple_merging_stl, TinyNumbersTest) {
+  std::vector<double> input_vector = { 1e-10, -1e-10, 1e-20, -1e-20 };
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = {-1e-10, -1e-20, 1e-20, 1e-10};
+  std::vector<double> result_vector = { -1e-10, -1e-20, 1e-20, 1e-10 };
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
@@ -161,7 +162,7 @@ TEST(bessonov_e_radix_sort_simple_merging_seq, TinyNumbersTest) {
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
   task_data->outputs_count.emplace_back(output_vector.size());
 
-  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL test_task(task_data);
   ASSERT_TRUE(test_task.Validation());
   test_task.PreProcessing();
   test_task.Run();
@@ -170,50 +171,114 @@ TEST(bessonov_e_radix_sort_simple_merging_seq, TinyNumbersTest) {
   ASSERT_EQ(output_vector, result_vector);
 }
 
-TEST(bessonov_e_radix_sort_simple_merging_seq, InvalidInputOutputSizeTest) {
-  std::vector<double> input = {1.0, 2.0, 3.0};
-  std::vector<double> output(2, 0.0);
+TEST(bessonov_e_radix_sort_simple_merging_stl, ReverseOrderTest) {
+  std::vector<double> input_vector = { 9.1, 8.9, 7.8, 6.7, 5.6, 4.5, 4.3, 3.4, 3.0, 2.3, 1.5, 1.2, 1.0, 0.5, 0.2 };
+  std::vector<double> output_vector(input_vector.size(), 0.0);
+  std::vector<double> result_vector = { 0.2, 0.5, 1.0, 1.2, 1.5, 2.3, 3.0, 3.4, 4.3, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1 };
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL test_task(task_data);
+  ASSERT_TRUE(test_task.Validation());
+  test_task.PreProcessing();
+  test_task.Run();
+  test_task.PostProcessing();
+
+  ASSERT_EQ(output_vector, result_vector);
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_stl, Validation_NullInput) {
+  std::vector<double> output(100);
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(nullptr);
+  task_data->inputs_count.emplace_back(100);
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL task(task_data);
+  ASSERT_FALSE(task.Validation());
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_stl, Validation_NullOutput) {
+  std::vector<double> input(100);
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(nullptr);
+  task_data->outputs_count.emplace_back(100);
+
+  bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL task(task_data);
+  ASSERT_FALSE(task.Validation());
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_stl, Validation_SizeMismatch) {
+  std::vector<double> input(100);
+  std::vector<double> output(50);
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
   task_data->inputs_count.emplace_back(input.size());
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
   task_data->outputs_count.emplace_back(output.size());
 
-  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
-  ASSERT_FALSE(test_task.Validation());
+  bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL task(task_data);
+  ASSERT_FALSE(task.Validation());
 }
 
-TEST(bessonov_e_radix_sort_simple_merging_seq, ValidationEmptyTest) {
-  std::vector<double> input_vector;
-  std::vector<double> output_vector;
-  std::vector<double> result_vector;
-
+TEST(bessonov_e_radix_sort_simple_merging_stl, Validation_ZeroSize) {
+  std::vector<double> input(0);
+  std::vector<double> output(0);
   auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
-  task_data->inputs_count.emplace_back(input_vector.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
-  task_data->outputs_count.emplace_back(output_vector.size());
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
 
-  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
-  ASSERT_FALSE(test_task.Validation());
+  bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL task(task_data);
+  ASSERT_FALSE(task.Validation());
 }
 
-TEST(bessonov_e_radix_sort_simple_merging_seq, ReverseOrderTest) {
-  std::vector<double> input_vector = {9.1, 8.9, 7.8, 6.7, 5.6, 4.5, 4.3, 3.4, 3.0, 2.3, 1.5, 1.2, 1.0, 0.5, 0.2};
-  std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = {0.2, 0.5, 1.0, 1.2, 1.5, 2.3, 3.0, 3.4, 4.3, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1};
+TEST(bessonov_e_radix_sort_simple_merging_stl, Validation_SizeOverflow) {
+  auto huge_size = static_cast<size_t>(INT_MAX) + 1;
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(nullptr);
+  task_data->inputs_count.emplace_back(huge_size);
+  task_data->outputs.emplace_back(nullptr);
+  task_data->outputs_count.emplace_back(huge_size);
+
+  bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL task(task_data);
+  ASSERT_FALSE(task.Validation());
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_stl, Validation_EmptyCounts) {
+  std::vector<double> input(100);
+  std::vector<double> output(100);
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+
+  bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL task(task_data);
+  ASSERT_FALSE(task.Validation());
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_stl, Validation_MaxSize) {
+  auto max_size = static_cast<size_t>(INT_MAX);
+
+  auto* dummy_input = new uint8_t[1];
+  auto* dummy_output = new uint8_t[1];
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
-  task_data->inputs_count.emplace_back(input_vector.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
-  task_data->outputs_count.emplace_back(output_vector.size());
+  task_data->inputs.emplace_back(dummy_input);
+  task_data->inputs_count.emplace_back(max_size);
+  task_data->outputs.emplace_back(dummy_output);
+  task_data->outputs_count.emplace_back(max_size);
 
-  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
-  ASSERT_TRUE(test_task.Validation());
-  test_task.PreProcessing();
-  test_task.Run();
-  test_task.PostProcessing();
+  bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL task(task_data);
+  ASSERT_TRUE(task.Validation());
 
-  ASSERT_EQ(output_vector, result_vector);
+  delete[] dummy_input;
+  delete[] dummy_output;
 }

--- a/tasks/stl/bessonov_e_radix_sort_simple_merging/include/ops_stl.hpp
+++ b/tasks/stl/bessonov_e_radix_sort_simple_merging/include/ops_stl.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace bessonov_e_radix_sort_simple_merging_seq {
+
+class TestTaskSequential : public ppc::core::Task {
+ public:
+  explicit TestTaskSequential(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<double> input_, output_;
+};
+
+}  // namespace bessonov_e_radix_sort_simple_merging_seq

--- a/tasks/stl/bessonov_e_radix_sort_simple_merging/include/ops_stl.hpp
+++ b/tasks/stl/bessonov_e_radix_sort_simple_merging/include/ops_stl.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
 #include <cstddef>
-#include <mutex>
-#include <thread>
+#include <cstdint>
 #include <utility>
 #include <vector>
 

--- a/tasks/stl/bessonov_e_radix_sort_simple_merging/include/ops_stl.hpp
+++ b/tasks/stl/bessonov_e_radix_sort_simple_merging/include/ops_stl.hpp
@@ -25,9 +25,9 @@ class TestTaskSTL : public ppc::core::Task {
 
   static void ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits, size_t start,
                                   size_t end);
-  static void ConvertBitsToDouble(const std::vector<uint64_t>&bits, std::vector<double>&output, size_t start,
+  static void ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output, size_t start,
                                   size_t end);
-  static void RadixSortPass(std::vector<uint64_t>&bits, std::vector<uint64_t>&temp, int shift, size_t start,
+  static void RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_t>& temp, int shift, size_t start,
                             size_t end);
 };
 

--- a/tasks/stl/bessonov_e_radix_sort_simple_merging/include/ops_stl.hpp
+++ b/tasks/stl/bessonov_e_radix_sort_simple_merging/include/ops_stl.hpp
@@ -26,8 +26,7 @@ class TestTaskSTL : public ppc::core::Task {
                                   size_t end);
   static void ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output, size_t start,
                                   size_t end);
-  static void RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_t>& temp, int shift, size_t start,
-                            size_t end);
+  static void RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_t>& temp, int shift);
 };
 
 }  // namespace bessonov_e_radix_sort_simple_merging_stl

--- a/tasks/stl/bessonov_e_radix_sort_simple_merging/include/ops_stl.hpp
+++ b/tasks/stl/bessonov_e_radix_sort_simple_merging/include/ops_stl.hpp
@@ -11,7 +11,7 @@
 namespace bessonov_e_radix_sort_simple_merging_stl {
 
 class TestTaskSTL : public ppc::core::Task {
-public:
+ public:
   explicit TestTaskSTL(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
 
   bool PreProcessingImpl() override;
@@ -19,16 +19,16 @@ public:
   bool RunImpl() override;
   bool PostProcessingImpl() override;
 
-private:
+ private:
   std::vector<double> input_;
   std::vector<double> output_;
 
-  static void ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits,
-                                  size_t start, size_t end);
-  static void ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output,
-                                  size_t start, size_t end);
-  static void RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_t>& temp,
-                            int shift, size_t start, size_t end);
+  static void ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits, size_t start,
+                                  size_t end);
+  static void ConvertBitsToDouble(const std::vector<uint64_t>&bits, std::vector<double>&output, size_t start,
+                                  size_t end);
+  static void RadixSortPass(std::vector<uint64_t>&bits, std::vector<uint64_t>&temp, int shift, size_t start,
+                            size_t end);
 };
 
 }  // namespace bessonov_e_radix_sort_simple_merging_stl

--- a/tasks/stl/bessonov_e_radix_sort_simple_merging/include/ops_stl.hpp
+++ b/tasks/stl/bessonov_e_radix_sort_simple_merging/include/ops_stl.hpp
@@ -1,23 +1,34 @@
 #pragma once
 
+#include <cstddef>
+#include <mutex>
+#include <thread>
 #include <utility>
 #include <vector>
 
 #include "core/task/include/task.hpp"
 
-namespace bessonov_e_radix_sort_simple_merging_seq {
+namespace bessonov_e_radix_sort_simple_merging_stl {
 
-class TestTaskSequential : public ppc::core::Task {
- public:
-  explicit TestTaskSequential(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  class TestTaskSTL : public ppc::core::Task {
+  public:
+    explicit TestTaskSTL(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
 
-  bool PreProcessingImpl() override;
-  bool ValidationImpl() override;
-  bool RunImpl() override;
-  bool PostProcessingImpl() override;
+    bool PreProcessingImpl() override;
+    bool ValidationImpl() override;
+    bool RunImpl() override;
+    bool PostProcessingImpl() override;
 
- private:
-  std::vector<double> input_, output_;
-};
+  private:
+    std::vector<double> input_;
+    std::vector<double> output_;
 
-}  // namespace bessonov_e_radix_sort_simple_merging_seq
+    static void ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits,
+      size_t start, size_t end);
+    static void ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output,
+      size_t start, size_t end);
+    static void RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_t>& temp,
+      int shift, size_t start, size_t end);
+  };
+
+}  // namespace bessonov_e_radix_sort_simple_merging_stl

--- a/tasks/stl/bessonov_e_radix_sort_simple_merging/include/ops_stl.hpp
+++ b/tasks/stl/bessonov_e_radix_sort_simple_merging/include/ops_stl.hpp
@@ -10,25 +10,25 @@
 
 namespace bessonov_e_radix_sort_simple_merging_stl {
 
-  class TestTaskSTL : public ppc::core::Task {
-  public:
-    explicit TestTaskSTL(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+class TestTaskSTL : public ppc::core::Task {
+public:
+  explicit TestTaskSTL(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
 
-    bool PreProcessingImpl() override;
-    bool ValidationImpl() override;
-    bool RunImpl() override;
-    bool PostProcessingImpl() override;
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
 
-  private:
-    std::vector<double> input_;
-    std::vector<double> output_;
+private:
+  std::vector<double> input_;
+  std::vector<double> output_;
 
-    static void ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits,
-      size_t start, size_t end);
-    static void ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output,
-      size_t start, size_t end);
-    static void RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_t>& temp,
-      int shift, size_t start, size_t end);
-  };
+  static void ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits,
+                                  size_t start, size_t end);
+  static void ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output,
+                                  size_t start, size_t end);
+  static void RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_t>& temp,
+                            int shift, size_t start, size_t end);
+};
 
 }  // namespace bessonov_e_radix_sort_simple_merging_stl

--- a/tasks/stl/bessonov_e_radix_sort_simple_merging/perf_tests/main.cpp
+++ b/tasks/stl/bessonov_e_radix_sort_simple_merging/perf_tests/main.cpp
@@ -1,0 +1,83 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "stl/bessonov_e_radix_sort_simple_merging/include/ops_stl.hpp"
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, test_pipeline_run) {
+  const int n = 5000000;
+  std::vector<double> input_vector(n);
+  for (int i = 0; i < n; i++) {
+    input_vector[i] = static_cast<double>(n - i);
+  }
+  std::vector<double> output_vector(n, 0.0);
+
+  std::vector<double> result_vector = input_vector;
+  std::ranges::sort(result_vector);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  auto test_task = std::make_shared<bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential>(task_data);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [t0]() {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  ASSERT_EQ(output_vector, result_vector);
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, test_task_run) {
+  const int n = 5000000;
+  std::vector<double> input_vector(n);
+  for (int i = 0; i < n; i++) {
+    input_vector[i] = static_cast<double>(n - i);
+  }
+  std::vector<double> output_vector(n, 0.0);
+
+  std::vector<double> result_vector = input_vector;
+  std::ranges::sort(result_vector);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  auto test_task = std::make_shared<bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential>(task_data);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [t0]() {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  ASSERT_EQ(output_vector, result_vector);
+}

--- a/tasks/stl/bessonov_e_radix_sort_simple_merging/perf_tests/main.cpp
+++ b/tasks/stl/bessonov_e_radix_sort_simple_merging/perf_tests/main.cpp
@@ -27,7 +27,7 @@ TEST(bessonov_e_radix_sort_simple_merging_seq, test_pipeline_run) {
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
   task_data->outputs_count.emplace_back(output_vector.size());
 
-  auto test_task = std::make_shared<bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential>(task_data);
+  auto test_task = std::make_shared<bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL>(task_data);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;
@@ -63,7 +63,7 @@ TEST(bessonov_e_radix_sort_simple_merging_seq, test_task_run) {
   task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
   task_data->outputs_count.emplace_back(output_vector.size());
 
-  auto test_task = std::make_shared<bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential>(task_data);
+  auto test_task = std::make_shared<bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL>(task_data);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;

--- a/tasks/stl/bessonov_e_radix_sort_simple_merging/src/ops_stl.cpp
+++ b/tasks/stl/bessonov_e_radix_sort_simple_merging/src/ops_stl.cpp
@@ -53,7 +53,9 @@ void TestTaskSTL::RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_
   for (size_t i = 0; i < num_threads; ++i) {
     size_t start = i * block_size;
     size_t end = std::min(start + block_size, n);
-    if (start >= n) break;
+    if (start >= n) {
+      break;
+    }
 
     threads.emplace_back([&, start, end, i]() {
       auto& counts = local_counts[i];
@@ -141,7 +143,9 @@ bool bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL::RunImpl() {
       if (start >= n) break;
       threads.emplace_back(ConvertDoubleToBits, std::cref(input_), std::ref(bits), start, end);
     }
-    for (auto& t : threads) t.join();
+    for (auto& t : threads) {
+      t.join();
+    }
   }
 
   constexpr int kPasses = sizeof(uint64_t);
@@ -154,10 +158,14 @@ bool bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL::RunImpl() {
     for (size_t i = 0; i < num_threads; ++i) {
       size_t start = i * block_size;
       size_t end = std::min(start + block_size, n);
-      if (start >= n) break;
+      if (start >= n) {
+        break;
+      }
       threads.emplace_back(ConvertBitsToDouble, std::cref(bits), std::ref(output_), start, end);
     }
-    for (auto& t : threads) t.join();
+    for (auto& t : threads) {
+      t.join();
+    }
   }
 
   return true;

--- a/tasks/stl/bessonov_e_radix_sort_simple_merging/src/ops_stl.cpp
+++ b/tasks/stl/bessonov_e_radix_sort_simple_merging/src/ops_stl.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <functional>

--- a/tasks/stl/bessonov_e_radix_sort_simple_merging/src/ops_stl.cpp
+++ b/tasks/stl/bessonov_e_radix_sort_simple_merging/src/ops_stl.cpp
@@ -15,13 +15,9 @@ namespace bessonov_e_radix_sort_simple_merging_stl {
 void TestTaskSTL::ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits, size_t start,
                                       size_t end) {
   for (size_t i = start; i < end; ++i) {
-    uint64_t b = 0;
+    uint64_t b;
     std::memcpy(&b, &input[i], sizeof(double));
-    if ((b & (1ULL << 63)) != 0ULL) {
-      b = ~b;
-    } else {
-      b ^= (1ULL << 63);
-    }
+    b ^= (-static_cast<int64_t>(b >> 63) | (1ULL << 63));
     bits[i] = b;
   }
 }
@@ -30,12 +26,8 @@ void TestTaskSTL::ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::ve
                                       size_t end) {
   for (size_t i = start; i < end; ++i) {
     uint64_t b = bits[i];
-    if ((b & (1ULL << 63)) != 0ULL) {
-      b ^= (1ULL << 63);
-    } else {
-      b = ~b;
-    }
-    double d = 0.0;
+    b ^= (((b >> 63) - 1) | (1ULL << 63));
+    double d;
     std::memcpy(&d, &b, sizeof(double));
     output[i] = d;
   }

--- a/tasks/stl/bessonov_e_radix_sort_simple_merging/src/ops_stl.cpp
+++ b/tasks/stl/bessonov_e_radix_sort_simple_merging/src/ops_stl.cpp
@@ -7,7 +7,6 @@
 #include <cstring>
 #include <functional>
 #include <limits>
-#include <numeric>
 #include <thread>
 #include <vector>
 

--- a/tasks/stl/bessonov_e_radix_sort_simple_merging/src/ops_stl.cpp
+++ b/tasks/stl/bessonov_e_radix_sort_simple_merging/src/ops_stl.cpp
@@ -15,7 +15,7 @@ namespace bessonov_e_radix_sort_simple_merging_stl {
 void TestTaskSTL::ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits, size_t start,
                                       size_t end) {
   for (size_t i = start; i < end; ++i) {
-    uint64_t b;
+    uint64_t b = 0;
     std::memcpy(&b, &input[i], sizeof(double));
     b ^= (-static_cast<int64_t>(b >> 63) | (1ULL << 63));
     bits[i] = b;
@@ -27,7 +27,7 @@ void TestTaskSTL::ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::ve
   for (size_t i = start; i < end; ++i) {
     uint64_t b = bits[i];
     b ^= (((b >> 63) - 1) | (1ULL << 63));
-    double d;
+    double d = NAN;
     std::memcpy(&d, &b, sizeof(double));
     output[i] = d;
   }

--- a/tasks/stl/bessonov_e_radix_sort_simple_merging/src/ops_stl.cpp
+++ b/tasks/stl/bessonov_e_radix_sort_simple_merging/src/ops_stl.cpp
@@ -1,0 +1,92 @@
+#include "stl/bessonov_e_radix_sort_simple_merging/include/ops_stl.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+bool bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential::PreProcessingImpl() {
+  unsigned int input_size = task_data->inputs_count[0];
+  auto* in_ptr = reinterpret_cast<double*>(task_data->inputs[0]);
+  input_.assign(in_ptr, in_ptr + input_size);
+
+  unsigned int output_size = task_data->outputs_count[0];
+  output_.resize(output_size);
+
+  return true;
+}
+
+bool bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential::ValidationImpl() {
+  if (task_data->inputs[0] == nullptr || task_data->outputs[0] == nullptr) {
+    return false;
+  }
+
+  if (task_data->inputs_count[0] == 0) {
+    return false;
+  }
+
+  if (task_data->inputs_count[0] != task_data->outputs_count[0]) {
+    return false;
+  }
+
+  return true;
+}
+
+bool bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential::RunImpl() {
+  size_t n = input_.size();
+  std::vector<uint64_t> bits(n);
+
+  for (size_t i = 0; i < n; i++) {
+    uint64_t b = 0;
+    std::memcpy(&b, &input_[i], sizeof(double));
+    if ((b & (1ULL << 63)) != 0ULL) {
+      b = ~b;
+    } else {
+      b ^= (1ULL << 63);
+    }
+    bits[i] = b;
+  }
+
+  const int radix = 256;
+  const int passes = 8;
+  std::vector<uint64_t> temp(n);
+
+  for (int pass = 0; pass < passes; pass++) {
+    int shift = pass * 8;
+    std::vector<size_t> count(radix, 0);
+
+    for (size_t i = 0; i < n; i++) {
+      int digit = static_cast<int>((bits[i] >> shift) & 0xFF);
+      count[digit]++;
+    }
+    for (int i = 1; i < radix; i++) {
+      count[i] += count[i - 1];
+    }
+    for (size_t i = n; i-- > 0;) {
+      int digit = static_cast<int>((bits[i] >> shift) & 0xFF);
+      temp[--count[digit]] = bits[i];
+    }
+    bits.swap(temp);
+  }
+
+  for (size_t i = 0; i < n; i++) {
+    uint64_t b = bits[i];
+    if ((b & (1ULL << 63)) != 0ULL) {
+      b ^= (1ULL << 63);
+    } else {
+      b = ~b;
+    }
+    double d = 0.0;
+    std::memcpy(&d, &b, sizeof(double));
+    output_[i] = d;
+  }
+
+  return true;
+}
+
+bool bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential::PostProcessingImpl() {
+  for (size_t i = 0; i < output_.size(); i++) {
+    reinterpret_cast<double*>(task_data->outputs[0])[i] = output_[i];
+  }
+  return true;
+}

--- a/tasks/stl/bessonov_e_radix_sort_simple_merging/src/ops_stl.cpp
+++ b/tasks/stl/bessonov_e_radix_sort_simple_merging/src/ops_stl.cpp
@@ -10,29 +10,27 @@
 
 namespace bessonov_e_radix_sort_simple_merging_stl {
 
-void TestTaskSTL::ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits,
-                                      size_t start, size_t end) {
+void TestTaskSTL::ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits, size_t start,
+                                      size_t end) {
   for (size_t i = start; i < end; ++i) {
     uint64_t b = 0;
     std::memcpy(&b, &input[i], sizeof(double));
     if ((b & (1ULL << 63)) != 0ULL) {
       b = ~b;
-    }
-    else {
+    } else {
       b ^= (1ULL << 63);
     }
     bits[i] = b;
   }
 }
 
-void TestTaskSTL::ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output,
-                                      size_t start, size_t end) {
+void TestTaskSTL::ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output, size_t start,
+                                      size_t end) {
   for (size_t i = start; i < end; ++i) {
     uint64_t b = bits[i];
     if ((b & (1ULL << 63)) != 0ULL) {
       b ^= (1ULL << 63);
-    }
-    else {
+    } else {
       b = ~b;
     }
     double d = 0.0;
@@ -41,8 +39,8 @@ void TestTaskSTL::ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::ve
   }
 }
 
-void TestTaskSTL::RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_t>& temp,
-                                int shift, size_t start, size_t end) {
+void TestTaskSTL::RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_t>& temp, int shift, size_t start,
+                                size_t end) {
   constexpr int radix = 256;
   std::array<size_t, radix> count{};
 
@@ -130,7 +128,7 @@ bool bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL::RunImpl() {
           int digit = static_cast<int>((bits[j] >> shift) & 0xFF);
           counts[digit]++;
         }
-        });
+      });
     }
     for (auto& t : threads) t.join();
     threads.clear();
@@ -144,7 +142,7 @@ bool bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL::RunImpl() {
 
     std::partial_sum(global_count.begin(), global_count.end(), global_count.begin());
 
-    for (size_t i = n; i-- > 0; ) {
+    for (size_t i = n; i-- > 0;) {
       int digit = static_cast<int>((bits[i] >> shift) & 0xFF);
       temp[--global_count[digit]] = bits[i];
     }

--- a/tasks/stl/bessonov_e_radix_sort_simple_merging/src/ops_stl.cpp
+++ b/tasks/stl/bessonov_e_radix_sort_simple_merging/src/ops_stl.cpp
@@ -11,6 +11,8 @@
 #include <thread>
 #include <vector>
 
+#include "core/util/include/util.hpp"
+
 namespace bessonov_e_radix_sort_simple_merging_stl {
 
 void TestTaskSTL::ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits, size_t start,
@@ -37,7 +39,8 @@ void TestTaskSTL::ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::ve
 void TestTaskSTL::RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_t>& temp, int shift) {
   constexpr int kRadix = 256;
   const size_t n = bits.size();
-  const size_t num_threads = std::thread::hardware_concurrency();
+  size_t num_threads = ppc::util::GetPPCNumThreads();
+  num_threads = std::max<size_t>(1, num_threads);
   const size_t block_size = (n + num_threads - 1) / num_threads;
 
   std::vector<std::array<size_t, kRadix>> local_counts(num_threads);
@@ -128,7 +131,8 @@ bool bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL::RunImpl() {
   std::vector<uint64_t> bits(n);
   std::vector<uint64_t> temp(n);
 
-  const size_t num_threads = std::thread::hardware_concurrency();
+  size_t num_threads = ppc::util::GetPPCNumThreads();
+  num_threads = std::max<size_t>(1, num_threads);
   const size_t block_size = (n + num_threads - 1) / num_threads;
   {
     std::vector<std::thread> threads;

--- a/tasks/stl/bessonov_e_radix_sort_simple_merging/src/ops_stl.cpp
+++ b/tasks/stl/bessonov_e_radix_sort_simple_merging/src/ops_stl.cpp
@@ -65,7 +65,9 @@ void TestTaskSTL::RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_
       }
     });
   }
-  for (auto& t : threads) t.join();
+  for (auto& t : threads) {
+    t.join();
+  }
   threads.clear();
 
   std::array<size_t, kRadix> global_count{};
@@ -140,7 +142,9 @@ bool bessonov_e_radix_sort_simple_merging_stl::TestTaskSTL::RunImpl() {
     for (size_t i = 0; i < num_threads; ++i) {
       size_t start = i * block_size;
       size_t end = std::min(start + block_size, n);
-      if (start >= n) break;
+      if (start >= n) {
+        break;
+      }
       threads.emplace_back(ConvertDoubleToBits, std::cref(input_), std::ref(bits), start, end);
     }
     for (auto& t : threads) {


### PR DESCRIPTION
1. Параллельная обработка
- Данные разбиваются на блоки по числу потоков (std::thread::hardware_concurrency()).
- Каждый поток работает со своей частью массива при:
- - Конвертации double → uint64_t.

- - Подсчёте частот цифр в каждом разряде.

- - Обратной конвертации uint64_t → double.

3. Поразрядная сортировка (Radix Sort)

- Выполняется 8 проходов (по байту на каждый из 64 бит).

- На каждом проходе:

- - Локально в каждом потоке подсчитываются частоты цифр (0..255).

- - Частоты объединяются в глобальный массив global_count.

- - Вычисляются позиции элементов с помощью std::partial_sum.

- - Элементы переставляются во временный массив temp.

