### PR TITLE
Милованкин Максим. Задача 5. Вариант 28. Технология MPI+TBB. Повышение контраста полутонового изображения посредством линейной растяжки гистограммы.

### DIFF
--- a/tasks/all/milovankin_m_histogram_stretching/func_tests/main.cpp
+++ b/tasks/all/milovankin_m_histogram_stretching/func_tests/main.cpp
@@ -152,37 +152,25 @@ TEST(milovankin_m_histogram_stretching_all, test_mpi_gather_logic) {
     // GTEST_SKIP() << "Skipping MPI gather test on single process.";
   }
 
-  const std::size_t data_size = 20;
+  const std::size_t data_size = 120;
   std::vector<uint8_t> data_in(data_size);
   std::vector<uint8_t> data_out(data_size);
   std::vector<uint8_t> data_expected(data_size);
 
+  // Fill with the same value, then check that the value is the same on all processes to ensure that results were
+  // gathered correctly.
   if (rank == 0) {
-    std::size_t chunk_size = data_size / size;
-    std::size_t remainder = data_size % size;
-
-    for (int r = 0; r < size; ++r) {
-      std::size_t r_start_idx = r * chunk_size;
-      std::size_t r_chunk_size = (r == size - 1) ? (chunk_size + remainder) : chunk_size;
-      std::size_t r_end_idx = r_start_idx + r_chunk_size;
-
-      // Ensure end index does not exceed data size
-      r_end_idx = std::min(r_end_idx, data_size);
-
-      // Fill the chunk corresponding to rank 'r' with value 'r'
-      for (std::size_t i = r_start_idx; i < r_end_idx; ++i) {
-        data_in[i] = static_cast<uint8_t>(r);        // Assign rank number as value
-        data_expected[i] = static_cast<uint8_t>(r);  // Expected output is same for this simple case
-      }
-    }
+    std::ranges::fill(data_in.begin(), data_in.end(), static_cast<uint8_t>(42));
+    std::ranges::fill(data_expected.begin(), data_expected.end(), static_cast<uint8_t>(42));
   }
 
   boost::mpi::broadcast(world, data_in.data(), static_cast<int>(data_in.size()), 0);
 
+  // Create and run the task
   auto task = CreateParallelTask(data_in, data_out);
   ASSERT_TRUE(task.Validation());
   ASSERT_TRUE(task.PreProcessing());
