### PR TITLE
Ануфриев Даниил. Задача 1. Вариант 11. Технология STL. Вычисление многомерных интегралов с использованием многошаговой схемы (метод Симпсона).

### DIFF
--- a/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
@@ -128,7 +128,7 @@ TEST(anufriev_d_integrals_simpson_stl, test_no_output_buffer) {
 }
 
 TEST(anufriev_d_integrals_simpson_stl_coverage, MinValidIterationsN0_is_2_1D) {
-  std::vector<double> in = {1, 0.0, 3.0, 2, 0}; 
+  std::vector<double> in = {1, 0.0, 3.0, 2, 0};
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
   anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
@@ -228,9 +228,7 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, ManyIterations_PossibleSingleThr
 }
 
 TEST(anufriev_d_integrals_simpson_stl_coverage, TestWithFuncCode1_2D) {
-  std::vector<double> in = {2, 0.0, kPi / 2.0, 50,
-                                0.0, kPi / 2.0, 50,
-                                1};              
+  std::vector<double> in = {2, 0.0, kPi / 2.0, 50, 0.0, kPi / 2.0, 50, 1};              
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
   anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);

--- a/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
@@ -126,3 +126,117 @@ TEST(anufriev_d_integrals_simpson_stl, test_no_output_buffer) {
   anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
   EXPECT_FALSE(task.Validation());
 }
+
+TEST(anufriev_d_integrals_simpson_stl_coverage, MinValidIterationsN0_is_2_1D) {
+  std::vector<double> in = {1, 0.0, 3.0, 2, 0}; 
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+  EXPECT_NEAR(out_buffer[0], 9.0, 1e-5);
+}
+
+TEST(anufriev_d_integrals_simpson_stl_coverage, MinValidIterationsN0_is_2_2D) {
+  std::vector<double> in = {2, 0.0, 1.0, 2, 0.0, 1.0, 2, 0};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+  EXPECT_NEAR(out_buffer[0], 2.0 / 3.0, 1e-5);
+}
+
+TEST(anufriev_d_integrals_simpson_stl_coverage, FewIterationsN0_is_4_1D) {
+  std::vector<double> in = {1, 0.0, kPi, 4, 1};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+  EXPECT_NEAR(out_buffer[0], 2.0, 1e-5);
+}
+
+TEST(anufriev_d_integrals_simpson_stl_coverage, ManyIterationsN0_1D) {
+  std::vector<double> in = {1, 0.0, 1.0, 100, 0};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+  EXPECT_NEAR(out_buffer[0], 1.0 / 3.0, 1e-4);
+}
+
+TEST(anufriev_d_integrals_simpson_stl_coverage, MultiDim_N_Mismatch) {
+  std::vector<double> in = {2, 0.0, 1.0, 100, 0.0, 1.0, 2, 0};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+  EXPECT_NEAR(out_buffer[0], 2.0 / 3.0, 1e-4);
+}
+
+TEST(anufriev_d_integrals_simpson_stl_coverage, MultiDim_N_Mismatch_Reversed) {
+  std::vector<double> in = {2, 0.0, 1.0, 2, 0.0, 1.0, 100, 0};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+  EXPECT_NEAR(out_buffer[0], 2.0 / 3.0, 1e-4);
+}
+
+TEST(anufriev_d_integrals_simpson_stl_coverage, Preprocessing_InvalidN_Zero) {
+  std::vector<double> in = {1, 0.0, 1.0, 0, 0};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
+  ASSERT_FALSE(task.PreProcessing());
+}
+
+TEST(anufriev_d_integrals_simpson_stl_coverage, Preprocessing_InvalidN_Odd) {
+  std::vector<double> in = {1, 0.0, 1.0, 3, 0};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
+  ASSERT_FALSE(task.PreProcessing());
+}
+
+TEST(anufriev_d_integrals_simpson_stl_coverage, ManyIterations_PossibleSingleThreadPath) {
+  std::vector<double> in = {1, 0.0, 2.0, 200, 0};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+  EXPECT_NEAR(out_buffer[0], 8.0 / 3.0, 1e-4);
+}
+
+TEST(anufriev_d_integrals_simpson_stl_coverage, TestWithFuncCode1_2D) {
+  std::vector<double> in = {2, 0.0, kPi / 2.0, 50,
+                                0.0, kPi / 2.0, 50,
+                                1};              
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+  EXPECT_NEAR(out_buffer[0], 1.0, 1e-3);
+}

--- a/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
@@ -228,7 +228,7 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, ManyIterations_PossibleSingleThr
 }
 
 TEST(anufriev_d_integrals_simpson_stl_coverage, TestWithFuncCode1_2D) {
-  std::vector<double> in = {2, 0.0, kPi / 2.0, 50, 0.0, kPi / 2.0, 50, 1};              
+  std::vector<double> in = {2, 0.0, kPi / 2.0, 50, 0.0, kPi / 2.0, 50, 1};
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
   anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);

