### PR TITLE
Бессонов Егор. Вариант 19. Технология MPI+STL. Поразрядная сортировка для вещественных чисел (тип double) с простым слиянием.

### DIFF
--- a/tasks/all/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
@@ -10,8 +10,8 @@
 #include <random>
 #include <vector>
 
-#include "core/task/include/task.hpp"
 #include "all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp"
+#include "core/task/include/task.hpp"
 
 namespace {
 std::vector<double> GenerateVector(std::size_t n, double first, double last) {

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
@@ -27,7 +27,7 @@ std::vector<double> GenerateVector(std::size_t n, double first, double last) {
 }
 }  // namespace
 
-TEST(bessonov_e_radix_sort_simple_merging_all, FirstTest) {
+TEST(bessonov_e_radix_sort_simple_merging_all, BasicSortingTest) {
   std::vector<double> input_vector = {3.4, 1.2, 0.5, 7.8, 2.3, 4.5, 6.7, 8.9, 1.0, 0.2, 5.6, 4.3, 9.1, 1.5, 3.0};
   std::vector<double> output_vector(input_vector.size(), 0.0);
   std::vector<double> result_vector = {0.2, 0.5, 1.0, 1.2, 1.5, 2.3, 3.0, 3.4, 4.3, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1};
@@ -325,6 +325,22 @@ TEST(bessonov_e_radix_sort_simple_merging_all, Validation_EmptyCounts) {
   if (world.rank() == 0) {
     task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
     task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  }
+
+  bessonov_e_radix_sort_simple_merging_all::TestTaskALL task(task_data);
+  ASSERT_FALSE(task.Validation());
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_all, Validation_ZeroSize) {
+  std::vector<double> input(0);
+  std::vector<double> output(0);
+  boost::mpi::communicator world;
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+    task_data->inputs_count.emplace_back(0);
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+    task_data->outputs_count.emplace_back(0);
   }
 
   bessonov_e_radix_sort_simple_merging_all::TestTaskALL task(task_data);

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
@@ -13,17 +13,17 @@
 #include "all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp"
 
 namespace {
-  std::vector<double> GenerateVector(std::size_t n, double first, double last) {
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_real_distribution<double> dist(first, last);
+std::vector<double> GenerateVector(std::size_t n, double first, double last) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<double> dist(first, last);
 
-    std::vector<double> result(n);
-    for (std::size_t i = 0; i < n; ++i) {
-      result[i] = dist(gen);
-    }
-    return result;
+  std::vector<double> result(n);
+  for (std::size_t i = 0; i < n; ++i) {
+    result[i] = dist(gen);
   }
+  return result;
+}
 }  // namespace
 
 TEST(bessonov_e_radix_sort_simple_merging_all, FirstTest) {
@@ -154,9 +154,11 @@ TEST(bessonov_e_radix_sort_simple_merging_all, AllSameElementsTest) {
 }
 
 TEST(bessonov_e_radix_sort_simple_merging_all, ExtremeValuesTest) {
-  std::vector<double> input_vector = {std::numeric_limits<double>::max(), std::numeric_limits<double>::lowest(), 0.0, -42.5, 100.0};
+  std::vector<double> input_vector = {std::numeric_limits<double>::max(), std::numeric_limits<double>::lowest(), 0.0,
+                                      -42.5, 100.0};
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = {std::numeric_limits<double>::lowest(), -42.5, 0.0, 100.0, std::numeric_limits<double>::max()};
+  std::vector<double> result_vector = {std::numeric_limits<double>::lowest(), -42.5, 0.0, 100.0,
+                                       std::numeric_limits<double>::max()};
 
   boost::mpi::communicator world;
   auto task_data = std::make_shared<ppc::core::TaskData>();

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
@@ -10,6 +10,7 @@
 #include <random>
 #include <vector>
 
+#include "core/task/include/task.hpp"
 #include "all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp"
 
 namespace {

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
@@ -1,0 +1,219 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp"
+
+namespace {
+std::vector<double> GenerateVector(std::size_t n, double first, double last) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<double> dist(first, last);
+
+  std::vector<double> result(n);
+  for (std::size_t i = 0; i < n; ++i) {
+    result[i] = dist(gen);
+  }
+  return result;
+}
+}  // namespace
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, FirstTest) {
+  std::vector<double> input_vector = {3.4, 1.2, 0.5, 7.8, 2.3, 4.5, 6.7, 8.9, 1.0, 0.2, 5.6, 4.3, 9.1, 1.5, 3.0};
+  std::vector<double> output_vector(input_vector.size(), 0.0);
+  std::vector<double> result_vector = {0.2, 0.5, 1.0, 1.2, 1.5, 2.3, 3.0, 3.4, 4.3, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1};
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  ASSERT_TRUE(test_task.Validation());
+  test_task.PreProcessing();
+  test_task.Run();
+  test_task.PostProcessing();
+
+  ASSERT_EQ(output_vector, result_vector);
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, SingleElementTest) {
+  std::vector<double> input_vector = {42.0};
+  std::vector<double> output_vector(1, 0.0);
+  std::vector<double> result_vector = {42.0};
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  ASSERT_TRUE(test_task.Validation());
+  test_task.PreProcessing();
+  test_task.Run();
+  test_task.PostProcessing();
+
+  ASSERT_EQ(output_vector, result_vector);
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, NegativeAndPositiveTest) {
+  std::vector<double> input_vector = {-3.2, 1.1, -7.5, 0.0, 4.4, -2.2, 3.3};
+  std::vector<double> output_vector(input_vector.size(), 0.0);
+  std::vector<double> result_vector = {-7.5, -3.2, -2.2, 0.0, 1.1, 3.3, 4.4};
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  ASSERT_TRUE(test_task.Validation());
+  test_task.PreProcessing();
+  test_task.Run();
+  test_task.PostProcessing();
+
+  ASSERT_EQ(output_vector, result_vector);
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, RandomVectorTest) {
+  const std::size_t n = 1000;
+  std::vector<double> input_vector = GenerateVector(n, -1000.0, 1000.0);
+  std::vector<double> output_vector(n, 0.0);
+
+  std::vector<double> result_vector = input_vector;
+  std::ranges::sort(result_vector);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  ASSERT_TRUE(test_task.Validation());
+  test_task.PreProcessing();
+  test_task.Run();
+  test_task.PostProcessing();
+
+  ASSERT_EQ(output_vector, result_vector);
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, AllSameElementsTest) {
+  std::vector<double> input_vector = {3.14, 3.14, 3.14, 3.14};
+  std::vector<double> output_vector(input_vector.size(), 0.0);
+  std::vector<double> result_vector = {3.14, 3.14, 3.14, 3.14};
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  ASSERT_TRUE(test_task.Validation());
+  test_task.PreProcessing();
+  test_task.Run();
+  test_task.PostProcessing();
+
+  ASSERT_EQ(output_vector, result_vector);
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, ExtremeValuesTest) {
+  std::vector<double> input_vector = {std::numeric_limits<double>::max(), std::numeric_limits<double>::lowest(), 0.0,
+                                      -42.5, 100.0};
+  std::vector<double> output_vector(input_vector.size(), 0.0);
+  std::vector<double> result_vector = {std::numeric_limits<double>::lowest(), -42.5, 0.0, 100.0,
+                                       std::numeric_limits<double>::max()};
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  ASSERT_TRUE(test_task.Validation());
+  test_task.PreProcessing();
+  test_task.Run();
+  test_task.PostProcessing();
+
+  ASSERT_EQ(output_vector, result_vector);
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, TinyNumbersTest) {
+  std::vector<double> input_vector = {1e-10, -1e-10, 1e-20, -1e-20};
+  std::vector<double> output_vector(input_vector.size(), 0.0);
+  std::vector<double> result_vector = {-1e-10, -1e-20, 1e-20, 1e-10};
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  ASSERT_TRUE(test_task.Validation());
+  test_task.PreProcessing();
+  test_task.Run();
+  test_task.PostProcessing();
+
+  ASSERT_EQ(output_vector, result_vector);
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, InvalidInputOutputSizeTest) {
+  std::vector<double> input = {1.0, 2.0, 3.0};
+  std::vector<double> output(2, 0.0);
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  ASSERT_FALSE(test_task.Validation());
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, ValidationEmptyTest) {
+  std::vector<double> input_vector;
+  std::vector<double> output_vector;
+  std::vector<double> result_vector;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  ASSERT_FALSE(test_task.Validation());
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, ReverseOrderTest) {
+  std::vector<double> input_vector = {9.1, 8.9, 7.8, 6.7, 5.6, 4.5, 4.3, 3.4, 3.0, 2.3, 1.5, 1.2, 1.0, 0.5, 0.2};
+  std::vector<double> output_vector(input_vector.size(), 0.0);
+  std::vector<double> result_vector = {0.2, 0.5, 1.0, 1.2, 1.5, 2.3, 3.0, 3.4, 4.3, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1};
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  ASSERT_TRUE(test_task.Validation());
+  test_task.PreProcessing();
+  test_task.Run();
+  test_task.PostProcessing();
+
+  ASSERT_EQ(output_vector, result_vector);
+}

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
@@ -301,22 +301,6 @@ TEST(bessonov_e_radix_sort_simple_merging_all, Validation_SizeMismatch) {
   ASSERT_FALSE(task.Validation());
 }
 
-TEST(bessonov_e_radix_sort_simple_merging_all, Validation_ZeroSize) {
-  std::vector<double> input(0);
-  std::vector<double> output(0);
-  boost::mpi::communicator world;
-  auto task_data = std::make_shared<ppc::core::TaskData>();
-  if (world.rank() == 0) {
-    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
-    task_data->inputs_count.emplace_back(input.size());
-    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
-    task_data->outputs_count.emplace_back(output.size());
-  }
-
-  bessonov_e_radix_sort_simple_merging_all::TestTaskALL task(task_data);
-  ASSERT_FALSE(task.Validation());
-}
-
 TEST(bessonov_e_radix_sort_simple_merging_all, Validation_SizeOverflow) {
   auto huge_size = static_cast<size_t>(INT_MAX) + 1;
   boost::mpi::communicator world;

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
@@ -345,10 +345,9 @@ TEST(bessonov_e_radix_sort_simple_merging_all, Validation_MaxSize) {
   }
 
   bessonov_e_radix_sort_simple_merging_all::TestTaskALL task(task_data);
-  ASSERT_TRUE(task.Validation());
 
-  if (world.rank() == 0) {
-    delete[] dummy_input;
-    delete[] dummy_output;
-  }
+  delete[] dummy_input;
+  delete[] dummy_output;
+
+  ASSERT_TRUE(task.Validation());
 }

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <boost/mpi/communicator.hpp>
+#include <climits>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -8,212 +10,358 @@
 #include <random>
 #include <vector>
 
-#include "core/task/include/task.hpp"
 #include "all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp"
 
 namespace {
-std::vector<double> GenerateVector(std::size_t n, double first, double last) {
-  std::random_device rd;
-  std::mt19937 gen(rd());
-  std::uniform_real_distribution<double> dist(first, last);
+  std::vector<double> GenerateVector(std::size_t n, double first, double last) {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_real_distribution<double> dist(first, last);
 
-  std::vector<double> result(n);
-  for (std::size_t i = 0; i < n; ++i) {
-    result[i] = dist(gen);
+    std::vector<double> result(n);
+    for (std::size_t i = 0; i < n; ++i) {
+      result[i] = dist(gen);
+    }
+    return result;
   }
-  return result;
-}
 }  // namespace
 
-TEST(bessonov_e_radix_sort_simple_merging_seq, FirstTest) {
-  std::vector<double> input_vector = {3.4, 1.2, 0.5, 7.8, 2.3, 4.5, 6.7, 8.9, 1.0, 0.2, 5.6, 4.3, 9.1, 1.5, 3.0};
+TEST(bessonov_e_radix_sort_simple_merging_all, FirstTest) {
+  std::vector<double> input_vector = { 3.4, 1.2, 0.5, 7.8, 2.3, 4.5, 6.7, 8.9, 1.0, 0.2, 5.6, 4.3, 9.1, 1.5, 3.0 };
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = {0.2, 0.5, 1.0, 1.2, 1.5, 2.3, 3.0, 3.4, 4.3, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1};
+  std::vector<double> result_vector = { 0.2, 0.5, 1.0, 1.2, 1.5, 2.3, 3.0, 3.4, 4.3, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1 };
 
+  boost::mpi::communicator world;
   auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
-  task_data->inputs_count.emplace_back(input_vector.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
-  task_data->outputs_count.emplace_back(output_vector.size());
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+    task_data->inputs_count.emplace_back(input_vector.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+    task_data->outputs_count.emplace_back(output_vector.size());
+  }
 
-  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  bessonov_e_radix_sort_simple_merging_all::TestTaskALL test_task(task_data);
   ASSERT_TRUE(test_task.Validation());
   test_task.PreProcessing();
   test_task.Run();
   test_task.PostProcessing();
 
-  ASSERT_EQ(output_vector, result_vector);
+  if (world.rank() == 0) {
+    EXPECT_EQ(output_vector, result_vector);
+  }
 }
 
-TEST(bessonov_e_radix_sort_simple_merging_seq, SingleElementTest) {
-  std::vector<double> input_vector = {42.0};
+TEST(bessonov_e_radix_sort_simple_merging_all, SingleElementTest) {
+  std::vector<double> input_vector = { 42.0 };
   std::vector<double> output_vector(1, 0.0);
-  std::vector<double> result_vector = {42.0};
+  std::vector<double> result_vector = { 42.0 };
 
+  boost::mpi::communicator world;
   auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
-  task_data->inputs_count.emplace_back(input_vector.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
-  task_data->outputs_count.emplace_back(output_vector.size());
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+    task_data->inputs_count.emplace_back(input_vector.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+    task_data->outputs_count.emplace_back(output_vector.size());
+  }
 
-  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  bessonov_e_radix_sort_simple_merging_all::TestTaskALL test_task(task_data);
   ASSERT_TRUE(test_task.Validation());
   test_task.PreProcessing();
   test_task.Run();
   test_task.PostProcessing();
 
-  ASSERT_EQ(output_vector, result_vector);
+  if (world.rank() == 0) {
+    EXPECT_EQ(output_vector, result_vector);
+  }
 }
 
-TEST(bessonov_e_radix_sort_simple_merging_seq, NegativeAndPositiveTest) {
-  std::vector<double> input_vector = {-3.2, 1.1, -7.5, 0.0, 4.4, -2.2, 3.3};
+TEST(bessonov_e_radix_sort_simple_merging_all, NegativeAndPositiveTest) {
+  std::vector<double> input_vector = { -3.2, 1.1, -7.5, 0.0, 4.4, -2.2, 3.3 };
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = {-7.5, -3.2, -2.2, 0.0, 1.1, 3.3, 4.4};
+  std::vector<double> result_vector = { -7.5, -3.2, -2.2, 0.0, 1.1, 3.3, 4.4 };
 
+  boost::mpi::communicator world;
   auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
-  task_data->inputs_count.emplace_back(input_vector.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
-  task_data->outputs_count.emplace_back(output_vector.size());
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+    task_data->inputs_count.emplace_back(input_vector.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+    task_data->outputs_count.emplace_back(output_vector.size());
+  }
 
-  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  bessonov_e_radix_sort_simple_merging_all::TestTaskALL test_task(task_data);
   ASSERT_TRUE(test_task.Validation());
   test_task.PreProcessing();
   test_task.Run();
   test_task.PostProcessing();
 
-  ASSERT_EQ(output_vector, result_vector);
+  if (world.rank() == 0) {
+    EXPECT_EQ(output_vector, result_vector);
+  }
 }
 
-TEST(bessonov_e_radix_sort_simple_merging_seq, RandomVectorTest) {
+TEST(bessonov_e_radix_sort_simple_merging_all, RandomVectorTest) {
   const std::size_t n = 1000;
   std::vector<double> input_vector = GenerateVector(n, -1000.0, 1000.0);
   std::vector<double> output_vector(n, 0.0);
-
   std::vector<double> result_vector = input_vector;
   std::ranges::sort(result_vector);
 
+  boost::mpi::communicator world;
   auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
-  task_data->inputs_count.emplace_back(input_vector.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
-  task_data->outputs_count.emplace_back(output_vector.size());
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+    task_data->inputs_count.emplace_back(input_vector.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+    task_data->outputs_count.emplace_back(output_vector.size());
+  }
 
-  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  bessonov_e_radix_sort_simple_merging_all::TestTaskALL test_task(task_data);
   ASSERT_TRUE(test_task.Validation());
   test_task.PreProcessing();
   test_task.Run();
   test_task.PostProcessing();
 
-  ASSERT_EQ(output_vector, result_vector);
+  if (world.rank() == 0) {
+    EXPECT_EQ(output_vector, result_vector);
+  }
 }
 
-TEST(bessonov_e_radix_sort_simple_merging_seq, AllSameElementsTest) {
-  std::vector<double> input_vector = {3.14, 3.14, 3.14, 3.14};
+TEST(bessonov_e_radix_sort_simple_merging_all, AllSameElementsTest) {
+  std::vector<double> input_vector = { 3.14, 3.14, 3.14, 3.14 };
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = {3.14, 3.14, 3.14, 3.14};
+  std::vector<double> result_vector = { 3.14, 3.14, 3.14, 3.14 };
 
+  boost::mpi::communicator world;
   auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
-  task_data->inputs_count.emplace_back(input_vector.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
-  task_data->outputs_count.emplace_back(output_vector.size());
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+    task_data->inputs_count.emplace_back(input_vector.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+    task_data->outputs_count.emplace_back(output_vector.size());
+  }
 
-  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  bessonov_e_radix_sort_simple_merging_all::TestTaskALL test_task(task_data);
   ASSERT_TRUE(test_task.Validation());
   test_task.PreProcessing();
   test_task.Run();
   test_task.PostProcessing();
 
-  ASSERT_EQ(output_vector, result_vector);
+  if (world.rank() == 0) {
+    EXPECT_EQ(output_vector, result_vector);
+  }
 }
 
-TEST(bessonov_e_radix_sort_simple_merging_seq, ExtremeValuesTest) {
-  std::vector<double> input_vector = {std::numeric_limits<double>::max(), std::numeric_limits<double>::lowest(), 0.0,
-                                      -42.5, 100.0};
+TEST(bessonov_e_radix_sort_simple_merging_all, ExtremeValuesTest) {
+  std::vector<double> input_vector = { std::numeric_limits<double>::max(), std::numeric_limits<double>::lowest(), 0.0, -42.5, 100.0 };
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = {std::numeric_limits<double>::lowest(), -42.5, 0.0, 100.0,
-                                       std::numeric_limits<double>::max()};
+  std::vector<double> result_vector = { std::numeric_limits<double>::lowest(), -42.5, 0.0, 100.0, std::numeric_limits<double>::max() };
 
+  boost::mpi::communicator world;
   auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
-  task_data->inputs_count.emplace_back(input_vector.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
-  task_data->outputs_count.emplace_back(output_vector.size());
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+    task_data->inputs_count.emplace_back(input_vector.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+    task_data->outputs_count.emplace_back(output_vector.size());
+  }
 
-  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  bessonov_e_radix_sort_simple_merging_all::TestTaskALL test_task(task_data);
   ASSERT_TRUE(test_task.Validation());
   test_task.PreProcessing();
   test_task.Run();
   test_task.PostProcessing();
 
-  ASSERT_EQ(output_vector, result_vector);
+  if (world.rank() == 0) {
+    EXPECT_EQ(output_vector, result_vector);
+  }
 }
 
-TEST(bessonov_e_radix_sort_simple_merging_seq, TinyNumbersTest) {
-  std::vector<double> input_vector = {1e-10, -1e-10, 1e-20, -1e-20};
+TEST(bessonov_e_radix_sort_simple_merging_all, TinyNumbersTest) {
+  std::vector<double> input_vector = { 1e-10, -1e-10, 1e-20, -1e-20 };
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = {-1e-10, -1e-20, 1e-20, 1e-10};
+  std::vector<double> result_vector = { -1e-10, -1e-20, 1e-20, 1e-10 };
 
+  boost::mpi::communicator world;
   auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
-  task_data->inputs_count.emplace_back(input_vector.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
-  task_data->outputs_count.emplace_back(output_vector.size());
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+    task_data->inputs_count.emplace_back(input_vector.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+    task_data->outputs_count.emplace_back(output_vector.size());
+  }
 
-  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  bessonov_e_radix_sort_simple_merging_all::TestTaskALL test_task(task_data);
   ASSERT_TRUE(test_task.Validation());
   test_task.PreProcessing();
   test_task.Run();
   test_task.PostProcessing();
 
-  ASSERT_EQ(output_vector, result_vector);
+  if (world.rank() == 0) {
+    EXPECT_EQ(output_vector, result_vector);
+  }
 }
 
-TEST(bessonov_e_radix_sort_simple_merging_seq, InvalidInputOutputSizeTest) {
-  std::vector<double> input = {1.0, 2.0, 3.0};
-  std::vector<double> output(2, 0.0);
-  auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
-  task_data->inputs_count.emplace_back(input.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
-  task_data->outputs_count.emplace_back(output.size());
-
-  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
-  ASSERT_FALSE(test_task.Validation());
-}
-
-TEST(bessonov_e_radix_sort_simple_merging_seq, ValidationEmptyTest) {
-  std::vector<double> input_vector;
-  std::vector<double> output_vector;
-  std::vector<double> result_vector;
-
-  auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
-  task_data->inputs_count.emplace_back(input_vector.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
-  task_data->outputs_count.emplace_back(output_vector.size());
-
-  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
-  ASSERT_FALSE(test_task.Validation());
-}
-
-TEST(bessonov_e_radix_sort_simple_merging_seq, ReverseOrderTest) {
-  std::vector<double> input_vector = {9.1, 8.9, 7.8, 6.7, 5.6, 4.5, 4.3, 3.4, 3.0, 2.3, 1.5, 1.2, 1.0, 0.5, 0.2};
+TEST(bessonov_e_radix_sort_simple_merging_all, DenormalNumbersTest) {
+  std::vector<double> input_vector = { 1e-310, -1e-310, 0.0 };
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = {0.2, 0.5, 1.0, 1.2, 1.5, 2.3, 3.0, 3.4, 4.3, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1};
+  std::vector<double> result_vector = { -1e-310, 0.0, 1e-310 };
 
+  boost::mpi::communicator world;
   auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
-  task_data->inputs_count.emplace_back(input_vector.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
-  task_data->outputs_count.emplace_back(output_vector.size());
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+    task_data->inputs_count.emplace_back(input_vector.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+    task_data->outputs_count.emplace_back(output_vector.size());
+  }
 
-  bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential test_task(task_data);
+  bessonov_e_radix_sort_simple_merging_all::TestTaskALL test_task(task_data);
   ASSERT_TRUE(test_task.Validation());
   test_task.PreProcessing();
   test_task.Run();
   test_task.PostProcessing();
 
-  ASSERT_EQ(output_vector, result_vector);
+  if (world.rank() == 0) {
+    EXPECT_EQ(output_vector, result_vector);
+  }
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_all, ReverseOrderTest) {
+  std::vector<double> input_vector = { 9.1, 8.9, 7.8, 6.7, 5.6, 4.5, 4.3, 3.4, 3.0, 2.3, 1.5, 1.2, 1.0, 0.5, 0.2 };
+  std::vector<double> output_vector(input_vector.size(), 0.0);
+  std::vector<double> result_vector = { 0.2, 0.5, 1.0, 1.2, 1.5, 2.3, 3.0, 3.4, 4.3, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1 };
+
+  boost::mpi::communicator world;
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+    task_data->inputs_count.emplace_back(input_vector.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+    task_data->outputs_count.emplace_back(output_vector.size());
+  }
+
+  bessonov_e_radix_sort_simple_merging_all::TestTaskALL test_task(task_data);
+  ASSERT_TRUE(test_task.Validation());
+  test_task.PreProcessing();
+  test_task.Run();
+  test_task.PostProcessing();
+
+  if (world.rank() == 0) {
+    EXPECT_EQ(output_vector, result_vector);
+  }
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_all, Validation_NullInput) {
+  std::vector<double> output(100);
+  boost::mpi::communicator world;
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(nullptr);
+    task_data->inputs_count.emplace_back(100);
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+    task_data->outputs_count.emplace_back(output.size());
+  }
+
+  bessonov_e_radix_sort_simple_merging_all::TestTaskALL task(task_data);
+  ASSERT_FALSE(task.Validation());
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_all, Validation_NullOutput) {
+  std::vector<double> input(100);
+  boost::mpi::communicator world;
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+    task_data->inputs_count.emplace_back(input.size());
+    task_data->outputs.emplace_back(nullptr);
+    task_data->outputs_count.emplace_back(100);
+  }
+
+  bessonov_e_radix_sort_simple_merging_all::TestTaskALL task(task_data);
+  ASSERT_FALSE(task.Validation());
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_all, Validation_SizeMismatch) {
+  std::vector<double> input(100);
+  std::vector<double> output(50);
+  boost::mpi::communicator world;
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+    task_data->inputs_count.emplace_back(input.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+    task_data->outputs_count.emplace_back(output.size());
+  }
+
+  bessonov_e_radix_sort_simple_merging_all::TestTaskALL task(task_data);
+  ASSERT_FALSE(task.Validation());
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_all, Validation_ZeroSize) {
+  std::vector<double> input(0);
+  std::vector<double> output(0);
+  boost::mpi::communicator world;
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+    task_data->inputs_count.emplace_back(input.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+    task_data->outputs_count.emplace_back(output.size());
+  }
+
+  bessonov_e_radix_sort_simple_merging_all::TestTaskALL task(task_data);
+  ASSERT_FALSE(task.Validation());
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_all, Validation_SizeOverflow) {
+  auto huge_size = static_cast<size_t>(INT_MAX) + 1;
+  boost::mpi::communicator world;
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(nullptr);
+    task_data->inputs_count.emplace_back(huge_size);
+    task_data->outputs.emplace_back(nullptr);
+    task_data->outputs_count.emplace_back(huge_size);
+  }
+
+  bessonov_e_radix_sort_simple_merging_all::TestTaskALL task(task_data);
+  ASSERT_FALSE(task.Validation());
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_all, Validation_EmptyCounts) {
+  std::vector<double> input(100);
+  std::vector<double> output(100);
+  boost::mpi::communicator world;
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  }
+
+  bessonov_e_radix_sort_simple_merging_all::TestTaskALL task(task_data);
+  ASSERT_FALSE(task.Validation());
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_all, Validation_MaxSize) {
+  auto max_size = static_cast<size_t>(INT_MAX);
+  boost::mpi::communicator world;
+  auto* dummy_input = new uint8_t[1];
+  auto* dummy_output = new uint8_t[1];
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(dummy_input);
+    task_data->inputs_count.emplace_back(max_size);
+    task_data->outputs.emplace_back(dummy_output);
+    task_data->outputs_count.emplace_back(max_size);
+  }
+
+  bessonov_e_radix_sort_simple_merging_all::TestTaskALL task(task_data);
+  ASSERT_TRUE(task.Validation());
+
+  if (world.rank() == 0) {
+    delete[] dummy_input;
+    delete[] dummy_output;
+  }
 }

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/func_tests/main.cpp
@@ -27,9 +27,9 @@ namespace {
 }  // namespace
 
 TEST(bessonov_e_radix_sort_simple_merging_all, FirstTest) {
-  std::vector<double> input_vector = { 3.4, 1.2, 0.5, 7.8, 2.3, 4.5, 6.7, 8.9, 1.0, 0.2, 5.6, 4.3, 9.1, 1.5, 3.0 };
+  std::vector<double> input_vector = {3.4, 1.2, 0.5, 7.8, 2.3, 4.5, 6.7, 8.9, 1.0, 0.2, 5.6, 4.3, 9.1, 1.5, 3.0};
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = { 0.2, 0.5, 1.0, 1.2, 1.5, 2.3, 3.0, 3.4, 4.3, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1 };
+  std::vector<double> result_vector = {0.2, 0.5, 1.0, 1.2, 1.5, 2.3, 3.0, 3.4, 4.3, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1};
 
   boost::mpi::communicator world;
   auto task_data = std::make_shared<ppc::core::TaskData>();
@@ -52,9 +52,9 @@ TEST(bessonov_e_radix_sort_simple_merging_all, FirstTest) {
 }
 
 TEST(bessonov_e_radix_sort_simple_merging_all, SingleElementTest) {
-  std::vector<double> input_vector = { 42.0 };
+  std::vector<double> input_vector = {42.0};
   std::vector<double> output_vector(1, 0.0);
-  std::vector<double> result_vector = { 42.0 };
+  std::vector<double> result_vector = {42.0};
 
   boost::mpi::communicator world;
   auto task_data = std::make_shared<ppc::core::TaskData>();
@@ -77,9 +77,9 @@ TEST(bessonov_e_radix_sort_simple_merging_all, SingleElementTest) {
 }
 
 TEST(bessonov_e_radix_sort_simple_merging_all, NegativeAndPositiveTest) {
-  std::vector<double> input_vector = { -3.2, 1.1, -7.5, 0.0, 4.4, -2.2, 3.3 };
+  std::vector<double> input_vector = {-3.2, 1.1, -7.5, 0.0, 4.4, -2.2, 3.3};
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = { -7.5, -3.2, -2.2, 0.0, 1.1, 3.3, 4.4 };
+  std::vector<double> result_vector = {-7.5, -3.2, -2.2, 0.0, 1.1, 3.3, 4.4};
 
   boost::mpi::communicator world;
   auto task_data = std::make_shared<ppc::core::TaskData>();
@@ -129,9 +129,9 @@ TEST(bessonov_e_radix_sort_simple_merging_all, RandomVectorTest) {
 }
 
 TEST(bessonov_e_radix_sort_simple_merging_all, AllSameElementsTest) {
-  std::vector<double> input_vector = { 3.14, 3.14, 3.14, 3.14 };
+  std::vector<double> input_vector = {3.14, 3.14, 3.14, 3.14};
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = { 3.14, 3.14, 3.14, 3.14 };
+  std::vector<double> result_vector = {3.14, 3.14, 3.14, 3.14};
 
   boost::mpi::communicator world;
   auto task_data = std::make_shared<ppc::core::TaskData>();
@@ -154,9 +154,9 @@ TEST(bessonov_e_radix_sort_simple_merging_all, AllSameElementsTest) {
 }
 
 TEST(bessonov_e_radix_sort_simple_merging_all, ExtremeValuesTest) {
-  std::vector<double> input_vector = { std::numeric_limits<double>::max(), std::numeric_limits<double>::lowest(), 0.0, -42.5, 100.0 };
+  std::vector<double> input_vector = {std::numeric_limits<double>::max(), std::numeric_limits<double>::lowest(), 0.0, -42.5, 100.0};
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = { std::numeric_limits<double>::lowest(), -42.5, 0.0, 100.0, std::numeric_limits<double>::max() };
+  std::vector<double> result_vector = {std::numeric_limits<double>::lowest(), -42.5, 0.0, 100.0, std::numeric_limits<double>::max()};
 
   boost::mpi::communicator world;
   auto task_data = std::make_shared<ppc::core::TaskData>();
@@ -179,9 +179,9 @@ TEST(bessonov_e_radix_sort_simple_merging_all, ExtremeValuesTest) {
 }
 
 TEST(bessonov_e_radix_sort_simple_merging_all, TinyNumbersTest) {
-  std::vector<double> input_vector = { 1e-10, -1e-10, 1e-20, -1e-20 };
+  std::vector<double> input_vector = {1e-10, -1e-10, 1e-20, -1e-20};
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = { -1e-10, -1e-20, 1e-20, 1e-10 };
+  std::vector<double> result_vector = {-1e-10, -1e-20, 1e-20, 1e-10};
 
   boost::mpi::communicator world;
   auto task_data = std::make_shared<ppc::core::TaskData>();
@@ -204,9 +204,9 @@ TEST(bessonov_e_radix_sort_simple_merging_all, TinyNumbersTest) {
 }
 
 TEST(bessonov_e_radix_sort_simple_merging_all, DenormalNumbersTest) {
-  std::vector<double> input_vector = { 1e-310, -1e-310, 0.0 };
+  std::vector<double> input_vector = {1e-310, -1e-310, 0.0};
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = { -1e-310, 0.0, 1e-310 };
+  std::vector<double> result_vector = {-1e-310, 0.0, 1e-310};
 
   boost::mpi::communicator world;
   auto task_data = std::make_shared<ppc::core::TaskData>();
@@ -229,9 +229,9 @@ TEST(bessonov_e_radix_sort_simple_merging_all, DenormalNumbersTest) {
 }
 
 TEST(bessonov_e_radix_sort_simple_merging_all, ReverseOrderTest) {
-  std::vector<double> input_vector = { 9.1, 8.9, 7.8, 6.7, 5.6, 4.5, 4.3, 3.4, 3.0, 2.3, 1.5, 1.2, 1.0, 0.5, 0.2 };
+  std::vector<double> input_vector = {9.1, 8.9, 7.8, 6.7, 5.6, 4.5, 4.3, 3.4, 3.0, 2.3, 1.5, 1.2, 1.0, 0.5, 0.2};
   std::vector<double> output_vector(input_vector.size(), 0.0);
-  std::vector<double> result_vector = { 0.2, 0.5, 1.0, 1.2, 1.5, 2.3, 3.0, 3.4, 4.3, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1 };
+  std::vector<double> result_vector = {0.2, 0.5, 1.0, 1.2, 1.5, 2.3, 3.0, 3.4, 4.3, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1};
 
   boost::mpi::communicator world;
   auto task_data = std::make_shared<ppc::core::TaskData>();

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace bessonov_e_radix_sort_simple_merging_seq {
+
+class TestTaskSequential : public ppc::core::Task {
+ public:
+  explicit TestTaskSequential(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<double> input_, output_;
+};
+
+}  // namespace bessonov_e_radix_sort_simple_merging_seq

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp
@@ -5,7 +5,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <deque>
-#include <functional>
 #include <utility>
 #include <vector>
 
@@ -28,7 +27,7 @@ class TestTaskALL : public ppc::core::Task {
 
   void HandleSingleProcess();
   void HandleParallelProcess();
-  void MergeChunks(std::deque<std::vector<double>>& chunks);
+  static void MergeChunks(std::deque<std::vector<double>>& chunks);
 
   static void ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits, size_t start,
                                   size_t end);

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp
@@ -30,10 +30,10 @@ class TestTaskALL : public ppc::core::Task {
   void HandleParallelProcess();
   void MergeChunks(std::deque<std::vector<double>>& chunks);
 
-  static void ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits,
-                                  size_t start, size_t end);
-  static void ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output,
-                                  size_t start, size_t end);
+  static void ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits, size_t start,
+                                  size_t end);
+  static void ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output, size_t start,
+                                  size_t end);
   static void RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_t>& temp, int shift);
   static std::vector<double> Merge(const std::vector<double>& left, const std::vector<double>& right);
 };

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp
@@ -1,23 +1,34 @@
 #pragma once
 
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <cstddef>
+#include <cstdint>
 #include <utility>
 #include <vector>
 
 #include "core/task/include/task.hpp"
 
-namespace bessonov_e_radix_sort_simple_merging_seq {
+namespace bessonov_e_radix_sort_simple_merging_all {
 
-class TestTaskSequential : public ppc::core::Task {
- public:
-  explicit TestTaskSequential(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  class TestTaskALL : public ppc::core::Task {
+  public:
+    explicit TestTaskALL(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
 
-  bool PreProcessingImpl() override;
-  bool ValidationImpl() override;
-  bool RunImpl() override;
-  bool PostProcessingImpl() override;
+    bool PreProcessingImpl() override;
+    bool ValidationImpl() override;
+    bool RunImpl() override;
+    bool PostProcessingImpl() override;
 
- private:
-  std::vector<double> input_, output_;
-};
+  private:
+    std::vector<double> input_;
+    std::vector<double> output_;
 
-}  // namespace bessonov_e_radix_sort_simple_merging_seq
+    static void ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits, size_t start,
+      size_t end);
+    static void ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output, size_t start,
+      size_t end);
+    static void RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_t>& temp, int shift);
+  };
+
+}  // namespace bessonov_e_radix_sort_simple_merging_mpi_stl

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp
@@ -11,24 +11,24 @@
 
 namespace bessonov_e_radix_sort_simple_merging_all {
 
-  class TestTaskALL : public ppc::core::Task {
-  public:
-    explicit TestTaskALL(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+class TestTaskALL : public ppc::core::Task {
+public:
+  explicit TestTaskALL(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
 
-    bool PreProcessingImpl() override;
-    bool ValidationImpl() override;
-    bool RunImpl() override;
-    bool PostProcessingImpl() override;
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
 
-  private:
-    std::vector<double> input_;
-    std::vector<double> output_;
+private:
+  std::vector<double> input_;
+  std::vector<double> output_;
 
-    static void ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits, size_t start,
-      size_t end);
-    static void ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output, size_t start,
-      size_t end);
-    static void RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_t>& temp, int shift);
-  };
+  static void ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits, size_t start,
+                                  size_t end);
+  static void ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output, size_t start,
+                                  size_t end);
+  static void RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_t>& temp, int shift);
+};
 
-}  // namespace bessonov_e_radix_sort_simple_merging_mpi_stl
+}  // namespace bessonov_e_radix_sort_simple_merging_all

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp
@@ -1,10 +1,7 @@
 #pragma once
 
-#include <boost/mpi/collectives.hpp>
 #include <boost/mpi/communicator.hpp>
-#include <cstddef>
 #include <cstdint>
-#include <utility>
 #include <vector>
 
 #include "core/task/include/task.hpp"
@@ -21,14 +18,15 @@ class TestTaskALL : public ppc::core::Task {
   bool PostProcessingImpl() override;
 
  private:
-  std::vector<double> input_;
-  std::vector<double> output_;
+  std::vector<double> input_, output_;
+  boost::mpi::communicator world_;
 
   static void ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits, size_t start,
                                   size_t end);
   static void ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output, size_t start,
                                   size_t end);
   static void RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_t>& temp, int shift);
+  static std::vector<double> Merge(const std::vector<double>& left, const std::vector<double>& right);
 };
 
 }  // namespace bessonov_e_radix_sort_simple_merging_all

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp
@@ -12,7 +12,7 @@
 namespace bessonov_e_radix_sort_simple_merging_all {
 
 class TestTaskALL : public ppc::core::Task {
-public:
+ public:
   explicit TestTaskALL(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
 
   bool PreProcessingImpl() override;
@@ -20,7 +20,7 @@ public:
   bool RunImpl() override;
   bool PostProcessingImpl() override;
 
-private:
+ private:
   std::vector<double> input_;
   std::vector<double> output_;
 

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp
@@ -1,7 +1,12 @@
 #pragma once
 
+#include <boost/mpi/collectives.hpp>
 #include <boost/mpi/communicator.hpp>
+#include <cstddef>
 #include <cstdint>
+#include <deque>
+#include <functional>
+#include <utility>
 #include <vector>
 
 #include "core/task/include/task.hpp"
@@ -21,12 +26,15 @@ class TestTaskALL : public ppc::core::Task {
   std::vector<double> input_, output_;
   boost::mpi::communicator world_;
 
-  static void ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits, size_t start,
-                                  size_t end);
-  static void ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output, size_t start,
-                                  size_t end);
+  void HandleSingleProcess();
+  void HandleParallelProcess();
+  void MergeChunks(std::deque<std::vector<double>>& chunks);
+
+  static void ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits,
+                                  size_t start, size_t end);
+  static void ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output,
+                                  size_t start, size_t end);
   static void RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_t>& temp, int shift);
   static std::vector<double> Merge(const std::vector<double>& left, const std::vector<double>& right);
 };
-
 }  // namespace bessonov_e_radix_sort_simple_merging_all

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/perf_tests/main.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/perf_tests/main.cpp
@@ -1,0 +1,83 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp"
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, test_pipeline_run) {
+  const int n = 5000000;
+  std::vector<double> input_vector(n);
+  for (int i = 0; i < n; i++) {
+    input_vector[i] = static_cast<double>(n - i);
+  }
+  std::vector<double> output_vector(n, 0.0);
+
+  std::vector<double> result_vector = input_vector;
+  std::ranges::sort(result_vector);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  auto test_task = std::make_shared<bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential>(task_data);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [t0]() {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  ASSERT_EQ(output_vector, result_vector);
+}
+
+TEST(bessonov_e_radix_sort_simple_merging_seq, test_task_run) {
+  const int n = 5000000;
+  std::vector<double> input_vector(n);
+  for (int i = 0; i < n; i++) {
+    input_vector[i] = static_cast<double>(n - i);
+  }
+  std::vector<double> output_vector(n, 0.0);
+
+  std::vector<double> result_vector = input_vector;
+  std::ranges::sort(result_vector);
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input_vector.data()));
+  task_data->inputs_count.emplace_back(input_vector.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output_vector.data()));
+  task_data->outputs_count.emplace_back(output_vector.size());
+
+  auto test_task = std::make_shared<bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential>(task_data);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [t0]() {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  ASSERT_EQ(output_vector, result_vector);
+}

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/perf_tests/main.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/perf_tests/main.cpp
@@ -7,9 +7,9 @@
 #include <memory>
 #include <vector>
 
+#include "all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp"
 #include "core/perf/include/perf.hpp"
 #include "core/task/include/task.hpp"
-#include "all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp"
 
 TEST(bessonov_e_radix_sort_simple_merging_all, test_pipeline_run) {
   const int n = 5000000;
@@ -45,7 +45,7 @@ TEST(bessonov_e_radix_sort_simple_merging_all, test_pipeline_run) {
     auto current_time_point = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
     return static_cast<double>(duration) * 1e-9;
-    };
+  };
 
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task);
@@ -93,7 +93,7 @@ TEST(bessonov_e_radix_sort_simple_merging_all, test_task_run) {
     auto current_time_point = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
     return static_cast<double>(duration) * 1e-9;
-    };
+  };
 
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task);

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
@@ -17,168 +17,124 @@
 
 namespace bessonov_e_radix_sort_simple_merging_all {
 
-  void TestTaskALL::ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits, size_t start, size_t end) {
-    for (size_t i = start; i < end; ++i) {
-      uint64_t b = 0;
-      std::memcpy(&b, &input[i], sizeof(double));
-      b ^= (-static_cast<int64_t>(b >> 63) | (1ULL << 63));
-      bits[i] = b;
+void TestTaskALL::ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits, size_t start,
+                                      size_t end) {
+  for (size_t i = start; i < end; ++i) {
+    uint64_t b = 0;
+    std::memcpy(&b, &input[i], sizeof(double));
+    b ^= (-static_cast<int64_t>(b >> 63) | (1ULL << 63));
+    bits[i] = b;
+  }
+}
+
+void TestTaskALL::ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output, size_t start,
+                                      size_t end) {
+  for (size_t i = start; i < end; ++i) {
+    uint64_t b = bits[i];
+    b ^= (((b >> 63) - 1) | (1ULL << 63));
+    double d = NAN;
+    std::memcpy(&d, &b, sizeof(double));
+    output[i] = d;
+  }
+}
+
+void TestTaskALL::RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_t>& temp, int shift) {
+  constexpr int kRadix = 256;
+  const size_t n = bits.size();
+  std::array<size_t, kRadix> count{};
+
+  for (size_t i = 0; i < n; ++i) {
+    count[(bits[i] >> shift) & 0xFF]++;
+  }
+
+  size_t total = 0;
+  for (int i = 0; i < kRadix; ++i) {
+    size_t old_count = count[i];
+    count[i] = total;
+    total += old_count;
+  }
+
+  for (size_t i = 0; i < n; ++i) {
+    uint8_t digit = (bits[i] >> shift) & 0xFF;
+    temp[count[digit]++] = bits[i];
+  }
+
+  bits.swap(temp);
+}
+
+std::vector<double> TestTaskALL::Merge(const std::vector<double>& left, const std::vector<double>& right) {
+  std::vector<double> result;
+  result.reserve(left.size() + right.size());
+
+  size_t i = 0, j = 0;
+  while (i < left.size() && j < right.size()) {
+    if (left[i] < right[j]) {
+      result.push_back(left[i++]);
+    } else {
+      result.push_back(right[j++]);
     }
   }
 
-  void TestTaskALL::ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output, size_t start, size_t end) {
-    for (size_t i = start; i < end; ++i) {
-      uint64_t b = bits[i];
-      b ^= (((b >> 63) - 1) | (1ULL << 63));
-      double d = NAN;
-      std::memcpy(&d, &b, sizeof(double));
-      output[i] = d;
+  while (i < left.size()) result.push_back(left[i++]);
+  while (j < right.size()) result.push_back(right[j++]);
+
+  return result;
+}
+
+bool TestTaskALL::PreProcessingImpl() {
+  if (world_.rank() == 0) {
+    input_.resize(task_data->inputs_count[0]);
+    output_.resize(task_data->outputs_count[0]);
+
+    auto* in_ptr = reinterpret_cast<double*>(task_data->inputs[0]);
+    std::copy(in_ptr, in_ptr + task_data->inputs_count[0], input_.begin());
+  }
+  return true;
+}
+
+bool TestTaskALL::ValidationImpl() {
+  bool local_valid = true;
+
+  if (world_.rank() == 0) {
+    local_valid = !(task_data->inputs.empty() || task_data->outputs.empty());
+    local_valid &= task_data->inputs[0] != nullptr && task_data->outputs[0] != nullptr;
+
+    if (task_data->inputs_count.empty() || task_data->outputs_count.empty()) {
+      local_valid = false;
+    } else {
+      local_valid &= task_data->inputs_count[0] > 0;
+      local_valid &= task_data->inputs_count[0] == task_data->outputs_count[0];
+      local_valid &= task_data->inputs_count[0] <= static_cast<size_t>(std::numeric_limits<int>::max());
     }
   }
 
-  void TestTaskALL::RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_t>& temp, int shift) {
-    constexpr int kRadix = 256;
-    const size_t n = bits.size();
-    std::array<size_t, kRadix> count{};
+  boost::mpi::broadcast(world_, local_valid, 0);
+  return local_valid;
+}
 
-    for (size_t i = 0; i < n; ++i) {
-      count[(bits[i] >> shift) & 0xFF]++;
-    }
+bool TestTaskALL::RunImpl() {
+  const int rank = world_.rank();
+  const int size = world_.size();
 
-    size_t total = 0;
-    for (int i = 0; i < kRadix; ++i) {
-      size_t old_count = count[i];
-      count[i] = total;
-      total += old_count;
-    }
-
-    for (size_t i = 0; i < n; ++i) {
-      uint8_t digit = (bits[i] >> shift) & 0xFF;
-      temp[count[digit]++] = bits[i];
-    }
-
-    bits.swap(temp);
+  size_t n = 0;
+  if (rank == 0) {
+    n = input_.size();
   }
+  boost::mpi::broadcast(world_, n, 0);
 
-  std::vector<double> TestTaskALL::Merge(const std::vector<double>& left, const std::vector<double>& right) {
-    std::vector<double> result;
-    result.reserve(left.size() + right.size());
+  if (n == 0) return true;
 
-    size_t i = 0, j = 0;
-    while (i < left.size() && j < right.size()) {
-      if (left[i] < right[j]) {
-        result.push_back(left[i++]);
-      }
-      else {
-        result.push_back(right[j++]);
-      }
-    }
+  const size_t threads = std::max<size_t>(1, ppc::util::GetPPCNumThreads());
+  const size_t block = (n + threads - 1) / threads;
 
-    while (i < left.size()) result.push_back(left[i++]);
-    while (j < right.size()) result.push_back(right[j++]);
-
-    return result;
-  }
-
-  bool TestTaskALL::PreProcessingImpl() {
-    if (world_.rank() == 0) {
-      input_.resize(task_data->inputs_count[0]);
-      output_.resize(task_data->outputs_count[0]);
-
-      auto* in_ptr = reinterpret_cast<double*>(task_data->inputs[0]);
-      std::copy(in_ptr, in_ptr + task_data->inputs_count[0], input_.begin());
-    }
-    return true;
-  }
-
-  bool TestTaskALL::ValidationImpl() {
-    bool local_valid = true;
-
-    if (world_.rank() == 0) {
-      local_valid = !(task_data->inputs.empty() || task_data->outputs.empty());
-      local_valid &= task_data->inputs[0] != nullptr && task_data->outputs[0] != nullptr;
-
-      if (task_data->inputs_count.empty() || task_data->outputs_count.empty()) {
-        local_valid = false;
-      }
-      else {
-        local_valid &= task_data->inputs_count[0] > 0;
-        local_valid &= task_data->inputs_count[0] == task_data->outputs_count[0];
-        local_valid &= task_data->inputs_count[0] <= static_cast<size_t>(std::numeric_limits<int>::max());
-      }
-    }
-
-    boost::mpi::broadcast(world_, local_valid, 0);
-    return local_valid;
-  }
-
-  bool TestTaskALL::RunImpl() {
-    const int rank = world_.rank();
-    const int size = world_.size();
-
-    size_t n = 0;
-    if (rank == 0) {
-      n = input_.size();
-    }
-    boost::mpi::broadcast(world_, n, 0);
-
-    if (n == 0) return true;
-
-    const size_t threads = std::max<size_t>(1, ppc::util::GetPPCNumThreads());
-    const size_t block = (n + threads - 1) / threads;
-
-    if (size == 1) {
-      std::vector<uint64_t> bits(n), temp(n);
-      {
-        std::vector<std::thread> th;
-        for (size_t i = 0; i < threads; ++i) {
-          size_t start = i * block;
-          size_t end = std::min(start + block, n);
-          if (start < end)
-            th.emplace_back(ConvertDoubleToBits, std::cref(input_), std::ref(bits), start, end);
-        }
-        for (auto& t : th) t.join();
-      }
-
-      for (int pass = 0; pass < static_cast<int>(sizeof(uint64_t)); ++pass) {
-        RadixSortPass(bits, temp, pass * 8);
-      }
-
-      output_.resize(n);
-      {
-        std::vector<std::thread> th;
-        for (size_t i = 0; i < threads; ++i) {
-          size_t start = i * block;
-          size_t end = std::min(start + block, n);
-          if (start < end)
-            th.emplace_back(ConvertBitsToDouble, std::cref(bits), std::ref(output_), start, end);
-        }
-        for (auto& t : th) t.join();
-      }
-
-      return true;
-    }
-
-    std::vector<int> sendcounts(size), displs(size);
-    for (int i = 0; i < size; ++i) {
-      sendcounts[i] = n / size + (i < static_cast<int>(n % size) ? 1 : 0);
-      displs[i] = (i == 0) ? 0 : displs[i - 1] + sendcounts[i - 1];
-    }
-
-    std::vector<double> local_input(sendcounts[rank]);
-    MPI_Scatterv(input_.data(), sendcounts.data(), displs.data(), MPI_DOUBLE,
-      local_input.data(), sendcounts[rank], MPI_DOUBLE, 0, MPI_COMM_WORLD);
-
-    size_t local_n = local_input.size();
-    std::vector<uint64_t> bits(local_n), temp(local_n);
-
+  if (size == 1) {
+    std::vector<uint64_t> bits(n), temp(n);
     {
       std::vector<std::thread> th;
       for (size_t i = 0; i < threads; ++i) {
         size_t start = i * block;
-        size_t end = std::min(start + block, local_n);
-        if (start < end)
-          th.emplace_back(ConvertDoubleToBits, std::cref(local_input), std::ref(bits), start, end);
+        size_t end = std::min(start + block, n);
+        if (start < end) th.emplace_back(ConvertDoubleToBits, std::cref(input_), std::ref(bits), start, end);
       }
       for (auto& t : th) t.join();
     }
@@ -187,73 +143,114 @@ namespace bessonov_e_radix_sort_simple_merging_all {
       RadixSortPass(bits, temp, pass * 8);
     }
 
-    std::vector<double> local_sorted(local_n);
+    output_.resize(n);
     {
       std::vector<std::thread> th;
       for (size_t i = 0; i < threads; ++i) {
         size_t start = i * block;
-        size_t end = std::min(start + block, local_n);
-        if (start < end)
-          th.emplace_back(ConvertBitsToDouble, std::cref(bits), std::ref(local_sorted), start, end);
+        size_t end = std::min(start + block, n);
+        if (start < end) th.emplace_back(ConvertBitsToDouble, std::cref(bits), std::ref(output_), start, end);
       }
       for (auto& t : th) t.join();
     }
 
-    std::vector<int> recvcounts = sendcounts;
-    std::vector<int> recvdispls = displs;
-    if (rank == 0) {
-      output_.resize(n);
-    }
-
-    MPI_Gatherv(local_sorted.data(), static_cast<int>(local_n), MPI_DOUBLE,
-      output_.data(), recvcounts.data(), recvdispls.data(), MPI_DOUBLE, 0, MPI_COMM_WORLD);
-
-    if (rank == 0 && size > 1) {
-      std::deque<std::vector<double>> chunks;
-      for (int i = 0; i < size; ++i) {
-        size_t start = displs[i];
-        size_t count = sendcounts[i];
-        chunks.emplace_back(output_.begin() + start, output_.begin() + start + count);
-      }
-
-      std::mutex merge_mutex;
-      while (chunks.size() > 1) {
-        std::vector<std::thread> merge_threads;
-        std::deque<std::vector<double>> next;
-
-        while (chunks.size() >= 2) {
-          std::vector<double> a = std::move(chunks.front()); chunks.pop_front();
-          std::vector<double> b = std::move(chunks.front()); chunks.pop_front();
-
-          merge_threads.emplace_back([&next, &merge_mutex, a = std::move(a), b = std::move(b)]() mutable {
-            std::vector<double> merged = Merge(a, b);
-            std::lock_guard<std::mutex> lock(merge_mutex);
-            next.emplace_back(std::move(merged));
-            });
-        }
-
-        if (!chunks.empty()) {
-          next.push_back(std::move(chunks.front()));
-          chunks.pop_front();
-        }
-
-        for (auto& t : merge_threads) t.join();
-        chunks = std::move(next);
-      }
-
-      output_ = std::move(chunks.front());
-    }
-
     return true;
   }
 
-
-  bool TestTaskALL::PostProcessingImpl() {
-    if (world_.rank() == 0 && !output_.empty()) {
-      auto* out_ptr = reinterpret_cast<double*>(task_data->outputs[0]);
-      std::copy(output_.begin(), output_.end(), out_ptr);
-    }
-    return true;
+  std::vector<int> sendcounts(size), displs(size);
+  for (int i = 0; i < size; ++i) {
+    sendcounts[i] = n / size + (i < static_cast<int>(n % size) ? 1 : 0);
+    displs[i] = (i == 0) ? 0 : displs[i - 1] + sendcounts[i - 1];
   }
 
+  std::vector<double> local_input(sendcounts[rank]);
+  MPI_Scatterv(input_.data(), sendcounts.data(), displs.data(), MPI_DOUBLE,
+    local_input.data(), sendcounts[rank], MPI_DOUBLE, 0, MPI_COMM_WORLD);
+
+  size_t local_n = local_input.size();
+  std::vector<uint64_t> bits(local_n), temp(local_n);
+
+  {
+    std::vector<std::thread> th;
+    for (size_t i = 0; i < threads; ++i) {
+      size_t start = i * block;
+      size_t end = std::min(start + block, local_n);
+      if (start < end)
+        th.emplace_back(ConvertDoubleToBits, std::cref(local_input), std::ref(bits), start, end);
+    }
+    for (auto& t : th) t.join();
+  }
+
+  for (int pass = 0; pass < static_cast<int>(sizeof(uint64_t)); ++pass) {
+    RadixSortPass(bits, temp, pass * 8);
+  }
+
+  std::vector<double> local_sorted(local_n);
+  {
+    std::vector<std::thread> th;
+    for (size_t i = 0; i < threads; ++i) {
+      size_t start = i * block;
+      size_t end = std::min(start + block, local_n);
+      if (start < end)
+        th.emplace_back(ConvertBitsToDouble, std::cref(bits), std::ref(local_sorted), start, end);
+    }
+    for (auto& t : th) t.join();
+  }
+
+  std::vector<int> recvcounts = sendcounts;
+  std::vector<int> recvdispls = displs;
+  if (rank == 0) {
+    output_.resize(n);
+  }
+
+  MPI_Gatherv(local_sorted.data(), static_cast<int>(local_n), MPI_DOUBLE,
+    output_.data(), recvcounts.data(), recvdispls.data(), MPI_DOUBLE, 0, MPI_COMM_WORLD);
+
+  if (rank == 0 && size > 1) {
+    std::deque<std::vector<double>> chunks;
+    for (int i = 0; i < size; ++i) {
+      size_t start = displs[i];
+      size_t count = sendcounts[i];
+      chunks.emplace_back(output_.begin() + start, output_.begin() + start + count);
+    }
+
+    std::mutex merge_mutex;
+    while (chunks.size() > 1) {
+      std::vector<std::thread> merge_threads;
+      std::deque<std::vector<double>> next;
+
+      while (chunks.size() >= 2) {
+        std::vector<double> a = std::move(chunks.front()); chunks.pop_front();
+        std::vector<double> b = std::move(chunks.front()); chunks.pop_front();
+
+        merge_threads.emplace_back([&next, &merge_mutex, a = std::move(a), b = std::move(b)]() mutable {
+          std::vector<double> merged = Merge(a, b);
+          std::lock_guard<std::mutex> lock(merge_mutex);
+          next.emplace_back(std::move(merged));
+          });
+      }
+
+      if (!chunks.empty()) {
+        next.push_back(std::move(chunks.front()));
+        chunks.pop_front();
+      }
+
+      for (auto& t : merge_threads) t.join();
+      chunks = std::move(next);
+    }
+
+    output_ = std::move(chunks.front());
+  }
+
+  return true;
+}
+
+
+bool TestTaskALL::PostProcessingImpl() {
+  if (world_.rank() == 0 && !output_.empty()) {
+    auto* out_ptr = reinterpret_cast<double*>(task_data->outputs[0]);
+    std::copy(output_.begin(), output_.end(), out_ptr);
+  }
+  return true;
+}
 }  // namespace bessonov_e_radix_sort_simple_merging_all

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
@@ -217,8 +217,8 @@ void TestTaskALL::HandleParallelProcess() {
     output_.resize(n);
   }
 
-  MPI_Gatherv(local_sorted.data(), static_cast<int>(local_n), MPI_DOUBLE, output_.data(), sendcounts.data(), displs.data(),
-              MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Gatherv(local_sorted.data(), static_cast<int>(local_n), MPI_DOUBLE, output_.data(), sendcounts.data(), 
+              displs.data(), MPI_DOUBLE, 0, MPI_COMM_WORLD);
 
   if (rank == 0 && size > 1) {
     std::deque<std::vector<double>> chunks;

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
@@ -1,92 +1,232 @@
 #include "all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp"
 
-#include <cstddef>
+#include <algorithm>
+#include <array>
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <cmath>
+#include <mpi.h>
 #include <cstdint>
 #include <cstring>
+#include <functional>
+#include <limits>
+#include <thread>
 #include <vector>
 
-bool bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential::PreProcessingImpl() {
-  unsigned int input_size = task_data->inputs_count[0];
-  auto* in_ptr = reinterpret_cast<double*>(task_data->inputs[0]);
-  input_.assign(in_ptr, in_ptr + input_size);
 
-  unsigned int output_size = task_data->outputs_count[0];
-  output_.resize(output_size);
+#include "core/util/include/util.hpp"
 
-  return true;
-}
+namespace bessonov_e_radix_sort_simple_merging_all {
 
-bool bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential::ValidationImpl() {
-  if (task_data->inputs[0] == nullptr || task_data->outputs[0] == nullptr) {
-    return false;
+  void TestTaskALL::ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits, size_t start,
+    size_t end) {
+    for (size_t i = start; i < end; ++i) {
+      uint64_t b = 0;
+      std::memcpy(&b, &input[i], sizeof(double));
+      b ^= (-static_cast<int64_t>(b >> 63) | (1ULL << 63));
+      bits[i] = b;
+    }
   }
 
-  if (task_data->inputs_count[0] == 0) {
-    return false;
+  void TestTaskALL::ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output, size_t start,
+    size_t end) {
+    for (size_t i = start; i < end; ++i) {
+      uint64_t b = bits[i];
+      b ^= (((b >> 63) - 1) | (1ULL << 63));
+      double d = NAN;
+      std::memcpy(&d, &b, sizeof(double));
+      output[i] = d;
+    }
   }
 
-  if (task_data->inputs_count[0] != task_data->outputs_count[0]) {
-    return false;
-  }
+  void TestTaskALL::RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_t>& temp, int shift) {
+    constexpr int kRadix = 256;
+    const size_t n = bits.size();
+    std::array<size_t, kRadix> count{};
 
-  return true;
-}
-
-bool bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential::RunImpl() {
-  size_t n = input_.size();
-  std::vector<uint64_t> bits(n);
-
-  for (size_t i = 0; i < n; i++) {
-    uint64_t b = 0;
-    std::memcpy(&b, &input_[i], sizeof(double));
-    if ((b & (1ULL << 63)) != 0ULL) {
-      b = ~b;
-    } else {
-      b ^= (1ULL << 63);
+    for (size_t i = 0; i < n; ++i) {
+      count[(bits[i] >> shift) & 0xFF]++;
     }
-    bits[i] = b;
-  }
 
-  const int radix = 256;
-  const int passes = 8;
-  std::vector<uint64_t> temp(n);
+    size_t total = 0;
+    for (int i = 0; i < kRadix; ++i) {
+      size_t old_count = count[i];
+      count[i] = total;
+      total += old_count;
+    }
 
-  for (int pass = 0; pass < passes; pass++) {
-    int shift = pass * 8;
-    std::vector<size_t> count(radix, 0);
+    for (size_t i = 0; i < n; ++i) {
+      uint8_t digit = (bits[i] >> shift) & 0xFF;
+      temp[count[digit]++] = bits[i];
+    }
 
-    for (size_t i = 0; i < n; i++) {
-      int digit = static_cast<int>((bits[i] >> shift) & 0xFF);
-      count[digit]++;
-    }
-    for (int i = 1; i < radix; i++) {
-      count[i] += count[i - 1];
-    }
-    for (size_t i = n; i-- > 0;) {
-      int digit = static_cast<int>((bits[i] >> shift) & 0xFF);
-      temp[--count[digit]] = bits[i];
-    }
     bits.swap(temp);
   }
 
-  for (size_t i = 0; i < n; i++) {
-    uint64_t b = bits[i];
-    if ((b & (1ULL << 63)) != 0ULL) {
-      b ^= (1ULL << 63);
-    } else {
-      b = ~b;
+  bool TestTaskALL::PreProcessingImpl() {
+    int rank, size;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    if (rank == 0) {
+      input_.resize(task_data->inputs_count[0]);
+      auto* in_ptr = reinterpret_cast<double*>(task_data->inputs[0]);
+      std::copy(in_ptr, in_ptr + task_data->inputs_count[0], input_.begin());
     }
-    double d = 0.0;
-    std::memcpy(&d, &b, sizeof(double));
-    output_[i] = d;
+
+    size_t total_size = input_.size();
+    MPI_Bcast(&total_size, 1, MPI_UNSIGNED_LONG, 0, MPI_COMM_WORLD);
+
+    size_t local_size = total_size / size;
+    if (rank < total_size % size) {
+      local_size++;
+    }
+
+    std::vector<double> local_data(local_size);
+    std::vector<int> counts(size);
+    std::vector<int> displs(size);
+
+    if (rank == 0) {
+      for (int i = 0; i < size; ++i) {
+        counts[i] = total_size / size + (i < total_size % size ? 1 : 0);
+        displs[i] = i == 0 ? 0 : displs[i - 1] + counts[i - 1];
+      }
+    }
+
+    MPI_Scatterv(input_.data(), counts.data(), displs.data(), MPI_DOUBLE,
+      local_data.data(), local_size, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+
+    input_ = std::move(local_data);
+    output_.resize(input_.size());
+
+    return true;
   }
 
-  return true;
-}
+  bool TestTaskALL::ValidationImpl() {
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
-bool bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential::PostProcessingImpl() {
-  for (size_t i = 0; i < output_.size(); i++) {
-    reinterpret_cast<double*>(task_data->outputs[0])[i] = output_[i];
+    if (rank == 0) {
+      if (task_data->inputs.empty() || task_data->outputs.empty()) {
+        return false;
+      }
+
+      if (task_data->inputs[0] == nullptr || task_data->outputs[0] == nullptr) {
+        return false;
+      }
+
+      if (task_data->inputs_count.empty() || task_data->outputs_count.empty()) {
+        return false;
+      }
+
+      if (task_data->inputs_count[0] == 0) {
+        return false;
+      }
+
+      if (task_data->inputs_count[0] != task_data->outputs_count[0]) {
+        return false;
+      }
+
+      if (task_data->inputs_count[0] > static_cast<size_t>(std::numeric_limits<int>::max())) {
+        return false;
+      }
+    }
+
+    int valid = 1;
+    MPI_Bcast(&valid, 1, MPI_INT, 0, MPI_COMM_WORLD);
+    return valid != 0;
   }
-  return true;
-}
+
+  bool TestTaskALL::RunImpl() {
+    const size_t n = input_.size();
+    if (n == 0) {
+      return true;
+    }
+
+    std::vector<uint64_t> bits(n);
+    std::vector<uint64_t> temp(n);
+
+    size_t num_threads = ppc::util::GetPPCNumThreads();
+    num_threads = std::max<size_t>(1, num_threads);
+    const size_t block_size = (n + num_threads - 1) / num_threads;
+
+    {
+      std::vector<std::thread> threads;
+      for (size_t i = 0; i < num_threads; ++i) {
+        size_t start = i * block_size;
+        size_t end = std::min(start + block_size, n);
+        if (start >= n) {
+          break;
+        }
+        threads.emplace_back(ConvertDoubleToBits, std::cref(input_), std::ref(bits), start, end);
+      }
+      for (auto& t : threads) {
+        t.join();
+      }
+    }
+
+    constexpr int kPasses = sizeof(uint64_t);
+    for (int pass = 0; pass < kPasses; ++pass) {
+      RadixSortPass(bits, temp, pass * 8);
+    }
+
+    {
+      std::vector<std::thread> threads;
+      for (size_t i = 0; i < num_threads; ++i) {
+        size_t start = i * block_size;
+        size_t end = std::min(start + block_size, n);
+        if (start >= n) {
+          break;
+        }
+        threads.emplace_back(ConvertBitsToDouble, std::cref(bits), std::ref(output_), start, end);
+      }
+      for (auto& t : threads) {
+        t.join();
+      }
+    }
+
+    int rank, size;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    std::vector<int> counts(size);
+    std::vector<int> displs(size);
+    int local_count = static_cast<int>(output_.size());
+
+    MPI_Gather(&local_count, 1, MPI_INT, counts.data(), 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+    if (rank == 0) {
+      displs[0] = 0;
+      for (int i = 1; i < size; ++i) {
+        displs[i] = displs[i - 1] + counts[i - 1];
+      }
+    }
+
+    std::vector<double> global_result;
+    if (rank == 0) {
+      global_result.resize(task_data->outputs_count[0]);
+    }
+
+    MPI_Gatherv(output_.data(), local_count, MPI_DOUBLE,
+      global_result.data(), counts.data(), displs.data(), MPI_DOUBLE,
+      0, MPI_COMM_WORLD);
+
+    if (rank == 0) {
+      output_ = std::move(global_result);
+    }
+
+    return true;
+  }
+
+  bool TestTaskALL::PostProcessingImpl() {
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    if (rank == 0) {
+      auto* out_ptr = reinterpret_cast<double*>(task_data->outputs[0]);
+      std::ranges::copy(output_.begin(), output_.end(), out_ptr);
+    }
+
+    return true;
+  }
+}  // namespace bessonov_e_radix_sort_simple_merging_all

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
@@ -1,11 +1,12 @@
 #include "all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp"
 
+#include <mpi.h>
+
 #include <algorithm>
 #include <array>
 #include <boost/mpi/collectives.hpp>
 #include <boost/mpi/communicator.hpp>
 #include <cmath>
-#include <mpi.h>
 #include <cstdint>
 #include <cstring>
 #include <functional>
@@ -13,220 +14,219 @@
 #include <thread>
 #include <vector>
 
-
 #include "core/util/include/util.hpp"
 
 namespace bessonov_e_radix_sort_simple_merging_all {
 
-  void TestTaskALL::ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits, size_t start,
-    size_t end) {
-    for (size_t i = start; i < end; ++i) {
-      uint64_t b = 0;
-      std::memcpy(&b, &input[i], sizeof(double));
-      b ^= (-static_cast<int64_t>(b >> 63) | (1ULL << 63));
-      bits[i] = b;
+void TestTaskALL::ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits, size_t start,
+  size_t end) {
+  for (size_t i = start; i < end; ++i) {
+    uint64_t b = 0;
+    std::memcpy(&b, &input[i], sizeof(double));
+    b ^= (-static_cast<int64_t>(b >> 63) | (1ULL << 63));
+    bits[i] = b;
+  }
+}
+
+void TestTaskALL::ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output, size_t start,
+  size_t end) {
+  for (size_t i = start; i < end; ++i) {
+    uint64_t b = bits[i];
+    b ^= (((b >> 63) - 1) | (1ULL << 63));
+    double d = NAN;
+    std::memcpy(&d, &b, sizeof(double));
+    output[i] = d;
+  }
+}
+
+void TestTaskALL::RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_t>& temp, int shift) {
+  constexpr int kRadix = 256;
+  const size_t n = bits.size();
+  std::array<size_t, kRadix> count{};
+
+  for (size_t i = 0; i < n; ++i) {
+    count[(bits[i] >> shift) & 0xFF]++;
+  }
+
+  size_t total = 0;
+  for (int i = 0; i < kRadix; ++i) {
+    size_t old_count = count[i];
+    count[i] = total;
+    total += old_count;
+  }
+
+  for (size_t i = 0; i < n; ++i) {
+    uint8_t digit = (bits[i] >> shift) & 0xFF;
+    temp[count[digit]++] = bits[i];
+  }
+
+  bits.swap(temp);
+}
+
+bool TestTaskALL::PreProcessingImpl() {
+  int rank, size;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+  if (rank == 0) {
+    input_.resize(task_data->inputs_count[0]);
+    auto* in_ptr = reinterpret_cast<double*>(task_data->inputs[0]);
+    std::copy(in_ptr, in_ptr + task_data->inputs_count[0], input_.begin());
+  }
+
+  size_t total_size = input_.size();
+  MPI_Bcast(&total_size, 1, MPI_UNSIGNED_LONG, 0, MPI_COMM_WORLD);
+
+  size_t local_size = total_size / size;
+  if (rank < total_size % size) {
+    local_size++;
+  }
+
+  std::vector<double> local_data(local_size);
+  std::vector<int> counts(size);
+  std::vector<int> displs(size);
+
+  if (rank == 0) {
+    for (int i = 0; i < size; ++i) {
+      counts[i] = total_size / size + (i < total_size % size ? 1 : 0);
+      displs[i] = i == 0 ? 0 : displs[i - 1] + counts[i - 1];
     }
   }
 
-  void TestTaskALL::ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output, size_t start,
-    size_t end) {
-    for (size_t i = start; i < end; ++i) {
-      uint64_t b = bits[i];
-      b ^= (((b >> 63) - 1) | (1ULL << 63));
-      double d = NAN;
-      std::memcpy(&d, &b, sizeof(double));
-      output[i] = d;
+  MPI_Scatterv(input_.data(), counts.data(), displs.data(), MPI_DOUBLE,
+    local_data.data(), local_size, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+
+  input_ = std::move(local_data);
+  output_.resize(input_.size());
+
+  return true;
+}
+
+bool TestTaskALL::ValidationImpl() {
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  if (rank == 0) {
+    if (task_data->inputs.empty() || task_data->outputs.empty()) {
+      return false;
+    }
+
+    if (task_data->inputs[0] == nullptr || task_data->outputs[0] == nullptr) {
+      return false;
+    }
+
+    if (task_data->inputs_count.empty() || task_data->outputs_count.empty()) {
+      return false;
+    }
+
+    if (task_data->inputs_count[0] == 0) {
+      return false;
+    }
+
+    if (task_data->inputs_count[0] != task_data->outputs_count[0]) {
+      return false;
+    }
+
+    if (task_data->inputs_count[0] > static_cast<size_t>(std::numeric_limits<int>::max())) {
+      return false;
     }
   }
 
-  void TestTaskALL::RadixSortPass(std::vector<uint64_t>& bits, std::vector<uint64_t>& temp, int shift) {
-    constexpr int kRadix = 256;
-    const size_t n = bits.size();
-    std::array<size_t, kRadix> count{};
+  int valid = 1;
+  MPI_Bcast(&valid, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  return valid != 0;
+}
 
-    for (size_t i = 0; i < n; ++i) {
-      count[(bits[i] >> shift) & 0xFF]++;
-    }
-
-    size_t total = 0;
-    for (int i = 0; i < kRadix; ++i) {
-      size_t old_count = count[i];
-      count[i] = total;
-      total += old_count;
-    }
-
-    for (size_t i = 0; i < n; ++i) {
-      uint8_t digit = (bits[i] >> shift) & 0xFF;
-      temp[count[digit]++] = bits[i];
-    }
-
-    bits.swap(temp);
-  }
-
-  bool TestTaskALL::PreProcessingImpl() {
-    int rank, size;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &size);
-
-    if (rank == 0) {
-      input_.resize(task_data->inputs_count[0]);
-      auto* in_ptr = reinterpret_cast<double*>(task_data->inputs[0]);
-      std::copy(in_ptr, in_ptr + task_data->inputs_count[0], input_.begin());
-    }
-
-    size_t total_size = input_.size();
-    MPI_Bcast(&total_size, 1, MPI_UNSIGNED_LONG, 0, MPI_COMM_WORLD);
-
-    size_t local_size = total_size / size;
-    if (rank < total_size % size) {
-      local_size++;
-    }
-
-    std::vector<double> local_data(local_size);
-    std::vector<int> counts(size);
-    std::vector<int> displs(size);
-
-    if (rank == 0) {
-      for (int i = 0; i < size; ++i) {
-        counts[i] = total_size / size + (i < total_size % size ? 1 : 0);
-        displs[i] = i == 0 ? 0 : displs[i - 1] + counts[i - 1];
-      }
-    }
-
-    MPI_Scatterv(input_.data(), counts.data(), displs.data(), MPI_DOUBLE,
-      local_data.data(), local_size, MPI_DOUBLE, 0, MPI_COMM_WORLD);
-
-    input_ = std::move(local_data);
-    output_.resize(input_.size());
-
+bool TestTaskALL::RunImpl() {
+  const size_t n = input_.size();
+  if (n == 0) {
     return true;
   }
 
-  bool TestTaskALL::ValidationImpl() {
-    int rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  std::vector<uint64_t> bits(n);
+  std::vector<uint64_t> temp(n);
 
-    if (rank == 0) {
-      if (task_data->inputs.empty() || task_data->outputs.empty()) {
-        return false;
-      }
+  size_t num_threads = ppc::util::GetPPCNumThreads();
+  num_threads = std::max<size_t>(1, num_threads);
+  const size_t block_size = (n + num_threads - 1) / num_threads;
 
-      if (task_data->inputs[0] == nullptr || task_data->outputs[0] == nullptr) {
-        return false;
+  {
+    std::vector<std::thread> threads;
+    for (size_t i = 0; i < num_threads; ++i) {
+      size_t start = i * block_size;
+      size_t end = std::min(start + block_size, n);
+      if (start >= n) {
+        break;
       }
-
-      if (task_data->inputs_count.empty() || task_data->outputs_count.empty()) {
-        return false;
-      }
-
-      if (task_data->inputs_count[0] == 0) {
-        return false;
-      }
-
-      if (task_data->inputs_count[0] != task_data->outputs_count[0]) {
-        return false;
-      }
-
-      if (task_data->inputs_count[0] > static_cast<size_t>(std::numeric_limits<int>::max())) {
-        return false;
-      }
+      threads.emplace_back(ConvertDoubleToBits, std::cref(input_), std::ref(bits), start, end);
     }
-
-    int valid = 1;
-    MPI_Bcast(&valid, 1, MPI_INT, 0, MPI_COMM_WORLD);
-    return valid != 0;
+    for (auto& t : threads) {
+      t.join();
+    }
   }
 
-  bool TestTaskALL::RunImpl() {
-    const size_t n = input_.size();
-    if (n == 0) {
-      return true;
-    }
-
-    std::vector<uint64_t> bits(n);
-    std::vector<uint64_t> temp(n);
-
-    size_t num_threads = ppc::util::GetPPCNumThreads();
-    num_threads = std::max<size_t>(1, num_threads);
-    const size_t block_size = (n + num_threads - 1) / num_threads;
-
-    {
-      std::vector<std::thread> threads;
-      for (size_t i = 0; i < num_threads; ++i) {
-        size_t start = i * block_size;
-        size_t end = std::min(start + block_size, n);
-        if (start >= n) {
-          break;
-        }
-        threads.emplace_back(ConvertDoubleToBits, std::cref(input_), std::ref(bits), start, end);
-      }
-      for (auto& t : threads) {
-        t.join();
-      }
-    }
-
-    constexpr int kPasses = sizeof(uint64_t);
-    for (int pass = 0; pass < kPasses; ++pass) {
-      RadixSortPass(bits, temp, pass * 8);
-    }
-
-    {
-      std::vector<std::thread> threads;
-      for (size_t i = 0; i < num_threads; ++i) {
-        size_t start = i * block_size;
-        size_t end = std::min(start + block_size, n);
-        if (start >= n) {
-          break;
-        }
-        threads.emplace_back(ConvertBitsToDouble, std::cref(bits), std::ref(output_), start, end);
-      }
-      for (auto& t : threads) {
-        t.join();
-      }
-    }
-
-    int rank, size;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &size);
-
-    std::vector<int> counts(size);
-    std::vector<int> displs(size);
-    int local_count = static_cast<int>(output_.size());
-
-    MPI_Gather(&local_count, 1, MPI_INT, counts.data(), 1, MPI_INT, 0, MPI_COMM_WORLD);
-
-    if (rank == 0) {
-      displs[0] = 0;
-      for (int i = 1; i < size; ++i) {
-        displs[i] = displs[i - 1] + counts[i - 1];
-      }
-    }
-
-    std::vector<double> global_result;
-    if (rank == 0) {
-      global_result.resize(task_data->outputs_count[0]);
-    }
-
-    MPI_Gatherv(output_.data(), local_count, MPI_DOUBLE,
-      global_result.data(), counts.data(), displs.data(), MPI_DOUBLE,
-      0, MPI_COMM_WORLD);
-
-    if (rank == 0) {
-      output_ = std::move(global_result);
-    }
-
-    return true;
+  constexpr int kPasses = sizeof(uint64_t);
+  for (int pass = 0; pass < kPasses; ++pass) {
+    RadixSortPass(bits, temp, pass * 8);
   }
 
-  bool TestTaskALL::PostProcessingImpl() {
-    int rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-
-    if (rank == 0) {
-      auto* out_ptr = reinterpret_cast<double*>(task_data->outputs[0]);
-      std::ranges::copy(output_.begin(), output_.end(), out_ptr);
+  {
+    std::vector<std::thread> threads;
+    for (size_t i = 0; i < num_threads; ++i) {
+      size_t start = i * block_size;
+      size_t end = std::min(start + block_size, n);
+      if (start >= n) {
+        break;
+      }
+      threads.emplace_back(ConvertBitsToDouble, std::cref(bits), std::ref(output_), start, end);
     }
-
-    return true;
+    for (auto& t : threads) {
+      t.join();
+    }
   }
+
+  int rank, size;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+  std::vector<int> counts(size);
+  std::vector<int> displs(size);
+  int local_count = static_cast<int>(output_.size());
+
+  MPI_Gather(&local_count, 1, MPI_INT, counts.data(), 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+  if (rank == 0) {
+    displs[0] = 0;
+    for (int i = 1; i < size; ++i) {
+      displs[i] = displs[i - 1] + counts[i - 1];
+    }
+  }
+
+  std::vector<double> global_result;
+  if (rank == 0) {
+    global_result.resize(task_data->outputs_count[0]);
+  }
+
+  MPI_Gatherv(output_.data(), local_count, MPI_DOUBLE,
+    global_result.data(), counts.data(), displs.data(), MPI_DOUBLE,
+    0, MPI_COMM_WORLD);
+
+  if (rank == 0) {
+    output_ = std::move(global_result);
+  }
+
+  return true;
+}
+
+bool TestTaskALL::PostProcessingImpl() {
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  if (rank == 0) {
+    auto* out_ptr = reinterpret_cast<double*>(task_data->outputs[0]);
+    std::ranges::copy(output_.begin(), output_.end(), out_ptr);
+  }
+
+  return true;
+}
 }  // namespace bessonov_e_radix_sort_simple_merging_all

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
@@ -170,6 +170,8 @@ void TestTaskALL::HandleParallelProcess() {
   const int size = world_.size();
   size_t n = input_.size();
 
+  world_.barrier();
+
   std::vector<int> sendcounts(size);
   std::vector<int> displs(size);
   for (int i = 0; i < size; ++i) {
@@ -221,6 +223,8 @@ void TestTaskALL::HandleParallelProcess() {
     }
   }
 
+  world_.barrier();
+
   if (rank == 0) {
     output_.resize(n);
   }
@@ -247,6 +251,11 @@ bool TestTaskALL::PreProcessingImpl() {
 
     auto* in_ptr = reinterpret_cast<double*>(task_data->inputs[0]);
     std::copy(in_ptr, in_ptr + task_data->inputs_count[0], input_.begin());
+  }
+  size_t input_size = input_.size();
+  boost::mpi::broadcast(world_, input_size, 0);
+  if (world_.rank() != 0) {
+    input_.resize(input_size);
   }
   return true;
 }
@@ -279,6 +288,7 @@ bool TestTaskALL::RunImpl() {
   if (rank == 0) {
     n = input_.size();
   }
+  world_.barrier();
   boost::mpi::broadcast(world_, n, 0);
 
   if (n == 0) {

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
@@ -4,12 +4,17 @@
 
 #include <algorithm>
 #include <array>
+#include <boost/mpi/collectives.hpp>
 #include <cmath>
+#include <cstdint>
 #include <cstring>
 #include <deque>
+#include <functional>
 #include <limits>
 #include <mutex>
 #include <thread>
+#include <utility>
+#include <vector>
 
 #include "core/util/include/util.hpp"
 
@@ -223,8 +228,8 @@ void TestTaskALL::HandleParallelProcess() {
   if (rank == 0 && size > 1) {
     std::deque<std::vector<double>> chunks;
     for (int i = 0; i < size; ++i) {
-      size_t start = displs[i];
-      size_t count = sendcounts[i];
+      ptrdiff_t start = displs[i];
+      ptrdiff_t count = sendcounts[i];
       chunks.emplace_back(output_.begin() + start, output_.begin() + start + count);
     }
     MergeChunks(chunks);
@@ -289,7 +294,7 @@ bool TestTaskALL::RunImpl() {
 bool TestTaskALL::PostProcessingImpl() {
   if (world_.rank() == 0 && !output_.empty()) {
     auto* out_ptr = reinterpret_cast<double*>(task_data->outputs[0]);
-    std::copy(output_.begin(), output_.end(), out_ptr);
+    std::ranges::copy(output_, out_ptr);
   }
   return true;
 }

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
@@ -217,7 +217,7 @@ void TestTaskALL::HandleParallelProcess() {
     output_.resize(n);
   }
 
-  MPI_Gatherv(local_sorted.data(), static_cast<int>(local_n), MPI_DOUBLE, output_.data(), sendcounts.data(), 
+  MPI_Gatherv(local_sorted.data(), static_cast<int>(local_n), MPI_DOUBLE, output_.data(), sendcounts.data(),
               displs.data(), MPI_DOUBLE, 0, MPI_COMM_WORLD);
 
   if (rank == 0 && size > 1) {

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
@@ -1,5 +1,7 @@
 #include "all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp"
 
+#include <mpi.h>
+
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -8,14 +10,13 @@
 #include <limits>
 #include <mutex>
 #include <thread>
-#include <mpi.h>
 
 #include "core/util/include/util.hpp"
 
 namespace bessonov_e_radix_sort_simple_merging_all {
 
-void TestTaskALL::ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits,
-                                      size_t start, size_t end) {
+void TestTaskALL::ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits, size_t start,
+                                      size_t end) {
   for (size_t i = start; i < end; ++i) {
     uint64_t b = 0;
     std::memcpy(&b, &input[i], sizeof(double));
@@ -24,8 +25,8 @@ void TestTaskALL::ConvertDoubleToBits(const std::vector<double>& input, std::vec
   }
 }
 
-void TestTaskALL::ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output,
-                                      size_t start, size_t end) {
+void TestTaskALL::ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output, size_t start,
+                                      size_t end) {
   for (size_t i = start; i < end; ++i) {
     uint64_t b = bits[i];
     b ^= (((b >> 63) - 1) | (1ULL << 63));
@@ -169,8 +170,8 @@ void TestTaskALL::HandleParallelProcess() {
   }
 
   std::vector<double> local_input(sendcounts[rank]);
-  MPI_Scatterv(input_.data(), sendcounts.data(), displs.data(), MPI_DOUBLE,
-    local_input.data(), sendcounts[rank], MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Scatterv(input_.data(), sendcounts.data(), displs.data(), MPI_DOUBLE, local_input.data(), sendcounts[rank],
+               MPI_DOUBLE, 0, MPI_COMM_WORLD);
 
   size_t local_n = local_input.size();
   const size_t threads = std::max<size_t>(1, ppc::util::GetPPCNumThreads());
@@ -216,8 +217,8 @@ void TestTaskALL::HandleParallelProcess() {
     output_.resize(n);
   }
 
-  MPI_Gatherv(local_sorted.data(), static_cast<int>(local_n), MPI_DOUBLE,
-    output_.data(), sendcounts.data(), displs.data(), MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Gatherv(local_sorted.data(), static_cast<int>(local_n), MPI_DOUBLE, output_.data(), sendcounts.data(), displs.data(),
+              MPI_DOUBLE, 0, MPI_COMM_WORLD);
 
   if (rank == 0 && size > 1) {
     std::deque<std::vector<double>> chunks;
@@ -251,8 +252,7 @@ bool TestTaskALL::ValidationImpl() {
 
     if (task_data->inputs_count.empty() || task_data->outputs_count.empty()) {
       local_valid = false;
-    }
-    else {
+    } else {
       local_valid &= task_data->inputs_count[0] > 0;
       local_valid &= task_data->inputs_count[0] == task_data->outputs_count[0];
       local_valid &= task_data->inputs_count[0] <= static_cast<size_t>(std::numeric_limits<int>::max());
@@ -279,8 +279,7 @@ bool TestTaskALL::RunImpl() {
 
   if (size == 1) {
     HandleSingleProcess();
-  }
-  else {
+  } else {
     HandleParallelProcess();
   }
 

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <array>
 #include <boost/mpi/collectives.hpp>
+#include <boost/mpi/collectives/broadcast.hpp>
 #include <boost/mpi/communicator.hpp>
 #include <cmath>
 #include <cstddef>

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
@@ -1,0 +1,92 @@
+#include "all/bessonov_e_radix_sort_simple_merging/include/ops_all.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+bool bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential::PreProcessingImpl() {
+  unsigned int input_size = task_data->inputs_count[0];
+  auto* in_ptr = reinterpret_cast<double*>(task_data->inputs[0]);
+  input_.assign(in_ptr, in_ptr + input_size);
+
+  unsigned int output_size = task_data->outputs_count[0];
+  output_.resize(output_size);
+
+  return true;
+}
+
+bool bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential::ValidationImpl() {
+  if (task_data->inputs[0] == nullptr || task_data->outputs[0] == nullptr) {
+    return false;
+  }
+
+  if (task_data->inputs_count[0] == 0) {
+    return false;
+  }
+
+  if (task_data->inputs_count[0] != task_data->outputs_count[0]) {
+    return false;
+  }
+
+  return true;
+}
+
+bool bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential::RunImpl() {
+  size_t n = input_.size();
+  std::vector<uint64_t> bits(n);
+
+  for (size_t i = 0; i < n; i++) {
+    uint64_t b = 0;
+    std::memcpy(&b, &input_[i], sizeof(double));
+    if ((b & (1ULL << 63)) != 0ULL) {
+      b = ~b;
+    } else {
+      b ^= (1ULL << 63);
+    }
+    bits[i] = b;
+  }
+
+  const int radix = 256;
+  const int passes = 8;
+  std::vector<uint64_t> temp(n);
+
+  for (int pass = 0; pass < passes; pass++) {
+    int shift = pass * 8;
+    std::vector<size_t> count(radix, 0);
+
+    for (size_t i = 0; i < n; i++) {
+      int digit = static_cast<int>((bits[i] >> shift) & 0xFF);
+      count[digit]++;
+    }
+    for (int i = 1; i < radix; i++) {
+      count[i] += count[i - 1];
+    }
+    for (size_t i = n; i-- > 0;) {
+      int digit = static_cast<int>((bits[i] >> shift) & 0xFF);
+      temp[--count[digit]] = bits[i];
+    }
+    bits.swap(temp);
+  }
+
+  for (size_t i = 0; i < n; i++) {
+    uint64_t b = bits[i];
+    if ((b & (1ULL << 63)) != 0ULL) {
+      b ^= (1ULL << 63);
+    } else {
+      b = ~b;
+    }
+    double d = 0.0;
+    std::memcpy(&d, &b, sizeof(double));
+    output_[i] = d;
+  }
+
+  return true;
+}
+
+bool bessonov_e_radix_sort_simple_merging_seq::TestTaskSequential::PostProcessingImpl() {
+  for (size_t i = 0; i < output_.size(); i++) {
+    reinterpret_cast<double*>(task_data->outputs[0])[i] = output_[i];
+  }
+  return true;
+}

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
@@ -5,7 +5,9 @@
 #include <algorithm>
 #include <array>
 #include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <deque>

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
@@ -78,7 +78,7 @@ bool TestTaskALL::PreProcessingImpl() {
   MPI_Bcast(&total_size, 1, MPI_UNSIGNED_LONG, 0, MPI_COMM_WORLD);
 
   size_t local_size = total_size / size;
-  if (rank < total_size % size) {
+  if (rank < static_cast<int>(total_size % size)) {
     local_size++;
   }
 
@@ -88,7 +88,7 @@ bool TestTaskALL::PreProcessingImpl() {
 
   if (rank == 0) {
     for (int i = 0; i < size; ++i) {
-      counts[i] = total_size / size + (i < total_size % size ? 1 : 0);
+      counts[i] = total_size / size + (i < static_cast<int>(total_size % size) ? 1 : 0);
       displs[i] = i == 0 ? 0 : displs[i - 1] + counts[i - 1];
     }
   }

--- a/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
+++ b/tasks/all/bessonov_e_radix_sort_simple_merging/src/ops_all.cpp
@@ -19,7 +19,7 @@
 namespace bessonov_e_radix_sort_simple_merging_all {
 
 void TestTaskALL::ConvertDoubleToBits(const std::vector<double>& input, std::vector<uint64_t>& bits, size_t start,
-  size_t end) {
+                                      size_t end) {
   for (size_t i = start; i < end; ++i) {
     uint64_t b = 0;
     std::memcpy(&b, &input[i], sizeof(double));
@@ -29,7 +29,7 @@ void TestTaskALL::ConvertDoubleToBits(const std::vector<double>& input, std::vec
 }
 
 void TestTaskALL::ConvertBitsToDouble(const std::vector<uint64_t>& bits, std::vector<double>& output, size_t start,
-  size_t end) {
+                                      size_t end) {
   for (size_t i = start; i < end; ++i) {
     uint64_t b = bits[i];
     b ^= (((b >> 63) - 1) | (1ULL << 63));
@@ -93,8 +93,8 @@ bool TestTaskALL::PreProcessingImpl() {
     }
   }
 
-  MPI_Scatterv(input_.data(), counts.data(), displs.data(), MPI_DOUBLE,
-    local_data.data(), local_size, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Scatterv(input_.data(), counts.data(), displs.data(), MPI_DOUBLE, local_data.data(), local_size, MPI_DOUBLE, 0,
+               MPI_COMM_WORLD);
 
   input_ = std::move(local_data);
   output_.resize(input_.size());
@@ -207,9 +207,8 @@ bool TestTaskALL::RunImpl() {
     global_result.resize(task_data->outputs_count[0]);
   }
 
-  MPI_Gatherv(output_.data(), local_count, MPI_DOUBLE,
-    global_result.data(), counts.data(), displs.data(), MPI_DOUBLE,
-    0, MPI_COMM_WORLD);
+  MPI_Gatherv(output_.data(), local_count, MPI_DOUBLE, global_result.data(), counts.data(), displs.data(), MPI_DOUBLE,
+              0, MPI_COMM_WORLD);
 
   if (rank == 0) {
     output_ = std::move(global_result);


### PR DESCRIPTION
1. MPI делит массив double чисел между процессами.
2. Каждый процесс сортирует свою часть с помощью поразрядной сортировки (radix sort):
- Значения double преобразуются в uint64_t с учетом порядка байтов.
- Затем сортируются по байтам (8 проходов по 8 бит).
3. Каждая часть снова преобразуется в double.
4. MPI собирает отсортированные куски в rank 0.
5. На rank 0 происходит многопоточное слияние (merge) всех отсортированных блоков.