-  task.Run();  // Trigger the GatherResults logic
+  task.Run();
   task.PostProcessing();
 
   if (rank == 0) {

--- a/tasks/all/milovankin_m_histogram_stretching/func_tests/main.cpp
+++ b/tasks/all/milovankin_m_histogram_stretching/func_tests/main.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include <boost/mpi.hpp>
+#include <boost/mpi/communicator.hpp>
 #include <cstdint>
 #include <memory>
 #include <vector>

--- a/tasks/all/milovankin_m_histogram_stretching/func_tests/main.cpp
+++ b/tasks/all/milovankin_m_histogram_stretching/func_tests/main.cpp
@@ -1,0 +1,141 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi.hpp>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "../include/ops_all.hpp"
+#include "core/task/include/task.hpp"
+
+namespace {
+
+milovankin_m_histogram_stretching_all::TestTaskAll CreateParallelTask(std::vector<uint8_t>& data_in,
+                                                                      std::vector<uint8_t>& data_out) {
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+
+  task_data->inputs.emplace_back(data_in.data());
+  task_data->inputs_count.emplace_back(static_cast<uint32_t>(data_in.size()));
+
+  task_data->outputs.emplace_back(data_out.data());
+  task_data->outputs_count.emplace_back(static_cast<uint32_t>(data_out.size()));
+
+  return milovankin_m_histogram_stretching_all::TestTaskAll(task_data);
+}
+
+}  // namespace
+
+TEST(milovankin_m_histogram_stretching_all, test_small_data) {
+  boost::mpi::communicator world;
+
+  // clang-format off
+  std::vector<uint8_t> data_in = {
+    50, 100, 100, 200,
+    100, 50, 250, 100,
+    100, 100, 200, 50,
+    100, 200, 50, 250,
+  };
+  std::vector<uint8_t> data_expected = {
+    0,   64,  64,  191,
+    64,  0,   255, 64,
+    64,  64,  191, 0,
+    64,  191, 0,   255
+  };
+  // clang-format on
+  std::vector<uint8_t> data_out(data_in.size());
+
+  milovankin_m_histogram_stretching_all::TestTaskAll task = CreateParallelTask(data_in, data_out);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+
+  if (world.rank() == 0) {
+    ASSERT_EQ(data_out, data_expected);
+  }
+}
+
+TEST(milovankin_m_histogram_stretching_all, test_single_element) {
+  boost::mpi::communicator world;
+
+  std::vector<uint8_t> data_in = {150};
+  std::vector<uint8_t> data_out(1);
+
+  auto task = CreateParallelTask(data_in, data_out);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+
+  if (world.rank() == 0) {
+    EXPECT_EQ(data_out[0], 150);
+  }
+}
+
+TEST(milovankin_m_histogram_stretching_all, test_empty_data) {
+  std::vector<uint8_t> data_in;
+  std::vector<uint8_t> data_out;
+
+  auto task = CreateParallelTask(data_in, data_out);
+  ASSERT_FALSE(task.Validation());
+}
+
+TEST(milovankin_m_histogram_stretching_all, test_validation_fail_different_buffer_sizes) {
+  std::vector<uint8_t> data_in(10, 100);
+  std::vector<uint8_t> data_out(5);
+
+  auto task = CreateParallelTask(data_in, data_out);
+  ASSERT_FALSE(task.Validation());
+}
+
+TEST(milovankin_m_histogram_stretching_all, test_validation_fail_output_buffer_empty) {
+  std::vector<uint8_t> data_in(10);
+  std::vector<uint8_t> data_out;
+
+  auto task = CreateParallelTask(data_in, data_out);
+  ASSERT_FALSE(task.Validation());
+}
+
+TEST(milovankin_m_histogram_stretching_all, test_filled_image) {
+  boost::mpi::communicator world;
+
+  // clang-format off
+  std::vector<uint8_t> data_in(100, 123);
+  std::vector<uint8_t> data_expected(100, 123);
+  // clang-format on
+  std::vector<uint8_t> data_out(data_in.size());
+
+  milovankin_m_histogram_stretching_all::TestTaskAll task = CreateParallelTask(data_in, data_out);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  task.Run();
+  task.PostProcessing();
+
+  if (world.rank() == 0) {
+    ASSERT_EQ(data_expected, data_out);
+  }
+}
+
+TEST(milovankin_m_histogram_stretching_all, test_big_image) {
+  boost::mpi::communicator world;
+
+  std::vector<uint8_t> data_in(1024, 100);
+  std::vector<uint8_t> data_out(data_in.size());
+
+  data_in[0] = 50;
+  data_in[1] = 125;
+
+  std::vector<uint8_t> data_expected(data_in.size(), 170);
+  data_expected[0] = 0;
+  data_expected[1] = 255;
+
+  milovankin_m_histogram_stretching_all::TestTaskAll task = CreateParallelTask(data_in, data_out);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  task.Run();
+  task.PostProcessing();
+
+  if (world.rank() == 0) {
+    ASSERT_EQ(data_expected, data_out);
+  }
+}

--- a/tasks/all/milovankin_m_histogram_stretching/include/ops_all.hpp
+++ b/tasks/all/milovankin_m_histogram_stretching/include/ops_all.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace milovankin_m_histogram_stretching_all {
+
+class TestTaskAll : public ppc::core::Task {
+ public:
+  explicit TestTaskAll(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<uint8_t> img_;
+  boost::mpi::communicator world_;
+};
+
+}  // namespace milovankin_m_histogram_stretching_all

--- a/tasks/all/milovankin_m_histogram_stretching/perf_tests/main.cpp
+++ b/tasks/all/milovankin_m_histogram_stretching/perf_tests/main.cpp
@@ -45,7 +45,7 @@ TEST(milovankin_m_histogram_stretching_all, test_pipeline_run) {
   }
 
   // Broadcast data to all processes
-  boost::mpi::broadcast(world, data_in.data(), data_in.size(), 0);
+  boost::mpi::broadcast(world, data_in.data(), static_cast<int>(data_in.size()), 0);
 
   auto task =
       std::make_shared<milovankin_m_histogram_stretching_all::TestTaskAll>(CreateParallelTask(data_in, data_out));
@@ -98,7 +98,7 @@ TEST(milovankin_m_histogram_stretching_all, test_task_run) {
   }
 
   // Broadcast data to all processes
-  boost::mpi::broadcast(world, data_in.data(), data_in.size(), 0);
+  boost::mpi::broadcast(world, data_in.data(), static_cast<int>(data_in.size()), 0);
 
   auto task =
       std::make_shared<milovankin_m_histogram_stretching_all::TestTaskAll>(CreateParallelTask(data_in, data_out));

--- a/tasks/all/milovankin_m_histogram_stretching/perf_tests/main.cpp
+++ b/tasks/all/milovankin_m_histogram_stretching/perf_tests/main.cpp
@@ -45,8 +45,9 @@ TEST(milovankin_m_histogram_stretching_all, test_pipeline_run) {
     data_out.resize(123456789);
   }
 
-  // Broadcast data to all processes
-  boost::mpi::broadcast(world, data_in.data(), static_cast<int>(data_in.size()), 0);
+  // clang-format off
+  boost::mpi::broadcast(world, data_in.data(), static_cast<int>(data_in.size()), 0); // keeps saying no header included
+  // clang-format on
 
   auto task =
       std::make_shared<milovankin_m_histogram_stretching_all::TestTaskAll>(CreateParallelTask(data_in, data_out));

--- a/tasks/all/milovankin_m_histogram_stretching/perf_tests/main.cpp
+++ b/tasks/all/milovankin_m_histogram_stretching/perf_tests/main.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <boost/mpi/collectives.hpp>
+#include <boost/mpi/collectives/broadcast.hpp>
 #include <boost/mpi/communicator.hpp>
 #include <chrono>
 #include <cstdint>
@@ -45,9 +46,7 @@ TEST(milovankin_m_histogram_stretching_all, test_pipeline_run) {
     data_out.resize(123456789);
   }
 
-  // clang-format off
-  boost::mpi::broadcast(world, data_in.data(), static_cast<int>(data_in.size()), 0); // keeps saying no header included
-  // clang-format on
+  boost::mpi::broadcast(world, data_in.data(), static_cast<int>(data_in.size()), 0);
 
   auto task =
       std::make_shared<milovankin_m_histogram_stretching_all::TestTaskAll>(CreateParallelTask(data_in, data_out));

--- a/tasks/all/milovankin_m_histogram_stretching/perf_tests/main.cpp
+++ b/tasks/all/milovankin_m_histogram_stretching/perf_tests/main.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <boost/mpi/collectives.hpp>
 #include <boost/mpi/communicator.hpp>
 #include <chrono>
 #include <cstdint>

--- a/tasks/all/milovankin_m_histogram_stretching/perf_tests/main.cpp
+++ b/tasks/all/milovankin_m_histogram_stretching/perf_tests/main.cpp
@@ -1,0 +1,134 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "../include/ops_all.hpp"
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+
+namespace {
+
+milovankin_m_histogram_stretching_all::TestTaskAll CreateParallelTask(std::vector<uint8_t>& data_in,
+                                                                      std::vector<uint8_t>& data_out) {
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+
+  task_data->inputs.emplace_back(data_in.data());
+  task_data->inputs_count.emplace_back(static_cast<uint32_t>(data_in.size()));
+
+  task_data->outputs.emplace_back(data_out.data());
+  task_data->outputs_count.emplace_back(static_cast<uint32_t>(data_out.size()));
+
+  return milovankin_m_histogram_stretching_all::TestTaskAll(task_data);
+}
+
+}  // namespace
+
+TEST(milovankin_m_histogram_stretching_all, test_pipeline_run) {
+  boost::mpi::communicator world;
+
+  std::vector<uint8_t> data_in;
+  std::vector<uint8_t> data_out;
+
+  // Only rank 0 initializes the input data
+  if (world.rank() == 0) {
+    data_in.resize(123456789, 123);
+    data_out.resize(data_in.size());
+    data_in.front() = 5;
+    data_in.back() = 155;
+  } else {
+    data_in.resize(123456789);
+    data_out.resize(123456789);
+  }
+
+  // Broadcast data to all processes
+  boost::mpi::broadcast(world, data_in.data(), data_in.size(), 0);
+
+  auto task =
+      std::make_shared<milovankin_m_histogram_stretching_all::TestTaskAll>(CreateParallelTask(data_in, data_out));
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(task);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+
+  // Only rank 0 prints results and verifies output
+  if (world.rank() == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+    // Verify output correctness
+    std::vector<uint8_t> data_expected(data_in.size(), 201);  // ((123 - 5) * 255 + 150 / 2) / 150 = 201
+    data_expected.front() = 0;
+    data_expected.back() = 255;
+
+    EXPECT_EQ(data_out, data_expected);
+  }
+}
+
+TEST(milovankin_m_histogram_stretching_all, test_task_run) {
+  boost::mpi::communicator world;
+
+  std::vector<uint8_t> data_in;
+  std::vector<uint8_t> data_out;
+
+  // Only rank 0 initializes the input data
+  if (world.rank() == 0) {
+    data_in.resize(123456789, 123);
+    data_out.resize(data_in.size());
+    data_in.front() = 5;
+    data_in.back() = 155;
+  } else {
+    data_in.resize(123456789);
+    data_out.resize(123456789);
+  }
+
+  // Broadcast data to all processes
+  boost::mpi::broadcast(world, data_in.data(), data_in.size(), 0);
+
+  auto task =
+      std::make_shared<milovankin_m_histogram_stretching_all::TestTaskAll>(CreateParallelTask(data_in, data_out));
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(task);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+
+  // Only rank 0 prints results and verifies output
+  if (world.rank() == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+    // Verify output correctness
+    std::vector<uint8_t> data_expected(data_in.size(), 201);  // ((123 - 5) * 255 + 150 / 2) / 150 = 201
+    data_expected.front() = 0;
+    data_expected.back() = 255;
+
+    EXPECT_EQ(data_out, data_expected);
+  }
+}

--- a/tasks/all/milovankin_m_histogram_stretching/src/ops_all.cpp
+++ b/tasks/all/milovankin_m_histogram_stretching/src/ops_all.cpp
@@ -47,24 +47,51 @@ bool TestTaskAll::RunImpl() {
   int rank = world_.rank();
   int size = world_.size();
 
-  // Each process finds local min/max of its portion of the data
-  std::size_t chunk_size = img_.size() / size;
-  std::size_t start_idx = rank * chunk_size;
-  std::size_t end_idx = (rank == size - 1) ? img_.size() : (rank + 1) * chunk_size;
+  // Dataset smaller than grain size
+  bool is_small_dataset = img_.size() <= 100;
 
-  // Image size is smaller than number of processes
-  if (img_.size() < static_cast<std::size_t>(size)) {
+  if (is_small_dataset) {
     if (rank == 0) {
-      chunk_size = img_.size();
-      end_idx = img_.size();
-    } else {
-      chunk_size = 0;
-      start_idx = end_idx = 0;
+      uint8_t min_val = std::numeric_limits<uint8_t>::max();
+      uint8_t max_val = 0;
+      for (size_t i = 0; i < img_.size(); ++i) {
+        min_val = std::min(min_val, img_[i]);
+        max_val = std::max(max_val, img_[i]);
+      }
+
+      // Apply stretching if needed (min != max)
+      if (min_val != max_val) {
+        const int delta = max_val - min_val;
+        for (size_t i = 0; i < img_.size(); ++i) {
+          img_[i] = static_cast<uint8_t>(((img_[i] - min_val) * 255 + delta / 2) / delta);
+        }
+      }
     }
+
+    world_.barrier();
+    return true;
+  }
+
+  std::size_t img_size = img_.size();
+  boost::mpi::broadcast(world_, img_size, 0);
+
+  // Calculate chunk sizes based on the image size
+  std::size_t chunk_size = img_size / size;
+  // Last process might get more elements if division isn't even
+  std::size_t remainder = img_size % size;
+
+  std::size_t start_idx = rank * chunk_size;
+  std::size_t end_idx;
+
+  if (rank == size - 1) {
+    // Last process gets any remainder
+    end_idx = start_idx + chunk_size + remainder;
+  } else {
+    end_idx = start_idx + chunk_size;
   }
 
   // Skip if process has no data
-  if (start_idx >= img_.size() || chunk_size == 0) {
+  if (start_idx >= img_size || start_idx >= end_idx) {
     MinMaxPair dummy(std::numeric_limits<uint8_t>::max(), 0);
     MinMaxPair global_minmax;
 
@@ -77,7 +104,7 @@ bool TestTaskAll::RunImpl() {
 
   // Use TBB to find local min/max in parallel within this process
   const std::vector<uint8_t>& img_ref = img_;
-  const std::size_t grain_size = std::max(std::size_t(1024), chunk_size / 16);
+  const std::size_t grain_size = std::max(std::size_t(16), (end_idx - start_idx) / 16);
 
   MinMaxPair local_minmax = tbb::parallel_reduce(
       tbb::blocked_range<std::size_t>(start_idx, end_idx, grain_size), MinMaxPair(),
@@ -122,14 +149,24 @@ bool TestTaskAll::RunImpl() {
 
   if (size > 1) {
     if (rank == 0) {
-      // Process 0 already has its chunk processed in place
+      // Process 0 already has its chunk processed
       // Receive chunks from other processes
       for (int src_rank = 1; src_rank < size; ++src_rank) {
         std::size_t src_start = src_rank * chunk_size;
-        std::size_t src_end = (src_rank == size - 1) ? img_.size() : (src_rank + 1) * chunk_size;
+        std::size_t src_end;
+
+        if (src_rank == size - 1) {
+          // Last process has remainder
+          src_end = src_start + chunk_size + remainder;
+        } else {
+          src_end = src_start + chunk_size;
+        }
+
         std::size_t src_size = src_end - src_start;
 
-        if (src_size > 0) {
+        if (src_size > 0 && src_start < img_size) {
+          src_size = std::min(src_size, img_size - src_start);
+
           std::vector<uint8_t> temp_buffer(src_size);
           world_.recv(src_rank, 0, temp_buffer.data(), src_size);
           std::copy(temp_buffer.begin(), temp_buffer.end(), img_.begin() + src_start);
@@ -137,8 +174,10 @@ bool TestTaskAll::RunImpl() {
       }
     } else {
       // Send the processed chunk to process 0
-      if (chunk_size > 0) {
-        world_.send(0, 0, img_.data() + start_idx, chunk_size);
+      std::size_t my_chunk_size = end_idx - start_idx;
+      if (my_chunk_size > 0 && start_idx < img_size) {
+        my_chunk_size = std::min(my_chunk_size, img_size - start_idx);
+        world_.send(0, 0, img_.data() + start_idx, my_chunk_size);
       }
     }
   }

--- a/tasks/all/milovankin_m_histogram_stretching/src/ops_all.cpp
+++ b/tasks/all/milovankin_m_histogram_stretching/src/ops_all.cpp
@@ -1,0 +1,155 @@
+#include "../include/ops_all.hpp"
+
+#include <algorithm>
+#include <boost/mpi.hpp>
+#include <boost/mpi/collectives.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include "oneapi/tbb/blocked_range.h"
+#include "oneapi/tbb/parallel_for.h"
+#include "oneapi/tbb/parallel_reduce.h"
+
+namespace milovankin_m_histogram_stretching_all {
+
+bool TestTaskAll::ValidationImpl() {
+  return !task_data->inputs.empty() && !task_data->inputs_count.empty() && task_data->inputs_count[0] != 0 &&
+         !task_data->outputs.empty() && !task_data->outputs_count.empty() &&
+         task_data->inputs_count[0] == task_data->outputs_count[0];
+}
+
+bool TestTaskAll::PreProcessingImpl() {
+  const uint8_t* input_data = task_data->inputs.front();
+  const uint32_t input_size = task_data->inputs_count.front();
+
+  img_.assign(input_data, input_data + input_size);
+  return true;
+}
+
+struct MinMaxPair {
+  uint8_t min_val;
+  uint8_t max_val;
+
+  MinMaxPair() : min_val(std::numeric_limits<uint8_t>::max()), max_val(0) {}
+
+  MinMaxPair(uint8_t min, uint8_t max) : min_val(min), max_val(max) {}
+};
+
+bool TestTaskAll::RunImpl() {
+  int rank = world_.rank();
+  int size = world_.size();
+
+  // Each process finds local min/max of its portion of the data
+  std::size_t chunk_size = img_.size() / size;
+  std::size_t start_idx = rank * chunk_size;
+  std::size_t end_idx = (rank == size - 1) ? img_.size() : (rank + 1) * chunk_size;
+
+  // Image size is smaller than number of processes
+  if (img_.size() < static_cast<std::size_t>(size)) {
+    if (rank == 0) {
+      chunk_size = img_.size();
+      end_idx = img_.size();
+    } else {
+      chunk_size = 0;
+      start_idx = end_idx = 0;
+    }
+  }
+
+  // Skip if process has no data
+  if (start_idx >= img_.size() || chunk_size == 0) {
+    MinMaxPair dummy(std::numeric_limits<uint8_t>::max(), 0);
+    MinMaxPair global_minmax;
+
+    // Still participate in reduction
+    boost::mpi::all_reduce(world_, dummy, global_minmax, [](const MinMaxPair& a, const MinMaxPair& b) -> MinMaxPair {
+      return {std::min(a.min_val, b.min_val), std::max(a.max_val, b.max_val)};
+    });
+    return true;
+  }
+
+  // Use TBB to find local min/max in parallel within this process
+  const std::vector<uint8_t>& img_ref = img_;
+  const std::size_t grain_size = std::max(std::size_t(1024), chunk_size / 16);
+
+  MinMaxPair local_minmax = tbb::parallel_reduce(
+      tbb::blocked_range<std::size_t>(start_idx, end_idx, grain_size), MinMaxPair(),
+      [&img_ref](const tbb::blocked_range<std::size_t>& range, MinMaxPair init) -> MinMaxPair {
+        uint8_t local_min = init.min_val;
+        uint8_t local_max = init.max_val;
+
+        for (std::size_t i = range.begin(); i != range.end(); ++i) {
+          uint8_t val = img_ref[i];
+          local_min = std::min(val, local_min);
+          local_max = std::max(val, local_max);
+        }
+
+        return {local_min, local_max};
+      },
+      [](MinMaxPair a, MinMaxPair b) -> MinMaxPair {
+        return {std::min(a.min_val, b.min_val), std::max(a.max_val, b.max_val)};
+      });
+
+  // Find global min/max across all processes
+  MinMaxPair global_minmax;
+  boost::mpi::all_reduce(world_, local_minmax, global_minmax,
+                         [](const MinMaxPair& a, const MinMaxPair& b) -> MinMaxPair {
+                           return {std::min(a.min_val, b.min_val), std::max(a.max_val, b.max_val)};
+                         });
+
+  // Apply stretching in parallel
+  uint8_t min_val = global_minmax.min_val;
+  uint8_t max_val = global_minmax.max_val;
+
+  if (min_val != max_val) {
+    const int delta = max_val - min_val;
+    std::vector<uint8_t>& img_ref_mut = img_;
+
+    tbb::parallel_for(tbb::blocked_range<std::size_t>(start_idx, end_idx, grain_size),
+                      [min_val, delta, &img_ref_mut](const tbb::blocked_range<std::size_t>& range) {
+                        for (std::size_t i = range.begin(); i != range.end(); ++i) {
+                          img_ref_mut[i] = static_cast<uint8_t>(((img_ref_mut[i] - min_val) * 255 + delta / 2) / delta);
+                        }
+                      });
+  }
+
+  if (size > 1) {
+    if (rank == 0) {
+      // Process 0 already has its chunk processed in place
+      // Receive chunks from other processes
+      for (int src_rank = 1; src_rank < size; ++src_rank) {
+        std::size_t src_start = src_rank * chunk_size;
+        std::size_t src_end = (src_rank == size - 1) ? img_.size() : (src_rank + 1) * chunk_size;
+        std::size_t src_size = src_end - src_start;
+
+        if (src_size > 0) {
+          std::vector<uint8_t> temp_buffer(src_size);
+          world_.recv(src_rank, 0, temp_buffer.data(), src_size);
+          std::copy(temp_buffer.begin(), temp_buffer.end(), img_.begin() + src_start);
+        }
+      }
+    } else {
+      // Send the processed chunk to process 0
+      if (chunk_size > 0) {
+        world_.send(0, 0, img_.data() + start_idx, chunk_size);
+      }
+    }
+  }
+
+  return true;
+}
+
+bool TestTaskAll::PostProcessingImpl() {
+  uint8_t* output_data = task_data->outputs[0];
+  const uint32_t output_size = task_data->outputs_count[0];
+  const uint32_t copy_size = std::min(output_size, static_cast<uint32_t>(img_.size()));
+
+  if (world_.rank() == 0) {
+    std::copy_n(img_.cbegin(), copy_size, output_data);
+  }
+
+  return true;
+}
+
+}  // namespace milovankin_m_histogram_stretching_all

--- a/tasks/all/milovankin_m_histogram_stretching/src/ops_all.cpp
+++ b/tasks/all/milovankin_m_histogram_stretching/src/ops_all.cpp
@@ -1,9 +1,8 @@
 #include "../include/ops_all.hpp"
 
 #include <algorithm>
+#include <boost/mpi.hpp>
 #include <boost/mpi/collectives.hpp>
-#include <boost/serialization/nvp.hpp>
-#include <boost/serialization/serialization.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -44,144 +43,111 @@ struct MinMaxPair {
   }
 };
 
-bool TestTaskAll::RunImpl() {
-  int rank = world_.rank();
-  int size = world_.size();
-
-  // Dataset smaller than grain size
-  bool is_small_dataset = img_.size() <= 100;
-
-  if (is_small_dataset) {
-    if (rank == 0) {
-      uint8_t min_val = std::numeric_limits<uint8_t>::max();
-      uint8_t max_val = 0;
-      for (size_t i = 0; i < img_.size(); ++i) {
-        min_val = std::min(min_val, img_[i]);
-        max_val = std::max(max_val, img_[i]);
-      }
-
-      // Apply stretching if needed (min != max)
-      if (min_val != max_val) {
-        const int delta = max_val - min_val;
-        for (size_t i = 0; i < img_.size(); ++i) {
-          img_[i] = static_cast<uint8_t>(((img_[i] - min_val) * 255 + delta / 2) / delta);
-        }
-      }
-    }
-
-    world_.barrier();
-    return true;
-  }
-
-  std::size_t img_size = img_.size();
-  boost::mpi::broadcast(world_, img_size, 0);
-
-  // Calculate chunk sizes based on the image size
-  std::size_t chunk_size = img_size / size;
-  // Last process might get more elements if division isn't even
-  std::size_t remainder = img_size % size;
-
-  std::size_t start_idx = rank * chunk_size;
-  std::size_t end_idx = 0;
-
-  if (rank == size - 1) {
-    // Last process gets any remainder
-    end_idx = start_idx + chunk_size + remainder;
-  } else {
-    end_idx = start_idx + chunk_size;
-  }
-
-  // Skip if process has no data
-  if (start_idx >= img_size || start_idx >= end_idx) {
-    MinMaxPair dummy(std::numeric_limits<uint8_t>::max(), 0);
-    MinMaxPair global_minmax;
-
-    // Still participate in reduction
-    boost::mpi::all_reduce(world_, dummy, global_minmax, [](const MinMaxPair& a, const MinMaxPair& b) -> MinMaxPair {
-      return {std::min(a.min_val, b.min_val), std::max(a.max_val, b.max_val)};
-    });
-    return true;
-  }
-
-  // Use TBB to find local min/max in parallel within this process
-  const std::vector<uint8_t>& img_ref = img_;
+MinMaxPair CalculateLocalMinMax(const std::vector<uint8_t>& img, std::size_t start_idx, std::size_t end_idx) {
   const std::size_t grain_size = std::max(std::size_t(16), (end_idx - start_idx) / 16);
-
-  MinMaxPair local_minmax = tbb::parallel_reduce(
+  return tbb::parallel_reduce(
       tbb::blocked_range<std::size_t>(start_idx, end_idx, grain_size), MinMaxPair(),
-      [&img_ref](const tbb::blocked_range<std::size_t>& range, MinMaxPair init) -> MinMaxPair {
+      [&img](const tbb::blocked_range<std::size_t>& range, MinMaxPair init) -> MinMaxPair {
         uint8_t local_min = init.min_val;
         uint8_t local_max = init.max_val;
-
         for (std::size_t i = range.begin(); i != range.end(); ++i) {
-          uint8_t val = img_ref[i];
+          uint8_t val = img[i];
           local_min = std::min(val, local_min);
           local_max = std::max(val, local_max);
         }
-
         return {local_min, local_max};
       },
       [](MinMaxPair a, MinMaxPair b) -> MinMaxPair {
         return {std::min(a.min_val, b.min_val), std::max(a.max_val, b.max_val)};
       });
+}
 
-  // Find global min/max across all processes
-  MinMaxPair global_minmax;
-  boost::mpi::all_reduce(world_, local_minmax, global_minmax,
-                         [](const MinMaxPair& a, const MinMaxPair& b) -> MinMaxPair {
-                           return {std::min(a.min_val, b.min_val), std::max(a.max_val, b.max_val)};
-                         });
+void ApplyStretchingLocal(std::vector<uint8_t>& img, std::size_t start_idx, std::size_t end_idx, uint8_t global_min,
+                          uint8_t global_max) {
+  if (global_min == global_max) return;  // No stretching needed
 
-  // Apply stretching in parallel
-  uint8_t min_val = global_minmax.min_val;
-  uint8_t max_val = global_minmax.max_val;
+  const int delta = global_max - global_min;
+  const std::size_t grain_size = std::max(std::size_t(16), (end_idx - start_idx) / 16);
 
-  if (min_val != max_val) {
-    const int delta = max_val - min_val;
-    std::vector<uint8_t>& img_ref_mut = img_;
+  tbb::parallel_for(tbb::blocked_range<std::size_t>(start_idx, end_idx, grain_size),
+                    [global_min, delta, &img](const tbb::blocked_range<std::size_t>& range) {
+                      for (std::size_t i = range.begin(); i != range.end(); ++i) {
+                        img[i] = static_cast<uint8_t>(((img[i] - global_min) * 255 + delta / 2) / delta);
+                      }
+                    });
+}
 
-    tbb::parallel_for(tbb::blocked_range<std::size_t>(start_idx, end_idx, grain_size),
-                      [min_val, delta, &img_ref_mut](const tbb::blocked_range<std::size_t>& range) {
-                        for (std::size_t i = range.begin(); i != range.end(); ++i) {
-                          img_ref_mut[i] = static_cast<uint8_t>(((img_ref_mut[i] - min_val) * 255 + delta / 2) / delta);
-                        }
-                      });
-  }
+// Gather results using MPI
+void GatherResults(boost::mpi::communicator& world, std::vector<uint8_t>& img, std::size_t img_size,
+                   std::size_t chunk_size, std::size_t remainder) {
+  int rank = world.rank();
+  int size = world.size();
 
-  if (size > 1) {
-    if (rank == 0) {
-      // Process 0 already has its chunk processed
-      // Receive chunks from other processes
-      for (int src_rank = 1; src_rank < size; ++src_rank) {
-        std::size_t src_start = src_rank * chunk_size;
-        std::size_t src_end = 0;
+  if (size <= 1) return;
 
-        if (src_rank == size - 1) {
-          // Last process has remainder
-          src_end = src_start + chunk_size + remainder;
-        } else {
-          src_end = src_start + chunk_size;
-        }
+  if (rank == 0) {
+    for (int src_rank = 1; src_rank < size; ++src_rank) {
+      std::size_t src_start = src_rank * chunk_size;
+      std::size_t src_size = (src_rank == size - 1) ? (chunk_size + remainder) : chunk_size;
 
-        std::size_t src_size = src_end - src_start;
-
-        if (src_size > 0 && src_start < img_size) {
-          src_size = std::min(src_size, img_size - src_start);
-
-          std::vector<uint8_t> temp_buffer(src_size);
-          world_.recv(src_rank, 0, temp_buffer.data(), static_cast<int>(src_size));
-          std::copy(temp_buffer.begin(), temp_buffer.end(), img_.begin() + src_start);
-        }
-      }
-    } else {
-      // Send the processed chunk to process 0
-      std::size_t my_chunk_size = end_idx - start_idx;
-      if (my_chunk_size > 0 && start_idx < img_size) {
-        my_chunk_size = std::min(my_chunk_size, img_size - start_idx);
-        world_.send(0, 0, img_.data() + start_idx, static_cast<int>(my_chunk_size));
+      if (src_size > 0 && src_start < img_size) {
+        src_size = std::min(src_size, img_size - src_start);
+        world.recv(src_rank, 0, img.data() + src_start, static_cast<int>(src_size));
       }
     }
+  } else {
+    std::size_t start_idx = rank * chunk_size;
+    std::size_t my_chunk_size = (rank == size - 1) ? (chunk_size + remainder) : chunk_size;
+
+    if (my_chunk_size > 0 && start_idx < img_size) {
+      my_chunk_size = std::min(my_chunk_size, img_size - start_idx);
+      world.send(0, 0, img.data() + start_idx, static_cast<int>(my_chunk_size));
+    }
   }
+}
+
+bool TestTaskAll::RunImpl() {
+  int rank = world_.rank();
+  int size = world_.size();
+
+  bool is_small_dataset = img_.size() <= 100;
+  if (is_small_dataset) {
+    if (rank == 0) {
+      MinMaxPair minmax = CalculateLocalMinMax(img_, 0, img_.size());
+      ApplyStretchingLocal(img_, 0, img_.size(), minmax.min_val, minmax.max_val);
+    }
+    world_.barrier();
+    return true;
+  }
+
+  std::size_t img_size = img_.size();
+  boost::mpi::broadcast(world_, img_size, 0);  // Ensure all processes know the size
+
+  // Calculate chunk sizes
+  std::size_t chunk_size = img_size / size;
+  std::size_t remainder = img_size % size;
+  std::size_t start_idx = rank * chunk_size;
+  std::size_t end_idx = (rank == size - 1) ? (start_idx + chunk_size + remainder) : (start_idx + chunk_size);
+
+  // Handle cases where a process might get no data
+  if (start_idx >= img_size || start_idx >= end_idx) {
+    MinMaxPair local_minmax(std::numeric_limits<uint8_t>::max(), 0);  // Participate with neutral values
+    MinMaxPair global_minmax;
+    boost::mpi::all_reduce(world_, local_minmax, global_minmax, [](const MinMaxPair& a, const MinMaxPair& b) {
+      return MinMaxPair{std::min(a.min_val, b.min_val), std::max(a.max_val, b.max_val)};
+    });
+  } else {
+    MinMaxPair local_minmax = CalculateLocalMinMax(img_, start_idx, end_idx);
+
+    MinMaxPair global_minmax;
+    boost::mpi::all_reduce(world_, local_minmax, global_minmax, [](const MinMaxPair& a, const MinMaxPair& b) {
+      return MinMaxPair{std::min(a.min_val, b.min_val), std::max(a.max_val, b.max_val)};
+    });
+
+    ApplyStretchingLocal(img_, start_idx, end_idx, global_minmax.min_val, global_minmax.max_val);
+  }
+
+  GatherResults(world_, img_, img_size, chunk_size, remainder);
 
   return true;
 }

--- a/tasks/all/milovankin_m_histogram_stretching/src/ops_all.cpp
+++ b/tasks/all/milovankin_m_histogram_stretching/src/ops_all.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <boost/mpi.hpp>
 #include <boost/mpi/collectives.hpp>
+#include <boost/serialization/access.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -35,6 +36,11 @@ struct MinMaxPair {
   MinMaxPair() : min_val(std::numeric_limits<uint8_t>::max()), max_val(0) {}
 
   MinMaxPair(uint8_t min, uint8_t max) : min_val(min), max_val(max) {}
+
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int) {
+    ar & min_val & max_val;
+  }
 };
 
 bool TestTaskAll::RunImpl() {


### PR DESCRIPTION
Сначала каждый процесс находит локальные min и max в своей части данных с помощью `parallel_reduce`, затем результаты со всех процессов объединяются через `boost::mpi::all_reduce`. Итоговое изображение получается применением к каждому пикселю формулы `value = ((value - min) * 255 + (max - min)/2) / (max - min)` параллельно в каждом процессе, используя `parallel_for`. Обработанные части изображения собираются на процессе с рангом 0 с помощью `boost::mpi::send/recv`.