--- a/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
@@ -249,7 +249,7 @@ TEST(anufriev_d_integrals_simpson_stl, Run_Without_PreProcessing) {
   std::vector<double> out = {0.0};
   auto td = MakeTaskData(in, out);
   IntegralsSimpsonSTL task(td);
-  EXPECT_THROW(task.Run(), ::std::exception);
+  EXPECT_ANY_THROW(task.Run());
 }
 
 TEST(anufriev_d_integrals_simpson_stl, PostProcessing_Only) {
@@ -257,7 +257,7 @@ TEST(anufriev_d_integrals_simpson_stl, PostProcessing_Only) {
   std::vector<double> out = {0.0};
   auto td = MakeTaskData(in, out);
   IntegralsSimpsonSTL task(td);
-  EXPECT_THROW(task.PostProcessing(), ::std::exception);
+  EXPECT_ANY_THROW(task.PostProcessing());
 }
 
 TEST(anufriev_d_integrals_simpson_stl, Validation_EmptyOutputsCount) {

--- a/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
@@ -160,7 +160,7 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, FewIterationsN0_is_4_1D) {
   ASSERT_TRUE(task.PreProcessing());
   ASSERT_TRUE(task.Run());
   ASSERT_TRUE(task.PostProcessing());
-  EXPECT_NEAR(out_buffer[0], 2.0, 1e-5);
+  EXPECT_NEAR(out_buffer[0], 2.0, 5e-3);
 }
 
 TEST(anufriev_d_integrals_simpson_stl_coverage, ManyIterationsN0_1D) {
@@ -205,7 +205,7 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, Preprocessing_InvalidN_Zero) {
   auto td = MakeTaskData(in, out_buffer);
   anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
   ASSERT_TRUE(task.Validation());
-  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_FALSE(task.PreProcessing());
 }
 
 TEST(anufriev_d_integrals_simpson_stl_coverage, Preprocessing_InvalidN_Odd) {
@@ -214,7 +214,7 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, Preprocessing_InvalidN_Odd) {
   auto td = MakeTaskData(in, out_buffer);
   anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
   ASSERT_TRUE(task.Validation());
-  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_FALSE(task.PreProcessing());
 }
 
 TEST(anufriev_d_integrals_simpson_stl_coverage, ManyIterations_PossibleSingleThreadPath) {

--- a/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
@@ -283,7 +283,7 @@ TEST(anufriev_d_integrals_simpson_stl, 3D_SumOfSquares) {
 }
 
 TEST(anufriev_d_integrals_simpson_stl, 1D_SinFunction) {
-  std::vector<double> in = {1, 0.0, kPi/2, 100, 1};
+  std::vector<double> in = {1, 0.0, kPi / 2, 100, 1};
   std::vector<double> out(1, 0.0);
   auto td = MakeTaskData(in, out);
   IntegralsSimpsonSTL task(td);
@@ -307,10 +307,10 @@ TEST(anufriev_d_integrals_simpson_stl, test_PreProcessingImpl_small_input_size) 
   double dummy = 0.0;
   auto td = std::make_shared<ppc::core::TaskData>();
   td->inputs.push_back(reinterpret_cast<uint8_t*>(&dummy));
-  td->inputs_count.push_back(static_cast<uint32_t>(sizeof(double) / 2));  // 4 байта
+  td->inputs_count.push_back(static_cast<uint32_t>(sizeof(double) / 2));
   std::vector<double> out(1);
   td->outputs.push_back(reinterpret_cast<uint8_t*>(out.data()));
   td->outputs_count.push_back(static_cast<uint32_t>(sizeof(double)));
   anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
   EXPECT_FALSE(task.PreProcessingImpl());
-} // namespace anufriev_d_integrals_simpson_stl
+}  // namespace anufriev_d_integrals_simpson_stl

--- a/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <exception>
 #include <memory>
 #include <numbers>
 #include <vector>
@@ -248,7 +249,7 @@ TEST(anufriev_d_integrals_simpson_stl, Run_Without_PreProcessing) {
   std::vector<double> out = {0.0};
   auto td = MakeTaskData(in, out);
   IntegralsSimpsonSTL task(td);
-  EXPECT_THROW(task.Run(), std::exception);
+  EXPECT_THROW(task.Run(), ::std::exception);
 }
 
 TEST(anufriev_d_integrals_simpson_stl, PostProcessing_Only) {
@@ -256,7 +257,7 @@ TEST(anufriev_d_integrals_simpson_stl, PostProcessing_Only) {
   std::vector<double> out = {0.0};
   auto td = MakeTaskData(in, out);
   IntegralsSimpsonSTL task(td);
-  EXPECT_THROW(task.PostProcessing(), std::exception);
+  EXPECT_THROW(task.PostProcessing(), ::std::exception);
 }
 
 TEST(anufriev_d_integrals_simpson_stl, Validation_EmptyOutputsCount) {

--- a/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
@@ -24,6 +24,8 @@ std::shared_ptr<ppc::core::TaskData> MakeTaskData(const std::vector<double>& ele
 }
 }  // namespace
 
+using namespace anufriev_d_integrals_simpson_stl;
+
 TEST(anufriev_d_integrals_simpson_stl, test_1D_sin) {
   std::vector<double> in = {1, 0.0, kPi / 2.0, 100, 1};
   std::vector<double> out_buffer(1, 0.0);
@@ -127,7 +129,7 @@ TEST(anufriev_d_integrals_simpson_stl, test_no_output_buffer) {
   EXPECT_FALSE(task.Validation());
 }
 
-TEST(anufriev_d_integrals_simpson_stl_coverage, MinValidIterationsN0_is_2_1D) {
+TEST(anufriev_d_integrals_simpson_stl, MinValidIterationsN0_is_2_1D) {
   std::vector<double> in = {1, 0.0, 3.0, 2, 0};
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
@@ -139,7 +141,7 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, MinValidIterationsN0_is_2_1D) {
   EXPECT_NEAR(out_buffer[0], 9.0, 1e-5);
 }
 
-TEST(anufriev_d_integrals_simpson_stl_coverage, MinValidIterationsN0_is_2_2D) {
+TEST(anufriev_d_integrals_simpson_stl, MinValidIterationsN0_is_2_2D) {
   std::vector<double> in = {2, 0.0, 1.0, 2, 0.0, 1.0, 2, 0};
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
@@ -151,7 +153,7 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, MinValidIterationsN0_is_2_2D) {
   EXPECT_NEAR(out_buffer[0], 2.0 / 3.0, 1e-5);
 }
 
-TEST(anufriev_d_integrals_simpson_stl_coverage, FewIterationsN0_is_4_1D) {
+TEST(anufriev_d_integrals_simpson_stl, FewIterationsN0_is_4_1D) {
   std::vector<double> in = {1, 0.0, kPi, 4, 1};
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
@@ -163,7 +165,7 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, FewIterationsN0_is_4_1D) {
   EXPECT_NEAR(out_buffer[0], 2.0, 5e-3);
 }
 
-TEST(anufriev_d_integrals_simpson_stl_coverage, ManyIterationsN0_1D) {
+TEST(anufriev_d_integrals_simpson_stl, ManyIterationsN0_1D) {
   std::vector<double> in = {1, 0.0, 1.0, 100, 0};
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
@@ -175,7 +177,7 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, ManyIterationsN0_1D) {
   EXPECT_NEAR(out_buffer[0], 1.0 / 3.0, 1e-4);
 }
 
-TEST(anufriev_d_integrals_simpson_stl_coverage, MultiDim_N_Mismatch) {
+TEST(anufriev_d_integrals_simpson_stl, MultiDim_N_Mismatch) {
   std::vector<double> in = {2, 0.0, 1.0, 100, 0.0, 1.0, 2, 0};
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
@@ -187,7 +189,7 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, MultiDim_N_Mismatch) {
   EXPECT_NEAR(out_buffer[0], 2.0 / 3.0, 1e-4);
 }
 
-TEST(anufriev_d_integrals_simpson_stl_coverage, MultiDim_N_Mismatch_Reversed) {
+TEST(anufriev_d_integrals_simpson_stl, MultiDim_N_Mismatch_Reversed) {
   std::vector<double> in = {2, 0.0, 1.0, 2, 0.0, 1.0, 100, 0};
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
@@ -199,7 +201,7 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, MultiDim_N_Mismatch_Reversed) {
   EXPECT_NEAR(out_buffer[0], 2.0 / 3.0, 1e-4);
 }
 
-TEST(anufriev_d_integrals_simpson_stl_coverage, Preprocessing_InvalidN_Zero) {
+TEST(anufriev_d_integrals_simpson_stl, Preprocessing_InvalidN_Zero) {
   std::vector<double> in = {1, 0.0, 1.0, 0, 0};
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
@@ -208,7 +210,7 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, Preprocessing_InvalidN_Zero) {
   ASSERT_FALSE(task.PreProcessing());
 }
 
-TEST(anufriev_d_integrals_simpson_stl_coverage, Preprocessing_InvalidN_Odd) {
+TEST(anufriev_d_integrals_simpson_stl, Preprocessing_InvalidN_Odd) {
   std::vector<double> in = {1, 0.0, 1.0, 3, 0};
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
@@ -217,7 +219,7 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, Preprocessing_InvalidN_Odd) {
   ASSERT_FALSE(task.PreProcessing());
 }
 
-TEST(anufriev_d_integrals_simpson_stl_coverage, ManyIterations_PossibleSingleThreadPath) {
+TEST(anufriev_d_integrals_simpson_stl, ManyIterations_PossibleSingleThreadPath) {
   std::vector<double> in = {1, 0.0, 2.0, 200, 0};
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
@@ -229,7 +231,7 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, ManyIterations_PossibleSingleThr
   EXPECT_NEAR(out_buffer[0], 8.0 / 3.0, 1e-4);
 }
 
-TEST(anufriev_d_integrals_simpson_stl_coverage, TestWithFuncCode1_2D) {
+TEST(anufriev_d_integrals_simpson_stl, TestWithFuncCode1_2D) {
   std::vector<double> in = {2, 0.0, kPi / 2.0, 50, 0.0, kPi / 2.0, 50, 1};
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
@@ -240,3 +242,75 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, TestWithFuncCode1_2D) {
   ASSERT_TRUE(task.PostProcessing());
   EXPECT_NEAR(out_buffer[0], 1.0, 1e-3);
 }
+
+TEST(anufriev_d_integrals_simpson_stl, Run_Without_PreProcessing) {
+  std::vector<double> in = {1, 0.0, 1.0, 2, 0};
+  std::vector<double> out = {0.0};
+  auto td = MakeTaskData(in, out);
+  IntegralsSimpsonSTL task(td);
+  EXPECT_THROW(task.Run(), std::exception);
+}
+
+TEST(anufriev_d_integrals_simpson_stl, PostProcessing_Only) {
+  std::vector<double> in = {1, 0.0, 1.0, 2, 0};
+  std::vector<double> out = {0.0};
+  auto td = MakeTaskData(in, out);
+  IntegralsSimpsonSTL task(td);
+  EXPECT_THROW(task.PostProcessing(), std::exception);
+}
+
+TEST(anufriev_d_integrals_simpson_stl, Validation_EmptyOutputsCount) {
+  std::vector<double> in = {1, 0.0, 1.0, 2, 0};
+  std::vector<double> out(1, 0.0);
+  auto td = std::make_shared<ppc::core::TaskData>();
+  td->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<double*>(in.data())));
+  td->inputs_count.push_back(static_cast<uint32_t>(in.size() * sizeof(double)));
+  td->outputs.push_back(reinterpret_cast<uint8_t*>(out.data()));
+  IntegralsSimpsonSTL task(td);
+  EXPECT_FALSE(task.Validation());
+}
+
+TEST(anufriev_d_integrals_simpson_stl, 3D_SumOfSquares) {
+  std::vector<double> in = {3, 0.0, 1.0, 10, 0.0, 2.0, 10, 0.0, 3.0, 10, 0};
+  std::vector<double> out(1, 0.0);
+  auto td = MakeTaskData(in, out);
+  IntegralsSimpsonSTL task(td);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+  EXPECT_GT(out[0], 0.0);
+}
+
+TEST(anufriev_d_integrals_simpson_stl, 1D_SinFunction) {
+  std::vector<double> in = {1, 0.0, kPi/2, 100, 1};
+  std::vector<double> out(1, 0.0);
+  auto td = MakeTaskData(in, out);
+  IntegralsSimpsonSTL task(td);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+  EXPECT_NEAR(out[0], 1.0, 1e-3);
+}
+
+TEST(anufriev_d_integrals_simpson_stl, test_ValidationImpl_no_outputs) {
+  std::vector<double> in = {1, 0.0, 1.0, 2, 0};
+  auto td = std::make_shared<ppc::core::TaskData>();
+  td->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<double*>(in.data())));
+  td->inputs_count.push_back(static_cast<uint32_t>(in.size() * sizeof(double)));
+  anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
+  EXPECT_FALSE(task.ValidationImpl());
+}
+
+TEST(anufriev_d_integrals_simpson_stl, test_PreProcessingImpl_small_input_size) {
+  double dummy = 0.0;
+  auto td = std::make_shared<ppc::core::TaskData>();
+  td->inputs.push_back(reinterpret_cast<uint8_t*>(&dummy));
+  td->inputs_count.push_back(static_cast<uint32_t>(sizeof(double) / 2));  // 4 байта
+  std::vector<double> out(1);
+  td->outputs.push_back(reinterpret_cast<uint8_t*>(out.data()));
+  td->outputs_count.push_back(static_cast<uint32_t>(sizeof(double)));
+  anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
+  EXPECT_FALSE(task.PreProcessingImpl());
+} // namespace anufriev_d_integrals_simpson_stl

--- a/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
@@ -145,7 +145,7 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, MinValidIterationsN0_is_2_2D) {
   auto td = MakeTaskData(in, out_buffer);
   anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
   ASSERT_TRUE(task.Validation());
-  ASSERT_TRUE(task.PreProcessing());;
+  ASSERT_TRUE(task.PreProcessing());
   ASSERT_TRUE(task.Run());
   ASSERT_TRUE(task.PostProcessing());
   EXPECT_NEAR(out_buffer[0], 2.0 / 3.0, 1e-5);
@@ -205,7 +205,7 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, Preprocessing_InvalidN_Zero) {
   auto td = MakeTaskData(in, out_buffer);
   anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
   ASSERT_TRUE(task.Validation());
-  ASSERT_TRUE(task.PreProcessing());;
+  ASSERT_TRUE(task.PreProcessing());
 }
 
 TEST(anufriev_d_integrals_simpson_stl_coverage, Preprocessing_InvalidN_Odd) {

--- a/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
-#include <exception>
 #include <memory>
 #include <numbers>
 #include <vector>

--- a/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "core/task/include/task.hpp"
-
 #include "stl/anufriev_d_integrals_simpson/include/ops_stl.hpp"
 
 namespace {

--- a/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
@@ -132,8 +132,8 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, MinValidIterationsN0_is_2_1D) {
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
   anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
-  ASSERT_TRUE(task.PreProcessing());
   ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
   ASSERT_TRUE(task.Run());
   ASSERT_TRUE(task.PostProcessing());
   EXPECT_NEAR(out_buffer[0], 9.0, 1e-5);
@@ -144,8 +144,8 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, MinValidIterationsN0_is_2_2D) {
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
   anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
-  ASSERT_TRUE(task.PreProcessing());
   ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());;
   ASSERT_TRUE(task.Run());
   ASSERT_TRUE(task.PostProcessing());
   EXPECT_NEAR(out_buffer[0], 2.0 / 3.0, 1e-5);
@@ -156,8 +156,8 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, FewIterationsN0_is_4_1D) {
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
   anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
-  ASSERT_TRUE(task.PreProcessing());
   ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
   ASSERT_TRUE(task.Run());
   ASSERT_TRUE(task.PostProcessing());
   EXPECT_NEAR(out_buffer[0], 2.0, 1e-5);
@@ -168,8 +168,8 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, ManyIterationsN0_1D) {
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
   anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
-  ASSERT_TRUE(task.PreProcessing());
   ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
   ASSERT_TRUE(task.Run());
   ASSERT_TRUE(task.PostProcessing());
   EXPECT_NEAR(out_buffer[0], 1.0 / 3.0, 1e-4);
@@ -180,8 +180,8 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, MultiDim_N_Mismatch) {
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
   anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
-  ASSERT_TRUE(task.PreProcessing());
   ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
   ASSERT_TRUE(task.Run());
   ASSERT_TRUE(task.PostProcessing());
   EXPECT_NEAR(out_buffer[0], 2.0 / 3.0, 1e-4);
@@ -192,8 +192,8 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, MultiDim_N_Mismatch_Reversed) {
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
   anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
-  ASSERT_TRUE(task.PreProcessing());
   ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
   ASSERT_TRUE(task.Run());
   ASSERT_TRUE(task.PostProcessing());
   EXPECT_NEAR(out_buffer[0], 2.0 / 3.0, 1e-4);
@@ -204,7 +204,8 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, Preprocessing_InvalidN_Zero) {
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
   anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
-  ASSERT_FALSE(task.PreProcessing());
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());;
 }
 
 TEST(anufriev_d_integrals_simpson_stl_coverage, Preprocessing_InvalidN_Odd) {
@@ -212,7 +213,8 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, Preprocessing_InvalidN_Odd) {
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
   anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
-  ASSERT_FALSE(task.PreProcessing());
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
 }
 
 TEST(anufriev_d_integrals_simpson_stl_coverage, ManyIterations_PossibleSingleThreadPath) {
@@ -220,8 +222,8 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, ManyIterations_PossibleSingleThr
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
   anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
-  ASSERT_TRUE(task.PreProcessing());
   ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
   ASSERT_TRUE(task.Run());
   ASSERT_TRUE(task.PostProcessing());
   EXPECT_NEAR(out_buffer[0], 8.0 / 3.0, 1e-4);
@@ -232,8 +234,8 @@ TEST(anufriev_d_integrals_simpson_stl_coverage, TestWithFuncCode1_2D) {
   std::vector<double> out_buffer(1, 0.0);
   auto td = MakeTaskData(in, out_buffer);
   anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
-  ASSERT_TRUE(task.PreProcessing());
   ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
   ASSERT_TRUE(task.Run());
   ASSERT_TRUE(task.PostProcessing());
   EXPECT_NEAR(out_buffer[0], 1.0, 1e-3);

--- a/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/func_tests/main.cpp
@@ -1,0 +1,129 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <numbers>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+#include "stl/anufriev_d_integrals_simpson/include/ops_stl.hpp"
+
+namespace {
+const double kPi = std::numbers::pi;
+
+std::shared_ptr<ppc::core::TaskData> MakeTaskData(const std::vector<double>& elements,
+                                                  std::vector<double>& out_buffer) {
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  auto* input_ptr = reinterpret_cast<uint8_t*>(const_cast<double*>(elements.data()));
+  auto* output_ptr = reinterpret_cast<uint8_t*>(out_buffer.data());
+  task_data->inputs.push_back(input_ptr);
+  task_data->inputs_count.push_back(static_cast<uint32_t>(elements.size() * sizeof(double)));
+  task_data->outputs.push_back(output_ptr);
+  task_data->outputs_count.push_back(static_cast<uint32_t>(out_buffer.size() * sizeof(double)));
+  return task_data;
+}
+}  // namespace
+
+TEST(anufriev_d_integrals_simpson_stl, test_1D_sin) {
+  std::vector<double> in = {1, 0.0, kPi / 2.0, 100, 1};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  task.Run();
+  task.PostProcessing();
+  double result = out_buffer[0];
+  EXPECT_NEAR(result, 1.0, 1e-3);
+}
+
+TEST(anufriev_d_integrals_simpson_stl, test_2D_sum_of_squares) {
+  std::vector<double> in = {2, 0.0, 1.0, 100, 0.0, 1.0, 100, 0};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  task.Run();
+  task.PostProcessing();
+  double result = out_buffer[0];
+  EXPECT_NEAR(result, 2.0 / 3.0, 1e-3);
+}
+
+TEST(anufriev_d_integrals_simpson_stl, test_2D_sin_cos) {
+  std::vector<double> in = {2, 0.0, kPi / 2.0, 100, 0.0, kPi / 2.0, 100, 1};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  task.Run();
+  task.PostProcessing();
+  double result = out_buffer[0];
+  EXPECT_NEAR(result, 1.0, 1e-3);
+}
+
+TEST(anufriev_d_integrals_simpson_stl, test_unknown_func) {
+  std::vector<double> in = {1, 0.0, 1.0, 2, 999};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  task.Run();
+  task.PostProcessing();
+  double result = out_buffer[0];
+  EXPECT_DOUBLE_EQ(result, 0.0);
+}
+
+TEST(anufriev_d_integrals_simpson_stl, test_invalid_empty_input) {
+  auto td = std::make_shared<ppc::core::TaskData>();
+  td->inputs.push_back(nullptr);
+  td->inputs_count.push_back(0);
+  td->outputs.push_back(nullptr);
+  td->outputs_count.push_back(0);
+  anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
+  EXPECT_FALSE(task.ValidationImpl());
+}
+
+TEST(anufriev_d_integrals_simpson_stl, test_invalid_dimension_zero) {
+  std::vector<double> in = {0, 0.0, 1.0, 2, 999};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
+  EXPECT_FALSE(task.PreProcessingImpl());
+}
+
+TEST(anufriev_d_integrals_simpson_stl, test_invalid_not_enough_data) {
+  std::vector<double> in = {2, 0.0, 1.0, 2.0, 999.0};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
+  EXPECT_FALSE(task.PreProcessingImpl());
+}
+
+TEST(anufriev_d_integrals_simpson_stl, test_invalid_odd_n) {
+  std::vector<double> in = {1, 0.0, 1.0, 3, 0};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
+  EXPECT_FALSE(task.PreProcessingImpl());
+}
+
+TEST(anufriev_d_integrals_simpson_stl, test_invalid_negative_n) {
+  std::vector<double> in = {1, 0.0, 1.0, -2, 0};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
+  EXPECT_FALSE(task.PreProcessingImpl());
+}
+
+TEST(anufriev_d_integrals_simpson_stl, test_no_output_buffer) {
+  std::vector<double> in = {1, 0.0, 1.0, 2, 0};
+  auto td = std::make_shared<ppc::core::TaskData>();
+  td->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<double*>(in.data())));
+  td->inputs_count.push_back(static_cast<std::uint32_t>(in.size()));
+  anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL task(td);
+  EXPECT_FALSE(task.Validation());
+}

--- a/tasks/stl/anufriev_d_integrals_simpson/include/ops_stl.hpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/include/ops_stl.hpp
@@ -31,7 +31,7 @@ class IntegralsSimpsonSTL : public ppc::core::Task {
   [[nodiscard]] double FunctionN(const std::vector<double>& coords) const;
   double RecursiveSimpsonSum(int dim_index, std::vector<int>& idx, const std::vector<double>& steps) const;
   void ThreadTaskRunner(int start_idx, int end_idx, const std::vector<double>& steps, double* partial_sum_output);
-  
+
   [[nodiscard]] static unsigned int DetermineNumThreads(int total_iterations);
   [[nodiscard]] static std::vector<IterationRange> DistributeIterations(int total_iterations, unsigned int num_threads);
 };

--- a/tasks/stl/anufriev_d_integrals_simpson/include/ops_stl.hpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/include/ops_stl.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace anufriev_d_integrals_simpson_stl {
+
+class IntegralsSimpsonSTL : public ppc::core::Task {
+ public:
+  explicit IntegralsSimpsonSTL(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  int dimension_{};
+
+  std::vector<double> a_, b_;
+  std::vector<int> n_;
+  int func_code_{};
+  double result_{};
+
+  [[nodiscard]] double FunctionN(const std::vector<double>& coords) const;
+
+  double RecursiveSimpsonSum(int dim_index, std::vector<int>& idx, const std::vector<double>& steps) const;
+};
+
+}  // namespace anufriev_d_integrals_simpson_stl

--- a/tasks/stl/anufriev_d_integrals_simpson/include/ops_stl.hpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/include/ops_stl.hpp
@@ -27,7 +27,10 @@ class IntegralsSimpsonSTL : public ppc::core::Task {
   double RecursiveSimpsonSum(int dim_index, std::vector<int>& idx, const std::vector<double>& steps) const;
   void ThreadTaskRunner(int start_idx, int end_idx, const std::vector<double>& steps, double* partial_sum_output);
   unsigned int DetermineNumThreads(int total_iterations) const;
-  struct IterationRange { int start; int end; };
+  struct IterationRange {
+    int start;
+    int end;
+  };
   std::vector<IterationRange> DistributeIterations(int total_iterations, unsigned int num_threads) const;
 };
 

--- a/tasks/stl/anufriev_d_integrals_simpson/include/ops_stl.hpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/include/ops_stl.hpp
@@ -25,7 +25,10 @@ class IntegralsSimpsonSTL : public ppc::core::Task {
 
   [[nodiscard]] double FunctionN(const std::vector<double>& coords) const;
   double RecursiveSimpsonSum(int dim_index, std::vector<int>& idx, const std::vector<double>& steps) const;
-  void thread_task_runner(int start_idx, int end_idx, const std::vector<double>& steps, double* partial_sum_output);
+  void ThreadTaskRunner(int start_idx, int end_idx, const std::vector<double>& steps, double* partial_sum_output);
+  unsigned int DetermineNumThreads(int total_iterations) const;
+  struct IterationRange { int start; int end; };
+  std::vector<IterationRange> DistributeIterations(int total_iterations, unsigned int num_threads) const;
 };
 
 }  // namespace anufriev_d_integrals_simpson_stl

--- a/tasks/stl/anufriev_d_integrals_simpson/include/ops_stl.hpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/include/ops_stl.hpp
@@ -17,6 +17,11 @@ class IntegralsSimpsonSTL : public ppc::core::Task {
   bool PostProcessingImpl() override;
 
  private:
+  struct IterationRange {
+    int start;
+    int end;
+  };
+
   int dimension_{};
   std::vector<double> a_, b_;
   std::vector<int> n_;
@@ -26,12 +31,9 @@ class IntegralsSimpsonSTL : public ppc::core::Task {
   [[nodiscard]] double FunctionN(const std::vector<double>& coords) const;
   double RecursiveSimpsonSum(int dim_index, std::vector<int>& idx, const std::vector<double>& steps) const;
   void ThreadTaskRunner(int start_idx, int end_idx, const std::vector<double>& steps, double* partial_sum_output);
-  unsigned int DetermineNumThreads(int total_iterations) const;
-  struct IterationRange {
-    int start;
-    int end;
-  };
-  std::vector<IterationRange> DistributeIterations(int total_iterations, unsigned int num_threads) const;
+  
+  [[nodiscard]] static unsigned int DetermineNumThreads(int total_iterations);
+  [[nodiscard]] static std::vector<IterationRange> DistributeIterations(int total_iterations, unsigned int num_threads);
 };
 
 }  // namespace anufriev_d_integrals_simpson_stl

--- a/tasks/stl/anufriev_d_integrals_simpson/include/ops_stl.hpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/include/ops_stl.hpp
@@ -18,15 +18,14 @@ class IntegralsSimpsonSTL : public ppc::core::Task {
 
  private:
   int dimension_{};
-
   std::vector<double> a_, b_;
   std::vector<int> n_;
   int func_code_{};
   double result_{};
 
   [[nodiscard]] double FunctionN(const std::vector<double>& coords) const;
-
   double RecursiveSimpsonSum(int dim_index, std::vector<int>& idx, const std::vector<double>& steps) const;
+  void thread_task_runner(int start_idx, int end_idx, const std::vector<double>& steps, double* partial_sum_output);
 };
 
 }  // namespace anufriev_d_integrals_simpson_stl

--- a/tasks/stl/anufriev_d_integrals_simpson/perf_tests/main.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/perf_tests/main.cpp
@@ -1,0 +1,74 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "stl/anufriev_d_integrals_simpson/include/ops_stl.hpp"
+
+TEST(anufriev_d_integrals_simpson_stl, test_pipeline_run) {
+  std::vector<double> in = {2, 0.0, 1.0, 2000, 0.0, 1.0, 2000, 0};
+  std::vector<double> out(1, 0.0);
+
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.push_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data_stl->inputs_count.push_back(static_cast<std::uint32_t>(in.size() * sizeof(double)));
+  task_data_stl->outputs.push_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_stl->outputs_count.push_back(static_cast<std::uint32_t>(out.size() * sizeof(double)));
+
+  auto task_stl = std::make_shared<anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL>(task_data_stl);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 15;
+
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(task_stl);
+
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  double result = out[0];
+  EXPECT_NEAR(result, 2.0 / 3.0, 1e-3);
+}
+
+TEST(anufriev_d_integrals_simpson_stl, test_task_run) {
+  std::vector<double> in = {2, 0.0, 1.0, 2000, 0.0, 1.0, 2000, 0};
+  std::vector<double> out(1, 0.0);
+
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.push_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data_stl->inputs_count.push_back(static_cast<std::uint32_t>(in.size() * sizeof(double)));
+  task_data_stl->outputs.push_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_stl->outputs_count.push_back(static_cast<std::uint32_t>(out.size() * sizeof(double)));
+
+  auto task_stl = std::make_shared<anufriev_d_integrals_simpson_stl::IntegralsSimpsonSTL>(task_data_stl);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 15;
+
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(task_stl);
+
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  double result = out[0];
+  EXPECT_NEAR(result, 2.0 / 3.0, 1e-3);
+}

--- a/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
@@ -2,9 +2,9 @@
 
 #include <cmath>
 #include <cstddef>
+#include <exception>
 #include <functional>
 #include <stdexcept>
-#include <exception>
 #include <thread>
 #include <vector>
 
@@ -136,20 +136,20 @@ void IntegralsSimpsonSTL::ThreadTaskRunner(int start_idx, int end_idx, const std
   }
 
   for (int i = start_idx; i < end_idx; ++i) {
-    if (dimension_ < 1) { 
+    if (dimension_ < 1) {
       throw std::logic_error("Critical error: dimension_ became < 1 inside loop unexpectedly.");
     }
-    std::vector<int> local_idx(dimension_); 
-    local_idx[0] = i;                      
+    std::vector<int> local_idx(dimension_);
+    local_idx[0] = i;
 
     try {
       local_partial_sum += RecursiveSimpsonSum(1, local_idx, steps);
     } catch (const std::exception& e) {
-      (void)e; 
-      return; 
+      (void)e;
+      return;
     }
   }
-  *partial_sum_output = local_partial_sum; 
+  *partial_sum_output = local_partial_sum;
 }
 
 unsigned int IntegralsSimpsonSTL::DetermineNumThreads(int total_iterations) const {
@@ -168,7 +168,8 @@ unsigned int IntegralsSimpsonSTL::DetermineNumThreads(int total_iterations) cons
   return num_threads;
 }
 
-std::vector<IntegralsSimpsonSTL::IterationRange> IntegralsSimpsonSTL::DistributeIterations(int total_iterations, unsigned int num_threads) const {
+std::vector<IntegralsSimpsonSTL::IterationRange> IntegralsSimpsonSTL::DistributeIterations(
+    int total_iterations, unsigned int num_threads) const {
   std::vector<IterationRange> ranges;
   if (num_threads == 0 || total_iterations == 0) {
     return ranges;
@@ -199,7 +200,6 @@ std::vector<IntegralsSimpsonSTL::IterationRange> IntegralsSimpsonSTL::Distribute
   }
   return ranges;
 }
-
 
 bool IntegralsSimpsonSTL::RunImpl() {
   if (dimension_ < 1) {

--- a/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
@@ -2,11 +2,11 @@
 
 #include <cmath>
 #include <cstddef>
-#include <numeric>
-#include <vector>
-#include <stdexcept>
 #include <functional>
+#include <numeric>
+#include <stdexcept>
 #include <thread>
+#include <vector>
 
 namespace {
 
@@ -49,7 +49,7 @@ double IntegralsSimpsonSTL::FunctionN(const std::vector<double>& coords) const {
 }
 
 double IntegralsSimpsonSTL::RecursiveSimpsonSum(int dim_index, std::vector<int>& idx,
-                                                 const std::vector<double>& steps) const {
+                                                const std::vector<double>& steps) const {
   if (dim_index == dimension_) {
     double coeff = 1.0;
     std::vector<double> coords(dimension_);
@@ -168,41 +168,41 @@ bool IntegralsSimpsonSTL::RunImpl() {
   if (static_cast<unsigned int>(total_iterations_dim0) < num_threads) {
     num_threads = static_cast<unsigned int>(total_iterations_dim0);
   }
-   if (num_threads == 0 && total_iterations_dim0 > 0) {
+  if (num_threads == 0 && total_iterations_dim0 > 0) {
     num_threads = 1;
   }
-  if (total_iterations_dim0 == 0){
-      num_threads = 0;
+  if (total_iterations_dim0 == 0) {
+    num_threads = 0;
   }
 
   std::vector<std::thread> threads;
   std::vector<double> partial_sums(num_threads, 0.0);
 
   if (num_threads == 0 && total_iterations_dim0 > 0) {
-      thread_task_runner(0, total_iterations_dim0, steps, &partial_sums[0]);
+    thread_task_runner(0, total_iterations_dim0, steps, &partial_sums[0]);
   } else if (num_threads > 0) {
-      threads.reserve(num_threads);
-      int iterations_per_thread = total_iterations_dim0 / num_threads;
-      int remaining_iterations = total_iterations_dim0 % num_threads;
-      int current_start_idx = 0;
+    threads.reserve(num_threads);
+    int iterations_per_thread = total_iterations_dim0 / num_threads;
+    int remaining_iterations = total_iterations_dim0 % num_threads;
+    int current_start_idx = 0;
 
-      for (unsigned int i = 0; i < num_threads; ++i) {
-          int current_end_idx = current_start_idx + iterations_per_thread;
-          if (remaining_iterations > 0) {
-          current_end_idx++;
-          remaining_iterations--;
-          }
-          if (current_end_idx > total_iterations_dim0) {
-          current_end_idx = total_iterations_dim0;
-          }
-
-          if (current_start_idx < current_end_idx) {
-          threads.emplace_back(&IntegralsSimpsonSTL::thread_task_runner, this, current_start_idx, current_end_idx,
-                                 std::cref(steps), &partial_sums[i]);
-          }
-          current_start_idx = current_end_idx;
-          if (current_start_idx >= total_iterations_dim0) break;
+    for (unsigned int i = 0; i < num_threads; ++i) {
+      int current_end_idx = current_start_idx + iterations_per_thread;
+      if (remaining_iterations > 0) {
+        current_end_idx++;
+        remaining_iterations--;
       }
+      if (current_end_idx > total_iterations_dim0) {
+        current_end_idx = total_iterations_dim0;
+      }
+
+      if (current_start_idx < current_end_idx) {
+        threads.emplace_back(&IntegralsSimpsonSTL::thread_task_runner, this, current_start_idx, current_end_idx,
+                             std::cref(steps), &partial_sums[i]);
+      }
+      current_start_idx = current_end_idx;
+      if (current_start_idx >= total_iterations_dim0) break;
+    }
   }
 
 
@@ -213,12 +213,12 @@ bool IntegralsSimpsonSTL::RunImpl() {
   }
 
   double total_sum = 0.0;
-  if (num_threads == 0 && total_iterations_dim0 > 0 && !partial_sums.empty()){
-      total_sum = partial_sums[0];
+  if (num_threads == 0 && total_iterations_dim0 > 0 && !partial_sums.empty()) {
+    total_sum = partial_sums[0];
   } else {
-      for (double p_sum : partial_sums) {
-        total_sum += p_sum;
-      }
+    for (double p_sum : partial_sums) {
+      total_sum += p_sum;
+    }
   }
 
 

--- a/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
-#include <exception>
 #include <functional>
 #include <thread>
 #include <vector>

--- a/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
@@ -2,21 +2,21 @@
 
 #include <cmath>
 #include <cstddef>
-#include <numeric>
-#include <vector>
 #include <execution>
 #include <functional>
+#include <numeric>
+#include <vector>
 
 namespace {
-  int SimpsonCoeff(int i, int n) {
-    if (i == 0 || i == n) {
-      return 1;
-    }
-    if (i % 2 != 0) {
-      return 4;
-    }
-    return 2;
+int SimpsonCoeff(int i, int n) {
+  if (i == 0 || i == n) {
+    return 1;
   }
+  if (i % 2 != 0) {
+    return 4;
+  }
+  return 2;
+}
 }  // namespace
 
 namespace anufriev_d_integrals_simpson_stl {
@@ -47,7 +47,7 @@ double IntegralsSimpsonSTL::FunctionN(const std::vector<double>& coords) const {
 }
 
 double IntegralsSimpsonSTL::RecursiveSimpsonSum(int dim_index, std::vector<int>& idx,
-                                                 const std::vector<double>& steps) const {
+                                                const std::vector<double>& steps) const {
   if (dim_index == dimension_) {
     double coeff = 1.0;
     std::vector<double> coords(dimension_);
@@ -129,18 +129,12 @@ bool IntegralsSimpsonSTL::RunImpl() {
   std::vector<int> first_dim_indices(n_[0] + 1);
   std::iota(first_dim_indices.begin(), first_dim_indices.end(), 0);
 
-  double total_sum = std::transform_reduce(
-      std::execution::par,
-      first_dim_indices.begin(),
-      first_dim_indices.end(),
-      0.0,
-      std::plus<double>(),
-      [&](int i) {
-        std::vector<int> local_idx(dimension_);
-        local_idx[0] = i;
-
-        return RecursiveSimpsonSum(1, local_idx, steps);
-      });
+  double total_sum = std::transform_reduce(std::execution::par, first_dim_indices.begin(), first_dim_indices.end(), 0.0,
+                                           std::plus<double>(), [&](int i) {
+                                             std::vector<int> local_idx(dimension_);
+                                             local_idx[0] = i;
+                                             return RecursiveSimpsonSum(1, local_idx, steps);
+                                           });
 
   double coeff = 1.0;
   for (int i = 0; i < dimension_; i++) {

--- a/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
@@ -2,11 +2,11 @@
 
 #include <cmath>
 #include <cstddef>
-#include <numeric>
-#include <vector>
 #include <execution>
 #include <functional>
+#include <numeric>
 #include <stdexcept>
+#include <vector>
 
 namespace {
 
@@ -49,17 +49,18 @@ double IntegralsSimpsonSTL::FunctionN(const std::vector<double>& coords) const {
 }
 
 double IntegralsSimpsonSTL::RecursiveSimpsonSum(int dim_index, std::vector<int>& idx,
-                                                 const std::vector<double>& steps) const {
+                                                const std::vector<double>& steps) const {
   if (dim_index == dimension_) {
     double coeff = 1.0;
     std::vector<double> coords(dimension_);
     for (int d = 0; d < dimension_; ++d) {
-      if (d < 0 || static_cast<size_t>(d) >= idx.size() || static_cast<size_t>(d) >= steps.size() || static_cast<size_t>(d) >= a_.size()) {
-           throw std::out_of_range("Index out of bounds in RecursiveSimpsonSum inner loop");
+      if (d < 0 || static_cast<size_t>(d) >= idx.size() || static_cast<size_t>(d) >= steps.size() ||
+          static_cast<size_t>(d) >= a_.size()) {
+        throw std::out_of_range("Index out of bounds in RecursiveSimpsonSum inner loop");
       }
       coords[d] = a_[d] + idx[d] * steps[d];
       if (d < 0 || static_cast<size_t>(d) >= n_.size()) {
-          throw std::out_of_range("Index out of bounds for n_ in RecursiveSimpsonSum");
+        throw std::out_of_range("Index out of bounds for n_ in RecursiveSimpsonSum");
       }
       coeff *= SimpsonCoeff(idx[d], n_[d]);
     }
@@ -67,7 +68,7 @@ double IntegralsSimpsonSTL::RecursiveSimpsonSum(int dim_index, std::vector<int>&
   }
   double sum = 0.0;
   if (dim_index < 0 || static_cast<size_t>(dim_index) >= n_.size() || static_cast<size_t>(dim_index) >= idx.size()) {
-      throw std::out_of_range("Index out of bounds before RecursiveSimpsonSum loop");
+    throw std::out_of_range("Index out of bounds before RecursiveSimpsonSum loop");
   }
   for (int i = 0; i <= n_[dim_index]; ++i) {
     idx[dim_index] = i;
@@ -130,49 +131,50 @@ bool IntegralsSimpsonSTL::ValidationImpl() {
 }
 
 bool IntegralsSimpsonSTL::RunImpl() {
-    if (dimension_ < 1) {
-        return false;
-    }
+  if (dimension_ < 1) {
+      return false;
+  }
 
-    std::vector<double> steps(dimension_);
-    for (int i = 0; i < dimension_; i++) {
-        if (n_[i] == 0) {
-             return false;
-        }
-        steps[i] = (b_[i] - a_[i]) / n_[i];
-    }
+  std::vector<double> steps(dimension_);
+  for (int i = 0; i < dimension_; i++) {
+      if (n_[i] == 0) {
+            return false;
+      }
+      steps[i] = (b_[i] - a_[i]) / n_[i];
+  }
 
-    std::vector<int> first_dim_indices(n_[0] + 1);
-    std::iota(first_dim_indices.begin(), first_dim_indices.end(), 0);
+  std::vector<int> first_dim_indices(n_[0] + 1);
+  std::iota(first_dim_indices.begin(), first_dim_indices.end(), 0);
 
-    double total_sum = 0.0;
-    try {
-        total_sum = std::transform_reduce(std::execution::par, first_dim_indices.begin(), first_dim_indices.end(), 0.0,
-                    std::plus<double>(), [&](int i) -> double {
-                      if (dimension_ < 1) {
-                          throw std::logic_error("IntegralsSimpsonSTL::RunImpl: dimension_ < 1 inside parallel lambda!");
-                      }
-                      std::vector<int> local_idx(dimension_);
-                      local_idx[0] = i;
-                      return RecursiveSimpsonSum(1, local_idx, steps);
-                    });
-    } catch (const std::exception& e) {
-        (void)e;
-        return false;
-    }
+  double total_sum = 0.0;
+  try {
+      total_sum = std::transform_reduce(std::execution::par, first_dim_indices.begin(), first_dim_indices.end(), 0.0,
+                  std::plus<double>(), [&](int i) -> double {
+                    if (dimension_ < 1) {
+                        throw std::logic_error("IntegralsSimpsonSTL::RunImpl: dimension_ < 1 inside parallel lambda!");
+                    }
+                    std::vector<int> local_idx(dimension_);
+                    local_idx[0] = i;
+                    return RecursiveSimpsonSum(1, local_idx, steps);
+                  });
+  } catch (const std::exception& e) {
+      (void)e;
+      return false;
+  }
 
-    double coeff = 1.0;
-    for (int i = 0; i < dimension_; i++) {
-         coeff *= steps[i] / 3.0;
-    }
+  double coeff = 1.0;
+  for (int i = 0; i < dimension_; i++) {
+        coeff *= steps[i] / 3.0;
+  }
 
-    result_ = coeff * total_sum;
-    return true;
+  result_ = coeff * total_sum;
+  return true;
 }
 
 bool IntegralsSimpsonSTL::PostProcessingImpl() {
-  if (task_data->outputs.empty() || task_data->outputs[0] == nullptr || task_data->outputs_count.empty() || task_data->outputs_count[0] < sizeof(double)) {
-       return false;
+  if (task_data->outputs.empty() || task_data->outputs[0] == nullptr || task_data->outputs_count.empty() ||
+      task_data->outputs_count[0] < sizeof(double)) {
+    return false;
   }
   auto* out_ptr = reinterpret_cast<double*>(task_data->outputs[0]);
   out_ptr[0] = result_;

--- a/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
@@ -132,15 +132,15 @@ bool IntegralsSimpsonSTL::ValidationImpl() {
 
 bool IntegralsSimpsonSTL::RunImpl() {
   if (dimension_ < 1) {
-      return false;
+    return false;
   }
 
   std::vector<double> steps(dimension_);
   for (int i = 0; i < dimension_; i++) {
-      if (n_[i] == 0) {
-            return false;
-      }
-      steps[i] = (b_[i] - a_[i]) / n_[i];
+    if (n_[i] == 0) {
+      return false;
+    }
+    steps[i] = (b_[i] - a_[i]) / n_[i];
   }
 
   std::vector<int> first_dim_indices(n_[0] + 1);
@@ -148,18 +148,19 @@ bool IntegralsSimpsonSTL::RunImpl() {
 
   double total_sum = 0.0;
   try {
-      total_sum = std::transform_reduce(std::execution::par, first_dim_indices.begin(), first_dim_indices.end(), 0.0,
-                  std::plus<double>(), [&](int i) -> double {
-                    if (dimension_ < 1) {
-                        throw std::logic_error("IntegralsSimpsonSTL::RunImpl: dimension_ < 1 inside parallel lambda!");
-                    }
-                    std::vector<int> local_idx(dimension_);
-                    local_idx[0] = i;
-                    return RecursiveSimpsonSum(1, local_idx, steps);
-                  });
+    total_sum = std::transform_reduce(
+        std::execution::par, first_dim_indices.begin(), first_dim_indices.end(), 0.0, std::plus<double>(),
+        [&](int i) -> double {
+          if (dimension_ < 1) {
+            throw std::logic_error("IntegralsSimpsonSTL::RunImpl: dimension_ < 1 inside parallel lambda!");
+          }
+          std::vector<int> local_idx(dimension_);
+          local_idx[0] = i;
+          return RecursiveSimpsonSum(1, local_idx, steps);
+        });
   } catch (const std::exception& e) {
-      (void)e;
-      return false;
+    (void)e;
+    return false;
   }
 
   double coeff = 1.0;

--- a/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
@@ -5,7 +5,6 @@
 #include <cstddef>
 #include <exception>
 #include <functional>
-#include <stdexcept>
 #include <thread>
 #include <vector>
 
@@ -119,11 +118,10 @@ void IntegralsSimpsonSTL::ThreadTaskRunner(int start_idx, int end_idx, const std
   double local_partial_sum = 0.0;
   *partial_sum_output = 0.0;
 
-  if (dimension_ < 1) {
-    return;
-  }
-
   for (int i = start_idx; i < end_idx; ++i) {
+    if (this->dimension_ < 1) {
+      return;
+    }
     std::vector<int> local_idx(dimension_);
     local_idx[0] = i;
 

--- a/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
@@ -8,6 +8,8 @@
 #include <thread>
 #include <vector>
 
+#include "core/util/include/util.hpp"
+
 namespace {
 
 int SimpsonCoeff(int i, int n) {
@@ -124,19 +126,13 @@ void IntegralsSimpsonSTL::ThreadTaskRunner(int start_idx, int end_idx, const std
     }
     std::vector<int> local_idx(dimension_);
     local_idx[0] = i;
-
-    try {
-      local_partial_sum += RecursiveSimpsonSum(1, local_idx, steps);
-    } catch (const std::exception& e) {
-      (void)e;
-      return;
-    }
+    local_partial_sum += RecursiveSimpsonSum(1, local_idx, steps);
   }
   *partial_sum_output = local_partial_sum;
 }
 
 unsigned int IntegralsSimpsonSTL::DetermineNumThreads(int total_iterations) {
-  unsigned int num_threads = std::thread::hardware_concurrency();
+  unsigned int num_threads = ppc::util::GetPPCNumThreads();
   if (num_threads == 0) {
     num_threads = 2;
   }

--- a/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
@@ -126,18 +126,25 @@ bool IntegralsSimpsonSTL::ValidationImpl() {
 void IntegralsSimpsonSTL::thread_task_runner(int start_idx, int end_idx, const std::vector<double>& steps,
                                              double* partial_sum_output) {
   double local_partial_sum = 0.0;
+
   if (dimension_ < 1) {
     *partial_sum_output = 0.0;
     return;
   }
 
   for (int i = start_idx; i < end_idx; ++i) {
+    if (dimension_ < 1) {
+    throw std::logic_error("Dimension became < 1 unexpectedly in thread_task_runner loop");
+    }
+
     std::vector<int> local_idx(dimension_);
     local_idx[0] = i;
+
     try {
       local_partial_sum += RecursiveSimpsonSum(1, local_idx, steps);
-    } catch (const std::exception&) {
-      *partial_sum_output = local_partial_sum;
+    } catch (const std::exception& e) {
+      (void)e; 
+      *partial_sum_output = local_partial_sum; 
       return;
     }
   }

--- a/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
@@ -1,0 +1,160 @@
+#include "stl/anufriev_d_integrals_simpson/include/ops_stl.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <numeric>
+#include <vector>
+#include <execution>
+#include <functional>
+
+namespace {
+  int SimpsonCoeff(int i, int n) {
+    if (i == 0 || i == n) {
+      return 1;
+    }
+    if (i % 2 != 0) {
+      return 4;
+    }
+    return 2;
+  }
+}  // namespace
+
+namespace anufriev_d_integrals_simpson_stl {
+
+double IntegralsSimpsonSTL::FunctionN(const std::vector<double>& coords) const {
+  switch (func_code_) {
+    case 0: {
+      double s = 0.0;
+      for (double c : coords) {
+        s += c * c;
+      }
+      return s;
+    }
+    case 1: {
+      double val = 1.0;
+      for (size_t i = 0; i < coords.size(); i++) {
+        if (i % 2 == 0) {
+          val *= std::sin(coords[i]);
+        } else {
+          val *= std::cos(coords[i]);
+        }
+      }
+      return val;
+    }
+    default:
+      return 0.0;
+  }
+}
+
+double IntegralsSimpsonSTL::RecursiveSimpsonSum(int dim_index, std::vector<int>& idx,
+                                                 const std::vector<double>& steps) const {
+  if (dim_index == dimension_) {
+    double coeff = 1.0;
+    std::vector<double> coords(dimension_);
+    for (int d = 0; d < dimension_; ++d) {
+      coords[d] = a_[d] + idx[d] * steps[d];
+      coeff *= SimpsonCoeff(idx[d], n_[d]);
+    }
+    return coeff * FunctionN(coords);
+  }
+  double sum = 0.0;
+  for (int i = 0; i <= n_[dim_index]; ++i) {
+    idx[dim_index] = i;
+    sum += RecursiveSimpsonSum(dim_index + 1, idx, steps);
+  }
+  return sum;
+}
+
+bool IntegralsSimpsonSTL::PreProcessingImpl() {
+  if (task_data->inputs.empty()) {
+    return false;
+  }
+
+  auto* in_ptr = reinterpret_cast<double*>(task_data->inputs[0]);
+  size_t in_size_bytes = task_data->inputs_count[0];
+  size_t num_doubles = in_size_bytes / sizeof(double);
+
+  if (num_doubles < 1) {
+    return false;
+  }
+
+  int d = static_cast<int>(in_ptr[0]);
+  if (d < 1) {
+    return false;
+  }
+
+  size_t needed_count = static_cast<size_t>(3 * d) + 2;
+  if (num_doubles < needed_count) {
+    return false;
+  }
+
+  dimension_ = d;
+  a_.resize(dimension_);
+  b_.resize(dimension_);
+  n_.resize(dimension_);
+
+  int idx_ptr = 1;
+  for (int i = 0; i < dimension_; i++) {
+    a_[i] = in_ptr[idx_ptr++];
+    b_[i] = in_ptr[idx_ptr++];
+    n_[i] = static_cast<int>(in_ptr[idx_ptr++]);
+    if (n_[i] <= 0 || (n_[i] % 2) != 0) {
+      return false;
+    }
+  }
+
+  func_code_ = static_cast<int>(in_ptr[idx_ptr]);
+
+  result_ = 0.0;
+
+  return true;
+}
+
+bool IntegralsSimpsonSTL::ValidationImpl() {
+  if (task_data->outputs.empty()) {
+    return false;
+  }
+  if (task_data->outputs_count.empty() || task_data->outputs_count[0] < 1) {
+    return false;
+  }
+  return true;
+}
+
+bool IntegralsSimpsonSTL::RunImpl() {
+  std::vector<double> steps(dimension_);
+  for (int i = 0; i < dimension_; i++) {
+    steps[i] = (b_[i] - a_[i]) / n_[i];
+  }
+
+  std::vector<int> first_dim_indices(n_[0] + 1);
+  std::iota(first_dim_indices.begin(), first_dim_indices.end(), 0);
+
+  double total_sum = std::transform_reduce(
+      std::execution::par,
+      first_dim_indices.begin(),
+      first_dim_indices.end(),
+      0.0,
+      std::plus<double>(),
+      [&](int i) {
+        std::vector<int> local_idx(dimension_);
+        local_idx[0] = i;
+
+        return RecursiveSimpsonSum(1, local_idx, steps);
+      });
+
+  double coeff = 1.0;
+  for (int i = 0; i < dimension_; i++) {
+    coeff *= steps[i] / 3.0;
+  }
+
+  result_ = coeff * total_sum;
+  return true;
+}
+
+bool IntegralsSimpsonSTL::PostProcessingImpl() {
+  auto* out_ptr = reinterpret_cast<double*>(task_data->outputs[0]);
+  out_ptr[0] = result_;
+  return true;
+}
+
+}  // namespace anufriev_d_integrals_simpson_stl

--- a/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
@@ -134,7 +134,7 @@ void IntegralsSimpsonSTL::thread_task_runner(int start_idx, int end_idx, const s
 
   for (int i = start_idx; i < end_idx; ++i) {
     if (dimension_ < 1) {
-    throw std::logic_error("Dimension became < 1 unexpectedly in thread_task_runner loop");
+      throw std::logic_error("Dimension became < 1 unexpectedly in thread_task_runner loop");
     }
 
     std::vector<int> local_idx(dimension_);
@@ -143,8 +143,8 @@ void IntegralsSimpsonSTL::thread_task_runner(int start_idx, int end_idx, const s
     try {
       local_partial_sum += RecursiveSimpsonSum(1, local_idx, steps);
     } catch (const std::exception& e) {
-      (void)e; 
-      *partial_sum_output = local_partial_sum; 
+      (void)e;
+      *partial_sum_output = local_partial_sum;
       return;
     }
   }

--- a/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
@@ -205,7 +205,6 @@ bool IntegralsSimpsonSTL::RunImpl() {
     }
   }
 
-
   for (auto& th : threads) {
     if (th.joinable()) {
       th.join();
@@ -220,7 +219,6 @@ bool IntegralsSimpsonSTL::RunImpl() {
       total_sum += p_sum;
     }
   }
-
 
   double coeff = 1.0;
   for (int i = 0; i < dimension_; i++) {

--- a/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
@@ -162,15 +162,15 @@ unsigned int IntegralsSimpsonSTL::DetermineNumThreads(int total_iterations) {
     return 0;
   }
   num_threads = std::min(num_threads, static_cast<unsigned int>(total_iterations));
-  
-  if (num_threads == 0) { 
+
+  if (num_threads == 0) {
     num_threads = 1;
   }
   return num_threads;
 }
 
-std::vector<IntegralsSimpsonSTL::IterationRange> IntegralsSimpsonSTL::DistributeIterations(
-    int total_iterations, unsigned int num_threads) {
+std::vector<IntegralsSimpsonSTL::IterationRange> IntegralsSimpsonSTL::DistributeIterations(int total_iterations,
+                                                                                           unsigned int num_threads) {
   std::vector<IterationRange> ranges;
   if (num_threads == 0 || total_iterations == 0) {
     return ranges;
@@ -186,9 +186,9 @@ std::vector<IntegralsSimpsonSTL::IterationRange> IntegralsSimpsonSTL::Distribute
       current_chunk_size++;
       remaining_iterations_unsigned--;
     }
-    
+
     if (current_chunk_size == 0) {
-      break; 
+      break;
     }
 
     int current_end_idx = current_start_idx + static_cast<int>(current_chunk_size);
@@ -224,12 +224,12 @@ bool IntegralsSimpsonSTL::RunImpl() {
   const int total_iterations_dim0 = n_[0] + 1;
 
   unsigned int num_actual_threads = DetermineNumThreads(total_iterations_dim0);
-  
+
   if (num_actual_threads == 0 && total_iterations_dim0 > 0) {
     num_actual_threads = 1;
   }
-  
-  std::vector<double> partial_sums(num_actual_threads, 0.0); 
+
+  std::vector<double> partial_sums(num_actual_threads, 0.0);
   std::vector<std::thread> threads;
 
   if (num_actual_threads == 0) {
@@ -239,18 +239,17 @@ bool IntegralsSimpsonSTL::RunImpl() {
     }
   } else {
     std::vector<IterationRange> ranges = DistributeIterations(total_iterations_dim0, num_actual_threads);
-    
+
     if (ranges.size() < num_actual_threads && !ranges.empty()) {
       partial_sums.resize(ranges.size());
     } else if (ranges.empty() && num_actual_threads > 0) {
       partial_sums.clear();
     }
 
-
     for (size_t i = 0; i < ranges.size(); ++i) {
       const auto& range = ranges[i];
-      threads.emplace_back(&IntegralsSimpsonSTL::ThreadTaskRunner, this, range.start, range.end,
-                           std::cref(steps), &partial_sums[i]);
+      threads.emplace_back(&IntegralsSimpsonSTL::ThreadTaskRunner, this, range.start, range.end, std::cref(steps),
+                           &partial_sums[i]);
     }
   }
 

--- a/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
@@ -165,7 +165,7 @@ bool IntegralsSimpsonSTL::RunImpl() {
 
   double coeff = 1.0;
   for (int i = 0; i < dimension_; i++) {
-        coeff *= steps[i] / 3.0;
+    coeff *= steps[i] / 3.0;
   }
 
   result_ = coeff * total_sum;

--- a/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
+++ b/tasks/stl/anufriev_d_integrals_simpson/src/ops_stl.cpp
@@ -1,5 +1,6 @@
 #include "stl/anufriev_d_integrals_simpson/include/ops_stl.hpp"
 
+#include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <execution>
@@ -128,6 +129,7 @@ bool IntegralsSimpsonSTL::RunImpl() {
 
   std::vector<int> first_dim_indices(n_[0] + 1);
   std::iota(first_dim_indices.begin(), first_dim_indices.end(), 0);
+  assert(dimension_ >= 1 && "Dimension must be positive before starting parallel reduction");
 
   double total_sum = std::transform_reduce(std::execution::par, first_dim_indices.begin(), first_dim_indices.end(), 0.0,
                                            std::plus<double>(), [&](int i) {


### PR DESCRIPTION
## Распараллеливание вычисления интегралов методом Симпсона с использованием std::thread
### Основные изменения и стратегия реализации:
* Параллельное выполнение с std::thread:
Основным механизмом распараллеливания служит std::thread. Это обеспечивает контроль над созданием и управлением потоками, а также широкую совместимость с различными компиляторами и окружениями.
Рекурсивный метод RecursiveSimpsonSum, отвечающий за вычисление интеграла по внутренним измерениям, сохранен и используется каждым потоком для обработки своей части задачи.
* Разделение вычислительной нагрузки:
Интегрирование по первой (внешней) размерности разделяется на подзадачи, каждая из которых назначается отдельному потоку.
Оптимальное количество потоков определяется с помощью std::thread::hardware_concurrency().
Каждый поток независимо вычисляет частичную сумму интеграла, соответствующую его диапазону итераций.
* Обработка многомерной сетки в потоках:
Каждый поток оперирует своей частью "столбцов" или "слоев" многомерной сетки интегрирования.
Для каждой точки i первой размерности, назначенной потоку:
Устанавливается индекс idx[0] = i.
Вызывается RecursiveSimpsonSum(1, local_idx, steps) для расчета суммы по оставшимся dimension - 1 измерениям, формируя вклад данного "столбца".
* Логика вычислений в задаче потока:
Для каждой итерации i внешнего цикла, обрабатываемой потоком:
Подготавливается локальный вектор индексов local_idx.
Устанавливается local_idx[0] = i.
С помощью RecursiveSimpsonSum вычисляется вклад от текущей точки i и связанных с ней внутренних узлов сетки.
Полученный вклад суммируется с локальной частичной суммой потока.
* Агрегация результатов:
После завершения всех вычислительных потоков (с использованием join()), частичные суммы, полученные от каждого потока, собираются и суммируются в основном потоке.
На основе этой общей суммы и соответствующих коэффициентов вычисляется итоговое значение многомерного интеграла.
Данный подход с использованием std::thread позволяет эффективно распараллелить вычисления, сохраняя при этом контроль над процессом и обеспечивая переносимость решения.