### PR TITLE
Борисов Сергей. Задача 1. Вариант 3. Технология MPI+STL. Умножение плотных матриц. Элементы типа double. Алгоритм Штрассена.

### DIFF
--- a/tasks/all/borisov_s_strassen/func_tests/main.cpp
+++ b/tasks/all/borisov_s_strassen/func_tests/main.cpp
@@ -164,7 +164,7 @@ TEST(borisov_s_strassen_all, Square5x5_Random) {
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), b.begin(), b.end());
 
-  std::size_t output_count = 2 + n * n;
+  std::size_t output_count = 2 + (n * n);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -212,7 +212,7 @@ TEST(borisov_s_strassen_all, Square20x20_Random) {
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), b.begin(), b.end());
 
-  std::size_t output_count = 2 + n * n;
+  std::size_t output_count = 2 + (n * n);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -260,7 +260,7 @@ TEST(borisov_s_strassen_all, Square32x32_Random) {
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), b.begin(), b.end());
 
-  std::size_t output_count = 2 + n * n;
+  std::size_t output_count = 2 + (n * n);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -308,7 +308,7 @@ TEST(borisov_s_strassen_all, Square128x128_Random) {
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), b.begin(), b.end());
 
-  std::size_t output_count = 2 + n * n;
+  std::size_t output_count = 2 + (n * n);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -349,14 +349,16 @@ TEST(borisov_s_strassen_all, Square128x128_IdentityMatrix) {
   std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
 
   std::vector<double> e(n * n, 0.0);
-  for (int i = 0; i < n; ++i) e[(i * n) + i] = 1.0;
+  for (int i = 0; i < n; ++i) {
+    e[(i * n) + i] = 1.0;
+  }
 
   std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
                                  static_cast<double>(n)};
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), e.begin(), e.end());
 
-  std::size_t output_count = 2 + n * n;
+  std::size_t output_count = 2 + (n * n);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -404,7 +406,7 @@ TEST(borisov_s_strassen_all, Square129x129_Random) {
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), b.begin(), b.end());
 
-  std::size_t output_count = 2 + n * n;
+  std::size_t output_count = 2 + (n * n);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -452,7 +454,7 @@ TEST(borisov_s_strassen_all, Square240x240_Random) {
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), b.begin(), b.end());
 
-  std::size_t output_count = 2 + n * n;
+  std::size_t output_count = 2 + (n * n);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -500,7 +502,7 @@ TEST(borisov_s_strassen_all, Square512x512_Random) {
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), b.begin(), b.end());
 
-  std::size_t output_count = 2 + n * n;
+  std::size_t output_count = 2 + (n * n);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -548,7 +550,7 @@ TEST(borisov_s_strassen_all, Square600x600_Random) {
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), b.begin(), b.end());
 
-  std::size_t output_count = 2 + n * n;
+  std::size_t output_count = 2 + (n * n);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -638,7 +640,9 @@ TEST(borisov_s_strassen_all, NotEnoughDataCase) {
 
 TEST(borisov_s_strassen_all, Rectangular16x17_Random) {
   boost::mpi::communicator world;
-  const int rows_a = 16, cols_a = 17, cols_b = 18;
+  const int rows_a = 16;
+  const int cols_a = 17;
+  const int cols_b = 18;
   std::vector<double> a = GenerateRandomMatrix(rows_a, cols_a, 7777);
   std::vector<double> b = GenerateRandomMatrix(cols_a, cols_b, 7777);
 
@@ -649,7 +653,7 @@ TEST(borisov_s_strassen_all, Rectangular16x17_Random) {
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), b.begin(), b.end());
 
-  std::size_t output_count = 2 + rows_a * cols_b;
+  std::size_t output_count = 2 + (rows_a * cols_b);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -699,7 +703,7 @@ TEST(borisov_s_strassen_all, Rectangular19x23_Random) {
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), b.begin(), b.end());
 
-  std::size_t output_count = 2 + rows_a * cols_b;
+  std::size_t output_count = 2 + (rows_a * cols_b);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
@@ -749,7 +753,7 @@ TEST(borisov_s_strassen_all, Rectangular32x64_Random) {
   in_data.insert(in_data.end(), a.begin(), a.end());
   in_data.insert(in_data.end(), b.begin(), b.end());
 
-  std::size_t output_count = 2 + rows_a * cols_b;
+  std::size_t output_count = 2 + (rows_a * cols_b);
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
   task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));

--- a/tasks/all/borisov_s_strassen/func_tests/main.cpp
+++ b/tasks/all/borisov_s_strassen/func_tests/main.cpp
@@ -1,0 +1,785 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "all/borisov_s_strassen/include/ops_all.hpp"
+#include "core/task/include/task.hpp"
+
+namespace {
+
+std::vector<double> MultiplyNaiveDouble(const std::vector<double>& a, const std::vector<double>& b, int rows_a,
+                                        int cols_a, int cols_b) {
+  std::vector<double> c(rows_a * cols_b, 0.0);
+  for (int i = 0; i < rows_a; ++i) {
+    for (int j = 0; j < cols_b; ++j) {
+      double sum = 0.0;
+      for (int k = 0; k < cols_a; ++k) {
+        sum += a[(i * cols_a) + k] * b[(k * cols_b) + j];
+      }
+      c[(i * cols_b) + j] = sum;
+    }
+  }
+  return c;
+}
+
+std::vector<double> GenerateRandomMatrix(int rows, int cols, int seed, double min_val = -50.0, double max_val = 50.0) {
+  std::mt19937 rng(seed);
+  std::uniform_real_distribution<double> dist(min_val, max_val);
+  std::vector<double> matrix(rows * cols);
+  for (double& x : matrix) {
+    x = dist(rng);
+  }
+  return matrix;
+}
+
+}  // namespace
+
+TEST(borisov_s_strassen_all, OneByOne) {
+  std::vector<double> in_data = {1.0, 1.0, 1.0, 1.0, 7.5, 2.5};
+  std::size_t output_count = 3;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_all::ParallelStrassenMpiStl task(task_data);
+
+  task.PreProcessingImpl();
+  ASSERT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  boost::mpi::communicator world;
+  if (world.rank() == 0) {
+    EXPECT_DOUBLE_EQ(out_ptr[0], 1.0);
+    EXPECT_DOUBLE_EQ(out_ptr[1], 1.0);
+    EXPECT_DOUBLE_EQ(out_ptr[2], 18.75);
+    delete[] out_ptr;
+  }
+}
+
+TEST(borisov_s_strassen_all, TwoByTwo) {
+  boost::mpi::communicator world;
+  std::vector<double> a = {1.0, 2.5, 3.0, 4.0};
+  std::vector<double> b = {1.5, 2.0, 0.5, 3.5};
+  std::vector<double> c_expected = {2.75, 10.75, 6.5, 20.0};
+
+  std::vector<double> in_data = {2.0, 2.0, 2.0, 2.0};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + 4;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_all::ParallelStrassenMpiStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    EXPECT_DOUBLE_EQ(out_ptr[0], 2.0);
+    EXPECT_DOUBLE_EQ(out_ptr[1], 2.0);
+    for (int i = 0; i < 4; ++i) {
+      EXPECT_NEAR(out_ptr[2 + i], c_expected[i], 1e-9);
+    }
+
+    delete[] out_ptr;
+  }
+}
+
+TEST(borisov_s_strassen_all, Rectangular2x3_3x4) {
+  boost::mpi::communicator world;
+  std::vector<double> a = {1.0, 2.5, 3.0, 4.0, 5.5, 6.0};
+  std::vector<double> b = {0.5, 1.0, 2.0, 1.5, 2.0, 0.5, 1.0, 3.0, 4.0, 2.5, 0.5, 1.0};
+
+  auto c_expected = MultiplyNaiveDouble(a, b, 2, 3, 4);
+
+  std::vector<double> in_data = {2.0, 3.0, 3.0, 4.0};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + 8;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_all::ParallelStrassenMpiStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    EXPECT_DOUBLE_EQ(out_ptr[0], 2.0);
+    EXPECT_DOUBLE_EQ(out_ptr[1], 4.0);
+
+    std::vector<double> c_result(8);
+    for (int i = 0; i < 8; ++i) {
+      c_result[i] = out_ptr[2 + i];
+    }
+
+    ASSERT_EQ(c_expected.size(), c_result.size());
+    for (std::size_t i = 0; i < c_expected.size(); ++i) {
+      EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+    }
+
+    delete[] out_ptr;
+  }
+}
+
+TEST(borisov_s_strassen_all, Square5x5_Random) {
+  boost::mpi::communicator world;
+  const int n = 5;
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + n * n;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_all::ParallelStrassenMpiStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+    EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+    std::vector<double> c_result(n * n);
+    for (int i = 0; i < n * n; ++i) {
+      c_result[i] = out_ptr[2 + i];
+    }
+
+    ASSERT_EQ(c_expected.size(), c_result.size());
+    for (std::size_t i = 0; i < c_expected.size(); ++i) {
+      EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+    }
+
+    delete[] out_ptr;
+  }
+}
+
+TEST(borisov_s_strassen_all, Square20x20_Random) {
+  boost::mpi::communicator world;
+  const int n = 20;
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + n * n;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_all::ParallelStrassenMpiStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+    EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+    std::vector<double> c_result(n * n);
+    for (int i = 0; i < n * n; ++i) {
+      c_result[i] = out_ptr[2 + i];
+    }
+
+    ASSERT_EQ(c_expected.size(), c_result.size());
+    for (std::size_t i = 0; i < c_expected.size(); ++i) {
+      EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+    }
+
+    delete[] out_ptr;
+  }
+}
+
+TEST(borisov_s_strassen_all, Square32x32_Random) {
+  boost::mpi::communicator world;
+  const int n = 32;
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + n * n;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_all::ParallelStrassenMpiStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+    EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+    std::vector<double> c_result(n * n);
+    for (int i = 0; i < n * n; ++i) {
+      c_result[i] = out_ptr[2 + i];
+    }
+
+    ASSERT_EQ(c_expected.size(), c_result.size());
+    for (std::size_t i = 0; i < c_expected.size(); ++i) {
+      EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+    }
+
+    delete[] out_ptr;
+  }
+}
+
+TEST(borisov_s_strassen_all, Square128x128_Random) {
+  boost::mpi::communicator world;
+  const int n = 128;
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + n * n;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_all::ParallelStrassenMpiStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+    EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+    std::vector<double> c_result(n * n);
+    for (int i = 0; i < n * n; ++i) {
+      c_result[i] = out_ptr[2 + i];
+    }
+
+    ASSERT_EQ(c_expected.size(), c_result.size());
+    for (std::size_t i = 0; i < c_expected.size(); ++i) {
+      EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+    }
+
+    delete[] out_ptr;
+  }
+}
+
+TEST(borisov_s_strassen_all, Square128x128_IdentityMatrix) {
+  boost::mpi::communicator world;
+  const int n = 128;
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+
+  std::vector<double> e(n * n, 0.0);
+  for (int i = 0; i < n; ++i) e[(i * n) + i] = 1.0;
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), e.begin(), e.end());
+
+  std::size_t output_count = 2 + n * n;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_all::ParallelStrassenMpiStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+    EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+    std::vector<double> c_result(n * n);
+    for (int i = 0; i < n * n; ++i) {
+      c_result[i] = out_ptr[2 + i];
+    }
+
+    ASSERT_EQ(a.size(), c_result.size());
+    for (std::size_t i = 0; i < a.size(); ++i) {
+      EXPECT_NEAR(a[i], c_result[i], 1e-9);
+    }
+
+    delete[] out_ptr;
+  }
+}
+
+TEST(borisov_s_strassen_all, Square129x129_Random) {
+  boost::mpi::communicator world;
+  const int n = 129;
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + n * n;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_all::ParallelStrassenMpiStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+    EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+    std::vector<double> c_result(n * n);
+    for (int i = 0; i < n * n; ++i) {
+      c_result[i] = out_ptr[2 + i];
+    }
+
+    ASSERT_EQ(c_expected.size(), c_result.size());
+    for (std::size_t i = 0; i < c_expected.size(); ++i) {
+      EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+    }
+
+    delete[] out_ptr;
+  }
+}
+
+TEST(borisov_s_strassen_all, Square240x240_Random) {
+  boost::mpi::communicator world;
+  const int n = 240;
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + n * n;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_all::ParallelStrassenMpiStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+    EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+    std::vector<double> c_result(n * n);
+    for (int i = 0; i < n * n; ++i) {
+      c_result[i] = out_ptr[2 + i];
+    }
+
+    ASSERT_EQ(c_expected.size(), c_result.size());
+    for (std::size_t i = 0; i < c_expected.size(); ++i) {
+      EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+    }
+
+    delete[] out_ptr;
+  }
+}
+
+TEST(borisov_s_strassen_all, Square512x512_Random) {
+  boost::mpi::communicator world;
+  const int n = 512;
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + n * n;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_all::ParallelStrassenMpiStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+    EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+    std::vector<double> c_result(n * n);
+    for (int i = 0; i < n * n; ++i) {
+      c_result[i] = out_ptr[2 + i];
+    }
+
+    ASSERT_EQ(c_expected.size(), c_result.size());
+    for (std::size_t i = 0; i < c_expected.size(); ++i) {
+      EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+    }
+
+    delete[] out_ptr;
+  }
+}
+
+TEST(borisov_s_strassen_all, Square600x600_Random) {
+  boost::mpi::communicator world;
+  const int n = 600;
+  std::vector<double> a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> b = GenerateRandomMatrix(n, n, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in_data = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                                 static_cast<double>(n)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + n * n;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_all::ParallelStrassenMpiStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(n));
+    EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(n));
+
+    std::vector<double> c_result(n * n);
+    for (int i = 0; i < n * n; ++i) {
+      c_result[i] = out_ptr[2 + i];
+    }
+
+    ASSERT_EQ(c_expected.size(), c_result.size());
+    for (std::size_t i = 0; i < c_expected.size(); ++i) {
+      EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+    }
+
+    delete[] out_ptr;
+  }
+}
+
+TEST(borisov_s_strassen_all, ValidCase) {
+  boost::mpi::communicator world;
+  std::vector<double> input_data = {2.0, 3.0, 3.0, 2.0};
+  input_data.insert(input_data.end(), {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
+  input_data.insert(input_data.end(), {7.0, 8.0, 9.0, 10.0, 11.0, 12.0});
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(input_data.data()));
+  task_data->inputs_count.push_back(input_data.size());
+  task_data->outputs.push_back(nullptr);
+  task_data->outputs_count.push_back(0);
+
+  borisov_s_strassen_all::ParallelStrassenMpiStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+}
+
+TEST(borisov_s_strassen_all, MismatchCase) {
+  boost::mpi::communicator world;
+  std::vector<double> input_data = {2.0, 2.0, 3.0, 3.0};
+  input_data.insert(input_data.end(), {1.0, 2.0, 3.0, 4.0});
+  input_data.insert(input_data.end(), {5.0, 6.0, 7.0, 8.0, 9.0});
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(input_data.data()));
+  task_data->inputs_count.push_back(input_data.size());
+  task_data->outputs.push_back(nullptr);
+  task_data->outputs_count.push_back(0);
+
+  borisov_s_strassen_all::ParallelStrassenMpiStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_FALSE(task.ValidationImpl());
+}
+
+TEST(borisov_s_strassen_all, NotEnoughDataCase) {
+  boost::mpi::communicator world;
+  std::vector<double> input_data = {2.0, 2.0, 2.0, 2.0};
+  input_data.insert(input_data.end(), {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(input_data.data()));
+  task_data->inputs_count.push_back(input_data.size());
+  task_data->outputs.push_back(nullptr);
+  task_data->outputs_count.push_back(0);
+
+  borisov_s_strassen_all::ParallelStrassenMpiStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_FALSE(task.ValidationImpl());
+}
+
+TEST(borisov_s_strassen_all, Rectangular16x17_Random) {
+  boost::mpi::communicator world;
+  const int rows_a = 16, cols_a = 17, cols_b = 18;
+  std::vector<double> a = GenerateRandomMatrix(rows_a, cols_a, 7777);
+  std::vector<double> b = GenerateRandomMatrix(cols_a, cols_b, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, rows_a, cols_a, cols_b);
+
+  std::vector<double> in_data = {static_cast<double>(rows_a), static_cast<double>(cols_a), static_cast<double>(cols_a),
+                                 static_cast<double>(cols_b)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + rows_a * cols_b;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_all::ParallelStrassenMpiStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(rows_a));
+    EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(cols_b));
+
+    std::vector<double> c_result(rows_a * cols_b);
+    for (int i = 0; i < rows_a * cols_b; ++i) {
+      c_result[i] = out_ptr[2 + i];
+    }
+
+    ASSERT_EQ(c_expected.size(), c_result.size());
+    for (std::size_t i = 0; i < c_expected.size(); ++i) {
+      EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+    }
+
+    delete[] out_ptr;
+  }
+}
+
+TEST(borisov_s_strassen_all, Rectangular19x23_Random) {
+  boost::mpi::communicator world;
+  const int rows_a = 19;
+  const int cols_a = 23;
+  const int cols_b = 21;
+  std::vector<double> a = GenerateRandomMatrix(rows_a, cols_a, 7777);
+  std::vector<double> b = GenerateRandomMatrix(cols_a, cols_b, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, rows_a, cols_a, cols_b);
+
+  std::vector<double> in_data = {static_cast<double>(rows_a), static_cast<double>(cols_a), static_cast<double>(cols_a),
+                                 static_cast<double>(cols_b)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + rows_a * cols_b;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_all::ParallelStrassenMpiStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(rows_a));
+    EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(cols_b));
+
+    std::vector<double> c_result(rows_a * cols_b);
+    for (int i = 0; i < rows_a * cols_b; ++i) {
+      c_result[i] = out_ptr[2 + i];
+    }
+
+    ASSERT_EQ(c_expected.size(), c_result.size());
+    for (std::size_t i = 0; i < c_expected.size(); ++i) {
+      EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+    }
+
+    delete[] out_ptr;
+  }
+}
+
+TEST(borisov_s_strassen_all, Rectangular32x64_Random) {
+  boost::mpi::communicator world;
+  const int rows_a = 32;
+  const int cols_a = 64;
+  const int cols_b = 32;
+  std::vector<double> a = GenerateRandomMatrix(rows_a, cols_a, 7777);
+  std::vector<double> b = GenerateRandomMatrix(cols_a, cols_b, 7777);
+
+  auto c_expected = MultiplyNaiveDouble(a, b, rows_a, cols_a, cols_b);
+
+  std::vector<double> in_data = {static_cast<double>(rows_a), static_cast<double>(cols_a), static_cast<double>(cols_a),
+                                 static_cast<double>(cols_b)};
+  in_data.insert(in_data.end(), a.begin(), a.end());
+  in_data.insert(in_data.end(), b.begin(), b.end());
+
+  std::size_t output_count = 2 + rows_a * cols_b;
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_data.data()));
+  task_data->inputs_count.push_back(in_data.size());
+
+  auto* out_ptr = new double[output_count]();
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_ptr));
+  task_data->outputs_count.push_back(output_count);
+
+  borisov_s_strassen_all::ParallelStrassenMpiStl task(task_data);
+
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  if (world.rank() == 0) {
+    EXPECT_DOUBLE_EQ(out_ptr[0], static_cast<double>(rows_a));
+    EXPECT_DOUBLE_EQ(out_ptr[1], static_cast<double>(cols_b));
+
+    std::vector<double> c_result(rows_a * cols_b);
+    for (int i = 0; i < rows_a * cols_b; ++i) {
+      c_result[i] = out_ptr[2 + i];
+    }
+
+    ASSERT_EQ(c_expected.size(), c_result.size());
+    for (std::size_t i = 0; i < c_expected.size(); ++i) {
+      EXPECT_NEAR(c_expected[i], c_result[i], 1e-9);
+    }
+
+    delete[] out_ptr;
+  }
+}

--- a/tasks/all/borisov_s_strassen/func_tests/main.cpp
+++ b/tasks/all/borisov_s_strassen/func_tests/main.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "all/borisov_s_strassen/include/ops_all.hpp"
+#include "boost/mpi/communicator.hpp"
 #include "core/task/include/task.hpp"
 
 namespace {

--- a/tasks/all/borisov_s_strassen/include/ops_all.hpp
+++ b/tasks/all/borisov_s_strassen/include/ops_all.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "boost/mpi/communicator.hpp"
+#include "core/task/include/task.hpp"
+
+namespace borisov_s_strassen_all {
+
+class ParallelStrassenMpiStl : public ppc::core::Task {
+ public:
+  explicit ParallelStrassenMpiStl(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<double> input_;
+  std::vector<double> a_pad_, b_pad_;
+  std::vector<double> output_;
+
+  int rowsA_ = 0;
+  int colsA_ = 0;
+  int rowsB_ = 0;
+  int colsB_ = 0;
+  int m_ = 0;
+
+  boost::mpi::communicator world_;
+};
+
+}  // namespace borisov_s_strassen_all

--- a/tasks/all/borisov_s_strassen/include/ops_all.hpp
+++ b/tasks/all/borisov_s_strassen/include/ops_all.hpp
@@ -3,7 +3,6 @@
 #include <utility>
 #include <vector>
 
-#include "boost/mpi/communicator.hpp"
 #include "core/task/include/task.hpp"
 
 namespace borisov_s_strassen_all {

--- a/tasks/all/borisov_s_strassen/include/ops_all.hpp
+++ b/tasks/all/borisov_s_strassen/include/ops_all.hpp
@@ -3,6 +3,7 @@
 #include <utility>
 #include <vector>
 
+#include "boost/mpi/communicator.hpp"
 #include "core/task/include/task.hpp"
 
 namespace borisov_s_strassen_all {

--- a/tasks/all/borisov_s_strassen/perf_tests/main.cpp
+++ b/tasks/all/borisov_s_strassen/perf_tests/main.cpp
@@ -1,0 +1,140 @@
+#include <gtest/gtest.h>
+
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "all/borisov_s_strassen/include/ops_all.hpp"
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+
+namespace {
+
+std::vector<double> MultiplyNaive(const std::vector<double>& a, const std::vector<double>& b, int rows_a,
+                                        int cols_a, int cols_b) {
+  std::vector<double> c(rows_a * cols_b, 0.0);
+  for (int i = 0; i < rows_a; ++i) {
+    for (int j = 0; j < cols_b; ++j) {
+      double sum = 0.0;
+      for (int k = 0; k < cols_a; ++k) {
+        sum += a[(i * cols_a) + k] * b[(k * cols_b) + j];
+      }
+      c[(i * cols_b) + j] = sum;
+    }
+  }
+  return c;
+}
+
+void GenerateRandomMatrix(int rows, int cols, std::vector<double>& matrix) {
+  std::random_device rd;
+  std::mt19937 rng(rd());
+  std::uniform_real_distribution<double> dist(-50.0, 50.0);
+  matrix.resize(rows * cols);
+  for (auto& value : matrix) {
+    value = dist(rng);
+  }
+}
+
+}  // namespace
+
+TEST(borisov_s_strassen_mpi_perf, pipeline_run) {
+  boost::mpi::communicator world;
+
+  constexpr int kRowsA = 512, kColsA = 512;
+  constexpr int kRowsB = 512, kColsB = 512;
+
+  std::vector<double> A, B, in_buf, out_buf;
+  if (world.rank() == 0) {
+    GenerateRandomMatrix(kRowsA, kColsA, A);
+    GenerateRandomMatrix(kRowsB, kColsB, B);
+    in_buf = {static_cast<double>(kRowsA), static_cast<double>(kColsA), static_cast<double>(kRowsB),
+              static_cast<double>(kColsB)};
+    in_buf.insert(in_buf.end(), A.begin(), A.end());
+    in_buf.insert(in_buf.end(), B.begin(), B.end());
+    out_buf.assign(2 + kRowsA * kColsB, 0.0);
+  }
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_buf.data()));
+    task_data->inputs_count.push_back(in_buf.size());
+    task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_buf.data()));
+    task_data->outputs_count.push_back(out_buf.size());
+  }
+
+  auto task = std::make_shared<borisov_s_strassen_all::ParallelStrassenMpiStl>(task_data);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 5;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto now = std::chrono::high_resolution_clock::now();
+    return std::chrono::duration<double>(now - t0).count();
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf = std::make_shared<ppc::core::Perf>(task);
+
+  perf->PipelineRun(perf_attr, perf_results);
+  if (world.rank() == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
+    auto expected = MultiplyNaive(A, B, kRowsA, kColsA, kColsB);
+    std::vector<double> got(out_buf.begin() + 2, out_buf.end());
+    ASSERT_EQ(expected.size(), got.size());
+    for (size_t i = 0; i < expected.size(); ++i) ASSERT_NEAR(expected[i], got[i], 1e-8);
+  }
+}
+
+TEST(borisov_s_strassen_mpi_perf, task_run) {
+  boost::mpi::communicator world;
+
+  constexpr int kRowsA = 512, kColsA = 512;
+  constexpr int kRowsB = 512, kColsB = 512;
+
+  std::vector<double> A, B, in_buf, out_buf;
+  if (world.rank() == 0) {
+    GenerateRandomMatrix(kRowsA, kColsA, A);
+    GenerateRandomMatrix(kRowsB, kColsB, B);
+    in_buf = {static_cast<double>(kRowsA), static_cast<double>(kColsA), static_cast<double>(kRowsB),
+              static_cast<double>(kColsB)};
+    in_buf.insert(in_buf.end(), A.begin(), A.end());
+    in_buf.insert(in_buf.end(), B.begin(), B.end());
+    out_buf.assign(2 + kRowsA * kColsB, 0.0);
+  }
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_buf.data()));
+    task_data->inputs_count.push_back(in_buf.size());
+    task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_buf.data()));
+    task_data->outputs_count.push_back(out_buf.size());
+  }
+
+  auto task = std::make_shared<borisov_s_strassen_all::ParallelStrassenMpiStl>(task_data);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 5;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto now = std::chrono::high_resolution_clock::now();
+    return std::chrono::duration<double>(now - t0).count();
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf = std::make_shared<ppc::core::Perf>(task);
+
+
+  perf->TaskRun(perf_attr, perf_results);
+  if (world.rank() == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
+    auto expected = MultiplyNaive(A, B, kRowsA, kColsA, kColsB);
+    std::vector<double> got(out_buf.begin() + 2, out_buf.end());
+    ASSERT_EQ(expected.size(), got.size());
+    for (size_t i = 0; i < expected.size(); ++i) ASSERT_NEAR(expected[i], got[i], 1e-8);
+  }
+}

--- a/tasks/all/borisov_s_strassen/perf_tests/main.cpp
+++ b/tasks/all/borisov_s_strassen/perf_tests/main.cpp
@@ -42,7 +42,7 @@ namespace test_utils {
 
 constexpr double kTol = 1e-9;
 
-inline bool IsMaster() {
+bool IsMaster() {
   static boost::mpi::communicator world;
   return world.rank() == 0;
 }

--- a/tasks/all/borisov_s_strassen/perf_tests/main.cpp
+++ b/tasks/all/borisov_s_strassen/perf_tests/main.cpp
@@ -41,7 +41,7 @@ void GenerateRandomMatrix(int rows, int cols, std::vector<double>& matrix) {
 
 }  // namespace
 
-TEST(borisov_s_strassen_mpi_perf, pipeline_run) {
+TEST(borisov_s_strassen_all, test_pipeline_run) {
   boost::mpi::communicator world;
 
   constexpr int kRowsA = 512;
@@ -96,7 +96,7 @@ TEST(borisov_s_strassen_mpi_perf, pipeline_run) {
   }
 }
 
-TEST(borisov_s_strassen_mpi_perf, task_run) {
+TEST(borisov_s_strassen_all, test_task_run) {
   boost::mpi::communicator world;
 
   constexpr int kRowsA = 512;

--- a/tasks/all/borisov_s_strassen/perf_tests/main.cpp
+++ b/tasks/all/borisov_s_strassen/perf_tests/main.cpp
@@ -128,7 +128,6 @@ TEST(borisov_s_strassen_mpi_perf, task_run) {
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
   auto perf = std::make_shared<ppc::core::Perf>(task);
 
-
   perf->TaskRun(perf_attr, perf_results);
   if (world.rank() == 0) {
     ppc::core::Perf::PrintPerfStatistic(perf_results);

--- a/tasks/all/borisov_s_strassen/perf_tests/main.cpp
+++ b/tasks/all/borisov_s_strassen/perf_tests/main.cpp
@@ -15,8 +15,8 @@
 
 namespace {
 
-std::vector<double> MultiplyNaive(const std::vector<double>& a, const std::vector<double>& b, int rows_a,
-                                        int cols_a, int cols_b) {
+std::vector<double> MultiplyNaive(const std::vector<double>& a, const std::vector<double>& b, int rows_a, int cols_a,
+                                  int cols_b) {
   std::vector<double> c(rows_a * cols_b, 0.0);
   for (int i = 0; i < rows_a; ++i) {
     for (int j = 0; j < cols_b; ++j) {

--- a/tasks/all/borisov_s_strassen/perf_tests/main.cpp
+++ b/tasks/all/borisov_s_strassen/perf_tests/main.cpp
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 
-#include <boost/mpi.hpp>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>

--- a/tasks/all/borisov_s_strassen/perf_tests/main.cpp
+++ b/tasks/all/borisov_s_strassen/perf_tests/main.cpp
@@ -8,6 +8,8 @@
 #include <vector>
 
 #include "all/borisov_s_strassen/include/ops_all.hpp"
+#include "boost/mpi/communicator.hpp"
+#include "core/perf/include/perf.hpp"
 #include "core/task/include/task.hpp"
 
 namespace {

--- a/tasks/all/borisov_s_strassen/perf_tests/main.cpp
+++ b/tasks/all/borisov_s_strassen/perf_tests/main.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include <boost/mpi/communicator.hpp>
-#include <boost/mpi/environment.hpp>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>

--- a/tasks/all/borisov_s_strassen/perf_tests/main.cpp
+++ b/tasks/all/borisov_s_strassen/perf_tests/main.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 
-#include <cmath>
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -8,14 +10,13 @@
 #include <vector>
 
 #include "all/borisov_s_strassen/include/ops_all.hpp"
-#include "boost/mpi/communicator.hpp"
 #include "core/perf/include/perf.hpp"
 #include "core/task/include/task.hpp"
 
 namespace {
 
-std::vector<double> MultiplyNaiveDouble(const std::vector<double>& a, const std::vector<double>& b, int rows_a,
-                                        int cols_a, int cols_b) {
+std::vector<double> MultiplyNaive(const std::vector<double>& a, const std::vector<double>& b, int rows_a, int cols_a,
+                                  int cols_b) {
   std::vector<double> c(rows_a * cols_b, 0.0);
   for (int i = 0; i < rows_a; ++i) {
     for (int j = 0; j < cols_b; ++j) {
@@ -29,387 +30,124 @@ std::vector<double> MultiplyNaiveDouble(const std::vector<double>& a, const std:
   return c;
 }
 
-std::vector<double> GenerateRandomMatrix(int rows, int cols, int seed, double min_val = -50.0, double max_val = 50.0) {
-  std::mt19937 rng(seed);
-  std::uniform_real_distribution<double> dist(min_val, max_val);
-  std::vector<double> m(rows * cols);
-  for (double& v : m) {
-    v = dist(rng);
-  }
-  return m;
-}
-
-namespace test_utils {
-
-constexpr double kTol = 1e-9;
-
-bool IsMaster() {
-  static boost::mpi::communicator world;
-  return world.rank() == 0;
-}
-
-using UniqueBuf = std::unique_ptr<double[]>;
-
-UniqueBuf ExecuteTask(const std::vector<double>& in, std::size_t out_count) {
-  auto data = std::make_shared<ppc::core::TaskData>();
-
-  data->inputs.emplace_back(reinterpret_cast<uint8_t*>(const_cast<double*>(in.data())));
-  data->inputs_count.emplace_back(in.size());
-
-  UniqueBuf out(new double[out_count]());
-  data->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.get()));
-  data->outputs_count.emplace_back(out_count);
-
-  borisov_s_strassen_all::ParallelStrassenMpiStl task(data);
-  task.PreProcessingImpl();
-  EXPECT_TRUE(task.ValidationImpl());
-  task.RunImpl();
-  task.PostProcessingImpl();
-
-  return out;
-}
-
-void ExpectVectorNear(const std::vector<double>& expected, const double* actual, std::size_t offset,
-                      double tol = kTol) {
-  for (std::size_t i = 0; i < expected.size(); ++i) {
-    EXPECT_NEAR(expected[i], actual[offset + i], tol);
+void GenerateRandomMatrix(int rows, int cols, std::vector<double>& matrix) {
+  std::random_device rd;
+  std::mt19937 rng(rd());
+  std::uniform_real_distribution<double> dist(-50.0, 50.0);
+  matrix.resize(rows * cols);
+  for (auto& value : matrix) {
+    value = dist(rng);
   }
 }
 
-}  // namespace test_utils
 }  // namespace
 
-TEST(borisov_s_strassen_all, OneByOne) {
-  std::vector<double> in = {1.0, 1.0, 1.0, 1.0, 7.5, 2.5};
-  auto out = test_utils::ExecuteTask(in, 3);
+TEST(borisov_s_strassen_mpi_perf, pipeline_run) {
+  boost::mpi::communicator world;
 
-  if (test_utils::IsMaster()) {
-    EXPECT_DOUBLE_EQ(out[0], 1.0);
-    EXPECT_DOUBLE_EQ(out[1], 1.0);
-    EXPECT_DOUBLE_EQ(out[2], 18.75);
+  constexpr int kRowsA = 512;
+  constexpr int kColsA = 512;
+  constexpr int kRowsB = 512;
+  constexpr int kColsB = 512;
+
+  std::vector<double> a;
+  std::vector<double> b;
+  std::vector<double> in_buf;
+  std::vector<double> out_buf;
+  if (world.rank() == 0) {
+    GenerateRandomMatrix(kRowsA, kColsA, a);
+    GenerateRandomMatrix(kRowsB, kColsB, b);
+    in_buf = {static_cast<double>(kRowsA), static_cast<double>(kColsA), static_cast<double>(kRowsB),
+              static_cast<double>(kColsB)};
+    in_buf.insert(in_buf.end(), a.begin(), a.end());
+    in_buf.insert(in_buf.end(), b.begin(), b.end());
+    out_buf.assign(2 + (kRowsA * kColsB), 0.0);
+  }
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_buf.data()));
+    task_data->inputs_count.push_back(in_buf.size());
+    task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_buf.data()));
+    task_data->outputs_count.push_back(out_buf.size());
+  }
+
+  auto task = std::make_shared<borisov_s_strassen_all::ParallelStrassenMpiStl>(task_data);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 5;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto now = std::chrono::high_resolution_clock::now();
+    return std::chrono::duration<double>(now - t0).count();
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf = std::make_shared<ppc::core::Perf>(task);
+
+  perf->PipelineRun(perf_attr, perf_results);
+  if (world.rank() == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
+    auto expected = MultiplyNaive(a, b, kRowsA, kColsA, kColsB);
+    std::vector<double> got(out_buf.begin() + 2, out_buf.end());
+    ASSERT_EQ(expected.size(), got.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+      ASSERT_NEAR(expected[i], got[i], 1e-8);
+    }
   }
 }
 
-TEST(borisov_s_strassen_all, TwoByTwo) {
-  const std::vector<double> a = {1.0, 2.5, 3.0, 4.0};
-  const std::vector<double> b = {1.5, 2.0, 0.5, 3.5};
-  const std::vector<double> c_exp = {2.75, 10.75, 6.5, 20.0};
+TEST(borisov_s_strassen_mpi_perf, task_run) {
+  boost::mpi::communicator world;
 
-  std::vector<double> in = {2.0, 2.0, 2.0, 2.0};
-  in.insert(in.end(), a.begin(), a.end());
-  in.insert(in.end(), b.begin(), b.end());
+  constexpr int kRowsA = 512;
+  constexpr int kColsA = 512;
+  constexpr int kRowsB = 512;
+  constexpr int kColsB = 512;
 
-  auto out = test_utils::ExecuteTask(in, 6);
-
-  if (test_utils::IsMaster()) {
-    EXPECT_DOUBLE_EQ(out[0], 2.0);
-    EXPECT_DOUBLE_EQ(out[1], 2.0);
-    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
-  }
-}
-
-TEST(borisov_s_strassen_all, Rectangular2x3_3x4) {
-  const std::vector<double> a = {1.0, 2.5, 3.0, 4.0, 5.5, 6.0};
-  const std::vector<double> b = {0.5, 1.0, 2.0, 1.5, 2.0, 0.5, 1.0, 3.0, 4.0, 2.5, 0.5, 1.0};
-  const auto c_exp = MultiplyNaiveDouble(a, b, 2, 3, 4);
-
-  std::vector<double> in = {2.0, 3.0, 3.0, 4.0};
-  in.insert(in.end(), a.begin(), a.end());
-  in.insert(in.end(), b.begin(), b.end());
-
-  auto out = test_utils::ExecuteTask(in, 10);
-
-  if (test_utils::IsMaster()) {
-    EXPECT_DOUBLE_EQ(out[0], 2.0);
-    EXPECT_DOUBLE_EQ(out[1], 4.0);
-    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
-  }
-}
-
-TEST(borisov_s_strassen_all, Square5x5_Random) {
-  const int n = 5;
-  auto a = GenerateRandomMatrix(n, n, 7777);
-  auto b = GenerateRandomMatrix(n, n, 7777);
-  auto c_exp = MultiplyNaiveDouble(a, b, n, n, n);
-
-  std::vector<double> in = {double(n), double(n), double(n), double(n)};
-  in.insert(in.end(), a.begin(), a.end());
-  in.insert(in.end(), b.begin(), b.end());
-
-  auto out = test_utils::ExecuteTask(in, 2 + (n * n));
-
-  if (test_utils::IsMaster()) {
-    EXPECT_DOUBLE_EQ(out[0], n);
-    EXPECT_DOUBLE_EQ(out[1], n);
-    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
-  }
-}
-
-TEST(borisov_s_strassen_all, Square20x20_Random) {
-  const int n = 20;
-  auto a = GenerateRandomMatrix(n, n, 7777);
-  auto b = GenerateRandomMatrix(n, n, 7777);
-  auto c_exp = MultiplyNaiveDouble(a, b, n, n, n);
-
-  std::vector<double> in = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
-                            static_cast<double>(n)};
-  in.insert(in.end(), a.begin(), a.end());
-  in.insert(in.end(), b.begin(), b.end());
-
-  auto out = test_utils::ExecuteTask(in, 2 + (n * n));
-
-  if (test_utils::IsMaster()) {
-    EXPECT_DOUBLE_EQ(out[0], n);
-    EXPECT_DOUBLE_EQ(out[1], n);
-    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
-  }
-}
-
-TEST(borisov_s_strassen_all, Square32x32_Random) {
-  const int n = 32;
-  auto a = GenerateRandomMatrix(n, n, 7777);
-  auto b = GenerateRandomMatrix(n, n, 7777);
-  auto c_exp = MultiplyNaiveDouble(a, b, n, n, n);
-
-  std::vector<double> in = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
-                            static_cast<double>(n)};
-  in.insert(in.end(), a.begin(), a.end());
-  in.insert(in.end(), b.begin(), b.end());
-
-  auto out = test_utils::ExecuteTask(in, 2 + (n * n));
-
-  if (test_utils::IsMaster()) {
-    EXPECT_DOUBLE_EQ(out[0], n);
-    EXPECT_DOUBLE_EQ(out[1], n);
-    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
-  }
-}
-
-TEST(borisov_s_strassen_all, Square128x128_Random) {
-  const int n = 128;
-  auto a = GenerateRandomMatrix(n, n, 7777);
-  auto b = GenerateRandomMatrix(n, n, 7777);
-  auto c_exp = MultiplyNaiveDouble(a, b, n, n, n);
-
-  std::vector<double> in = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
-                            static_cast<double>(n)};
-  in.insert(in.end(), a.begin(), a.end());
-  in.insert(in.end(), b.begin(), b.end());
-
-  auto out = test_utils::ExecuteTask(in, 2 + (n * n));
-
-  if (test_utils::IsMaster()) {
-    EXPECT_DOUBLE_EQ(out[0], n);
-    EXPECT_DOUBLE_EQ(out[1], n);
-    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
-  }
-}
-
-TEST(borisov_s_strassen_all, Square128x128_IdentityMatrix) {
-  const int n = 128;
-  auto a = GenerateRandomMatrix(n, n, 7777);
-  std::vector<double> e(n * n, 0.0);
-  for (int i = 0; i < n; ++i) {
-    e[(i * n) + i] = 1.0;
+  std::vector<double> a;
+  std::vector<double> b;
+  std::vector<double> in_buf;
+  std::vector<double> out_buf;
+  if (world.rank() == 0) {
+    GenerateRandomMatrix(kRowsA, kColsA, a);
+    GenerateRandomMatrix(kRowsB, kColsB, b);
+    in_buf = {static_cast<double>(kRowsA), static_cast<double>(kColsA), static_cast<double>(kRowsB),
+              static_cast<double>(kColsB)};
+    in_buf.insert(in_buf.end(), a.begin(), a.end());
+    in_buf.insert(in_buf.end(), b.begin(), b.end());
+    out_buf.assign(2 + (kRowsA * kColsB), 0.0);
   }
 
-  std::vector<double> in = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
-                            static_cast<double>(n)};
-  in.insert(in.end(), a.begin(), a.end());
-  in.insert(in.end(), e.begin(), e.end());
-
-  auto out = test_utils::ExecuteTask(in, 2 + (n * n));
-
-  if (test_utils::IsMaster()) {
-    EXPECT_DOUBLE_EQ(out[0], n);
-    EXPECT_DOUBLE_EQ(out[1], n);
-    test_utils::ExpectVectorNear(a, out.get(), 2);
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_buf.data()));
+    task_data->inputs_count.push_back(in_buf.size());
+    task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_buf.data()));
+    task_data->outputs_count.push_back(out_buf.size());
   }
-}
 
-TEST(borisov_s_strassen_all, Square129x129_Random) {
-  const int n = 129;
-  auto a = GenerateRandomMatrix(n, n, 7777);
-  auto b = GenerateRandomMatrix(n, n, 7777);
-  auto c_exp = MultiplyNaiveDouble(a, b, n, n, n);
+  auto task = std::make_shared<borisov_s_strassen_all::ParallelStrassenMpiStl>(task_data);
 
-  std::vector<double> in = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
-                            static_cast<double>(n)};
-  in.insert(in.end(), a.begin(), a.end());
-  in.insert(in.end(), b.begin(), b.end());
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 5;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto now = std::chrono::high_resolution_clock::now();
+    return std::chrono::duration<double>(now - t0).count();
+  };
 
-  auto out = test_utils::ExecuteTask(in, 2 + (n * n));
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf = std::make_shared<ppc::core::Perf>(task);
 
-  if (test_utils::IsMaster()) {
-    EXPECT_DOUBLE_EQ(out[0], n);
-    EXPECT_DOUBLE_EQ(out[1], n);
-    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
-  }
-}
-
-TEST(borisov_s_strassen_all, Square240x240_Random) {
-  const int n = 240;
-  auto a = GenerateRandomMatrix(n, n, 7777);
-  auto b = GenerateRandomMatrix(n, n, 7777);
-  auto c_exp = MultiplyNaiveDouble(a, b, n, n, n);
-
-  std::vector<double> in = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
-                            static_cast<double>(n)};
-  in.insert(in.end(), a.begin(), a.end());
-  in.insert(in.end(), b.begin(), b.end());
-
-  auto out = test_utils::ExecuteTask(in, 2 + (n * n));
-
-  if (test_utils::IsMaster()) {
-    EXPECT_DOUBLE_EQ(out[0], n);
-    EXPECT_DOUBLE_EQ(out[1], n);
-    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
-  }
-}
-
-TEST(borisov_s_strassen_all, Square512x512_Random) {
-  const int n = 512;
-  auto a = GenerateRandomMatrix(n, n, 7777);
-  auto b = GenerateRandomMatrix(n, n, 7777);
-  auto c_exp = MultiplyNaiveDouble(a, b, n, n, n);
-
-  std::vector<double> in = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
-                            static_cast<double>(n)};
-  in.insert(in.end(), a.begin(), a.end());
-  in.insert(in.end(), b.begin(), b.end());
-
-  auto out = test_utils::ExecuteTask(in, 2 + (n * n));
-
-  if (test_utils::IsMaster()) {
-    EXPECT_DOUBLE_EQ(out[0], n);
-    EXPECT_DOUBLE_EQ(out[1], n);
-    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
-  }
-}
-
-TEST(borisov_s_strassen_all, Square600x600_Random) {
-  const int n = 600;
-  auto a = GenerateRandomMatrix(n, n, 7777);
-  auto b = GenerateRandomMatrix(n, n, 7777);
-  auto c_exp = MultiplyNaiveDouble(a, b, n, n, n);
-
-  std::vector<double> in = {double(n), double(n), double(n), double(n)};
-  in.insert(in.end(), a.begin(), a.end());
-  in.insert(in.end(), b.begin(), b.end());
-
-  auto out = test_utils::ExecuteTask(in, 2 + (n * n));
-
-  if (test_utils::IsMaster()) {
-    EXPECT_DOUBLE_EQ(out[0], n);
-    EXPECT_DOUBLE_EQ(out[1], n);
-    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
-  }
-}
-
-TEST(borisov_s_strassen_all, ValidCase) {
-  std::vector<double> in = {2.0, 3.0, 3.0, 2.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0};
-
-  auto data = std::make_shared<ppc::core::TaskData>();
-  data->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
-  data->inputs_count.emplace_back(in.size());
-  data->outputs.emplace_back(nullptr);
-  data->outputs_count.emplace_back(0);
-
-  borisov_s_strassen_all::ParallelStrassenMpiStl task(data);
-  task.PreProcessingImpl();
-  EXPECT_TRUE(task.ValidationImpl());
-}
-
-TEST(borisov_s_strassen_all, MismatchCase) {
-  std::vector<double> in = {2.0, 2.0, 3.0, 3.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0};
-
-  auto data = std::make_shared<ppc::core::TaskData>();
-  data->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
-  data->inputs_count.emplace_back(in.size());
-  data->outputs.emplace_back(nullptr);
-  data->outputs_count.emplace_back(0);
-
-  borisov_s_strassen_all::ParallelStrassenMpiStl task(data);
-  task.PreProcessingImpl();
-  EXPECT_FALSE(task.ValidationImpl());
-}
-
-TEST(borisov_s_strassen_all, NotEnoughDataCase) {
-  std::vector<double> in = {2.0, 2.0, 2.0, 2.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
-
-  auto data = std::make_shared<ppc::core::TaskData>();
-  data->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
-  data->inputs_count.emplace_back(in.size());
-  data->outputs.emplace_back(nullptr);
-  data->outputs_count.emplace_back(0);
-
-  borisov_s_strassen_all::ParallelStrassenMpiStl task(data);
-  task.PreProcessingImpl();
-  EXPECT_FALSE(task.ValidationImpl());
-}
-
-TEST(borisov_s_strassen_all, Rectangular16x17_Random) {
-  const int r = 16;
-  const int c = 17;
-  const int cb = 18;
-  auto a = GenerateRandomMatrix(r, c, 7777);
-  auto b = GenerateRandomMatrix(c, cb, 7777);
-  auto c_exp = MultiplyNaiveDouble(a, b, r, c, cb);
-
-  std::vector<double> in = {static_cast<double>(r), static_cast<double>(c), static_cast<double>(c),
-                            static_cast<double>(cb)};
-  in.insert(in.end(), a.begin(), a.end());
-  in.insert(in.end(), b.begin(), b.end());
-
-  auto out = test_utils::ExecuteTask(in, 2 + (r * cb));
-
-  if (test_utils::IsMaster()) {
-    EXPECT_DOUBLE_EQ(out[0], r);
-    EXPECT_DOUBLE_EQ(out[1], cb);
-    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
-  }
-}
-
-TEST(borisov_s_strassen_all, Rectangular19x23_Random) {
-  const int r = 19;
-  const int c = 23;
-  const int cb = 21;
-  auto a = GenerateRandomMatrix(r, c, 7777);
-  auto b = GenerateRandomMatrix(c, cb, 7777);
-  auto c_exp = MultiplyNaiveDouble(a, b, r, c, cb);
-
-  std::vector<double> in = {static_cast<double>(r), static_cast<double>(c), static_cast<double>(c),
-                            static_cast<double>(cb)};
-  in.insert(in.end(), a.begin(), a.end());
-  in.insert(in.end(), b.begin(), b.end());
-
-  auto out = test_utils::ExecuteTask(in, 2 + (r * cb));
-
-  if (test_utils::IsMaster()) {
-    EXPECT_DOUBLE_EQ(out[0], r);
-    EXPECT_DOUBLE_EQ(out[1], cb);
-    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
-  }
-}
-
-TEST(borisov_s_strassen_all, Rectangular32x64_Random) {
-  const int r = 32;
-  const int c = 64;
-  const int cb = 32;
-  auto a = GenerateRandomMatrix(r, c, 7777);
-  auto b = GenerateRandomMatrix(c, cb, 7777);
-  auto c_exp = MultiplyNaiveDouble(a, b, r, c, cb);
-
-  std::vector<double> in = {static_cast<double>(r), static_cast<double>(c), static_cast<double>(c),
-                            static_cast<double>(cb)};
-  in.insert(in.end(), a.begin(), a.end());
-  in.insert(in.end(), b.begin(), b.end());
-
-  auto out = test_utils::ExecuteTask(in, 2 + (r * cb));
-
-  if (test_utils::IsMaster()) {
-    EXPECT_DOUBLE_EQ(out[0], r);
-    EXPECT_DOUBLE_EQ(out[1], cb);
-    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
+  perf->TaskRun(perf_attr, perf_results);
+  if (world.rank() == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
+    auto expected = MultiplyNaive(a, b, kRowsA, kColsA, kColsB);
+    std::vector<double> got(out_buf.begin() + 2, out_buf.end());
+    ASSERT_EQ(expected.size(), got.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+      ASSERT_NEAR(expected[i], got[i], 1e-8);
+    }
   }
 }

--- a/tasks/all/borisov_s_strassen/perf_tests/main.cpp
+++ b/tasks/all/borisov_s_strassen/perf_tests/main.cpp
@@ -1,8 +1,7 @@
 #include <gtest/gtest.h>
 
-#include <boost/mpi/communicator.hpp>
-#include <boost/mpi/environment.hpp>
-#include <chrono>
+#include <boost/mpi.hpp>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -10,13 +9,12 @@
 #include <vector>
 
 #include "all/borisov_s_strassen/include/ops_all.hpp"
-#include "core/perf/include/perf.hpp"
 #include "core/task/include/task.hpp"
 
 namespace {
 
-std::vector<double> MultiplyNaive(const std::vector<double>& a, const std::vector<double>& b, int rows_a, int cols_a,
-                                  int cols_b) {
+std::vector<double> MultiplyNaiveDouble(const std::vector<double>& a, const std::vector<double>& b, int rows_a,
+                                        int cols_a, int cols_b) {
   std::vector<double> c(rows_a * cols_b, 0.0);
   for (int i = 0; i < rows_a; ++i) {
     for (int j = 0; j < cols_b; ++j) {
@@ -30,124 +28,387 @@ std::vector<double> MultiplyNaive(const std::vector<double>& a, const std::vecto
   return c;
 }
 
-void GenerateRandomMatrix(int rows, int cols, std::vector<double>& matrix) {
-  std::random_device rd;
-  std::mt19937 rng(rd());
-  std::uniform_real_distribution<double> dist(-50.0, 50.0);
-  matrix.resize(rows * cols);
-  for (auto& value : matrix) {
-    value = dist(rng);
+std::vector<double> GenerateRandomMatrix(int rows, int cols, int seed, double min_val = -50.0, double max_val = 50.0) {
+  std::mt19937 rng(seed);
+  std::uniform_real_distribution<double> dist(min_val, max_val);
+  std::vector<double> m(rows * cols);
+  for (double& v : m) {
+    v = dist(rng);
+  }
+  return m;
+}
+
+namespace test_utils {
+
+constexpr double kTol = 1e-9;
+
+inline bool IsMaster() {
+  static boost::mpi::communicator world;
+  return world.rank() == 0;
+}
+
+using UniqueBuf = std::unique_ptr<double[]>;
+
+UniqueBuf ExecuteTask(const std::vector<double>& in, std::size_t out_count) {
+  auto data = std::make_shared<ppc::core::TaskData>();
+
+  data->inputs.emplace_back(reinterpret_cast<uint8_t*>(const_cast<double*>(in.data())));
+  data->inputs_count.emplace_back(in.size());
+
+  UniqueBuf out(new double[out_count]());
+  data->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.get()));
+  data->outputs_count.emplace_back(out_count);
+
+  borisov_s_strassen_all::ParallelStrassenMpiStl task(data);
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+  task.RunImpl();
+  task.PostProcessingImpl();
+
+  return out;
+}
+
+void ExpectVectorNear(const std::vector<double>& expected, const double* actual, std::size_t offset,
+                      double tol = kTol) {
+  for (std::size_t i = 0; i < expected.size(); ++i) {
+    EXPECT_NEAR(expected[i], actual[offset + i], tol);
   }
 }
 
+}  // namespace test_utils
 }  // namespace
 
-TEST(borisov_s_strassen_mpi_perf, pipeline_run) {
-  boost::mpi::communicator world;
+TEST(borisov_s_strassen_all, OneByOne) {
+  std::vector<double> in = {1.0, 1.0, 1.0, 1.0, 7.5, 2.5};
+  auto out = test_utils::ExecuteTask(in, 3);
 
-  constexpr int kRowsA = 512;
-  constexpr int kColsA = 512;
-  constexpr int kRowsB = 512;
-  constexpr int kColsB = 512;
-
-  std::vector<double> a;
-  std::vector<double> b;
-  std::vector<double> in_buf;
-  std::vector<double> out_buf;
-  if (world.rank() == 0) {
-    GenerateRandomMatrix(kRowsA, kColsA, a);
-    GenerateRandomMatrix(kRowsB, kColsB, b);
-    in_buf = {static_cast<double>(kRowsA), static_cast<double>(kColsA), static_cast<double>(kRowsB),
-              static_cast<double>(kColsB)};
-    in_buf.insert(in_buf.end(), a.begin(), a.end());
-    in_buf.insert(in_buf.end(), b.begin(), b.end());
-    out_buf.assign(2 + (kRowsA * kColsB), 0.0);
-  }
-
-  auto task_data = std::make_shared<ppc::core::TaskData>();
-  if (world.rank() == 0) {
-    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_buf.data()));
-    task_data->inputs_count.push_back(in_buf.size());
-    task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_buf.data()));
-    task_data->outputs_count.push_back(out_buf.size());
-  }
-
-  auto task = std::make_shared<borisov_s_strassen_all::ParallelStrassenMpiStl>(task_data);
-
-  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 5;
-  const auto t0 = std::chrono::high_resolution_clock::now();
-  perf_attr->current_timer = [&] {
-    auto now = std::chrono::high_resolution_clock::now();
-    return std::chrono::duration<double>(now - t0).count();
-  };
-
-  auto perf_results = std::make_shared<ppc::core::PerfResults>();
-  auto perf = std::make_shared<ppc::core::Perf>(task);
-
-  perf->PipelineRun(perf_attr, perf_results);
-  if (world.rank() == 0) {
-    ppc::core::Perf::PrintPerfStatistic(perf_results);
-    auto expected = MultiplyNaive(a, b, kRowsA, kColsA, kColsB);
-    std::vector<double> got(out_buf.begin() + 2, out_buf.end());
-    ASSERT_EQ(expected.size(), got.size());
-    for (size_t i = 0; i < expected.size(); ++i) {
-      ASSERT_NEAR(expected[i], got[i], 1e-8);
-    }
+  if (test_utils::IsMaster()) {
+    EXPECT_DOUBLE_EQ(out[0], 1.0);
+    EXPECT_DOUBLE_EQ(out[1], 1.0);
+    EXPECT_DOUBLE_EQ(out[2], 18.75);
   }
 }
 
-TEST(borisov_s_strassen_mpi_perf, task_run) {
-  boost::mpi::communicator world;
+TEST(borisov_s_strassen_all, TwoByTwo) {
+  const std::vector<double> a = {1.0, 2.5, 3.0, 4.0};
+  const std::vector<double> b = {1.5, 2.0, 0.5, 3.5};
+  const std::vector<double> c_exp = {2.75, 10.75, 6.5, 20.0};
 
-  constexpr int kRowsA = 512;
-  constexpr int kColsA = 512;
-  constexpr int kRowsB = 512;
-  constexpr int kColsB = 512;
+  std::vector<double> in = {2.0, 2.0, 2.0, 2.0};
+  in.insert(in.end(), a.begin(), a.end());
+  in.insert(in.end(), b.begin(), b.end());
 
-  std::vector<double> a;
-  std::vector<double> b;
-  std::vector<double> in_buf;
-  std::vector<double> out_buf;
-  if (world.rank() == 0) {
-    GenerateRandomMatrix(kRowsA, kColsA, a);
-    GenerateRandomMatrix(kRowsB, kColsB, b);
-    in_buf = {static_cast<double>(kRowsA), static_cast<double>(kColsA), static_cast<double>(kRowsB),
-              static_cast<double>(kColsB)};
-    in_buf.insert(in_buf.end(), a.begin(), a.end());
-    in_buf.insert(in_buf.end(), b.begin(), b.end());
-    out_buf.assign(2 + (kRowsA * kColsB), 0.0);
+  auto out = test_utils::ExecuteTask(in, 6);
+
+  if (test_utils::IsMaster()) {
+    EXPECT_DOUBLE_EQ(out[0], 2.0);
+    EXPECT_DOUBLE_EQ(out[1], 2.0);
+    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
+  }
+}
+
+TEST(borisov_s_strassen_all, Rectangular2x3_3x4) {
+  const std::vector<double> a = {1.0, 2.5, 3.0, 4.0, 5.5, 6.0};
+  const std::vector<double> b = {0.5, 1.0, 2.0, 1.5, 2.0, 0.5, 1.0, 3.0, 4.0, 2.5, 0.5, 1.0};
+  const auto c_exp = MultiplyNaiveDouble(a, b, 2, 3, 4);
+
+  std::vector<double> in = {2.0, 3.0, 3.0, 4.0};
+  in.insert(in.end(), a.begin(), a.end());
+  in.insert(in.end(), b.begin(), b.end());
+
+  auto out = test_utils::ExecuteTask(in, 10);
+
+  if (test_utils::IsMaster()) {
+    EXPECT_DOUBLE_EQ(out[0], 2.0);
+    EXPECT_DOUBLE_EQ(out[1], 4.0);
+    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
+  }
+}
+
+TEST(borisov_s_strassen_all, Square5x5_Random) {
+  const int n = 5;
+  auto a = GenerateRandomMatrix(n, n, 7777);
+  auto b = GenerateRandomMatrix(n, n, 7777);
+  auto c_exp = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in = {double(n), double(n), double(n), double(n)};
+  in.insert(in.end(), a.begin(), a.end());
+  in.insert(in.end(), b.begin(), b.end());
+
+  auto out = test_utils::ExecuteTask(in, 2 + (n * n));
+
+  if (test_utils::IsMaster()) {
+    EXPECT_DOUBLE_EQ(out[0], n);
+    EXPECT_DOUBLE_EQ(out[1], n);
+    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
+  }
+}
+
+TEST(borisov_s_strassen_all, Square20x20_Random) {
+  const int n = 20;
+  auto a = GenerateRandomMatrix(n, n, 7777);
+  auto b = GenerateRandomMatrix(n, n, 7777);
+  auto c_exp = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                            static_cast<double>(n)};
+  in.insert(in.end(), a.begin(), a.end());
+  in.insert(in.end(), b.begin(), b.end());
+
+  auto out = test_utils::ExecuteTask(in, 2 + (n * n));
+
+  if (test_utils::IsMaster()) {
+    EXPECT_DOUBLE_EQ(out[0], n);
+    EXPECT_DOUBLE_EQ(out[1], n);
+    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
+  }
+}
+
+TEST(borisov_s_strassen_all, Square32x32_Random) {
+  const int n = 32;
+  auto a = GenerateRandomMatrix(n, n, 7777);
+  auto b = GenerateRandomMatrix(n, n, 7777);
+  auto c_exp = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                            static_cast<double>(n)};
+  in.insert(in.end(), a.begin(), a.end());
+  in.insert(in.end(), b.begin(), b.end());
+
+  auto out = test_utils::ExecuteTask(in, 2 + (n * n));
+
+  if (test_utils::IsMaster()) {
+    EXPECT_DOUBLE_EQ(out[0], n);
+    EXPECT_DOUBLE_EQ(out[1], n);
+    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
+  }
+}
+
+TEST(borisov_s_strassen_all, Square128x128_Random) {
+  const int n = 128;
+  auto a = GenerateRandomMatrix(n, n, 7777);
+  auto b = GenerateRandomMatrix(n, n, 7777);
+  auto c_exp = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                            static_cast<double>(n)};
+  in.insert(in.end(), a.begin(), a.end());
+  in.insert(in.end(), b.begin(), b.end());
+
+  auto out = test_utils::ExecuteTask(in, 2 + (n * n));
+
+  if (test_utils::IsMaster()) {
+    EXPECT_DOUBLE_EQ(out[0], n);
+    EXPECT_DOUBLE_EQ(out[1], n);
+    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
+  }
+}
+
+TEST(borisov_s_strassen_all, Square128x128_IdentityMatrix) {
+  const int n = 128;
+  auto a = GenerateRandomMatrix(n, n, 7777);
+  std::vector<double> e(n * n, 0.0);
+  for (int i = 0; i < n; ++i) {
+    e[(i * n) + i] = 1.0;
   }
 
-  auto task_data = std::make_shared<ppc::core::TaskData>();
-  if (world.rank() == 0) {
-    task_data->inputs.push_back(reinterpret_cast<uint8_t*>(in_buf.data()));
-    task_data->inputs_count.push_back(in_buf.size());
-    task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_buf.data()));
-    task_data->outputs_count.push_back(out_buf.size());
+  std::vector<double> in = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                            static_cast<double>(n)};
+  in.insert(in.end(), a.begin(), a.end());
+  in.insert(in.end(), e.begin(), e.end());
+
+  auto out = test_utils::ExecuteTask(in, 2 + (n * n));
+
+  if (test_utils::IsMaster()) {
+    EXPECT_DOUBLE_EQ(out[0], n);
+    EXPECT_DOUBLE_EQ(out[1], n);
+    test_utils::ExpectVectorNear(a, out.get(), 2);
   }
+}
 
-  auto task = std::make_shared<borisov_s_strassen_all::ParallelStrassenMpiStl>(task_data);
+TEST(borisov_s_strassen_all, Square129x129_Random) {
+  const int n = 129;
+  auto a = GenerateRandomMatrix(n, n, 7777);
+  auto b = GenerateRandomMatrix(n, n, 7777);
+  auto c_exp = MultiplyNaiveDouble(a, b, n, n, n);
 
-  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 5;
-  const auto t0 = std::chrono::high_resolution_clock::now();
-  perf_attr->current_timer = [&] {
-    auto now = std::chrono::high_resolution_clock::now();
-    return std::chrono::duration<double>(now - t0).count();
-  };
+  std::vector<double> in = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                            static_cast<double>(n)};
+  in.insert(in.end(), a.begin(), a.end());
+  in.insert(in.end(), b.begin(), b.end());
 
-  auto perf_results = std::make_shared<ppc::core::PerfResults>();
-  auto perf = std::make_shared<ppc::core::Perf>(task);
+  auto out = test_utils::ExecuteTask(in, 2 + (n * n));
 
-  perf->TaskRun(perf_attr, perf_results);
-  if (world.rank() == 0) {
-    ppc::core::Perf::PrintPerfStatistic(perf_results);
-    auto expected = MultiplyNaive(a, b, kRowsA, kColsA, kColsB);
-    std::vector<double> got(out_buf.begin() + 2, out_buf.end());
-    ASSERT_EQ(expected.size(), got.size());
-    for (size_t i = 0; i < expected.size(); ++i) {
-      ASSERT_NEAR(expected[i], got[i], 1e-8);
-    }
+  if (test_utils::IsMaster()) {
+    EXPECT_DOUBLE_EQ(out[0], n);
+    EXPECT_DOUBLE_EQ(out[1], n);
+    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
+  }
+}
+
+TEST(borisov_s_strassen_all, Square240x240_Random) {
+  const int n = 240;
+  auto a = GenerateRandomMatrix(n, n, 7777);
+  auto b = GenerateRandomMatrix(n, n, 7777);
+  auto c_exp = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                            static_cast<double>(n)};
+  in.insert(in.end(), a.begin(), a.end());
+  in.insert(in.end(), b.begin(), b.end());
+
+  auto out = test_utils::ExecuteTask(in, 2 + (n * n));
+
+  if (test_utils::IsMaster()) {
+    EXPECT_DOUBLE_EQ(out[0], n);
+    EXPECT_DOUBLE_EQ(out[1], n);
+    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
+  }
+}
+
+TEST(borisov_s_strassen_all, Square512x512_Random) {
+  const int n = 512;
+  auto a = GenerateRandomMatrix(n, n, 7777);
+  auto b = GenerateRandomMatrix(n, n, 7777);
+  auto c_exp = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in = {static_cast<double>(n), static_cast<double>(n), static_cast<double>(n),
+                            static_cast<double>(n)};
+  in.insert(in.end(), a.begin(), a.end());
+  in.insert(in.end(), b.begin(), b.end());
+
+  auto out = test_utils::ExecuteTask(in, 2 + (n * n));
+
+  if (test_utils::IsMaster()) {
+    EXPECT_DOUBLE_EQ(out[0], n);
+    EXPECT_DOUBLE_EQ(out[1], n);
+    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
+  }
+}
+
+TEST(borisov_s_strassen_all, Square600x600_Random) {
+  const int n = 600;
+  auto a = GenerateRandomMatrix(n, n, 7777);
+  auto b = GenerateRandomMatrix(n, n, 7777);
+  auto c_exp = MultiplyNaiveDouble(a, b, n, n, n);
+
+  std::vector<double> in = {double(n), double(n), double(n), double(n)};
+  in.insert(in.end(), a.begin(), a.end());
+  in.insert(in.end(), b.begin(), b.end());
+
+  auto out = test_utils::ExecuteTask(in, 2 + (n * n));
+
+  if (test_utils::IsMaster()) {
+    EXPECT_DOUBLE_EQ(out[0], n);
+    EXPECT_DOUBLE_EQ(out[1], n);
+    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
+  }
+}
+
+TEST(borisov_s_strassen_all, ValidCase) {
+  std::vector<double> in = {2.0, 3.0, 3.0, 2.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0};
+
+  auto data = std::make_shared<ppc::core::TaskData>();
+  data->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+  data->inputs_count.emplace_back(in.size());
+  data->outputs.emplace_back(nullptr);
+  data->outputs_count.emplace_back(0);
+
+  borisov_s_strassen_all::ParallelStrassenMpiStl task(data);
+  task.PreProcessingImpl();
+  EXPECT_TRUE(task.ValidationImpl());
+}
+
+TEST(borisov_s_strassen_all, MismatchCase) {
+  std::vector<double> in = {2.0, 2.0, 3.0, 3.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0};
+
+  auto data = std::make_shared<ppc::core::TaskData>();
+  data->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+  data->inputs_count.emplace_back(in.size());
+  data->outputs.emplace_back(nullptr);
+  data->outputs_count.emplace_back(0);
+
+  borisov_s_strassen_all::ParallelStrassenMpiStl task(data);
+  task.PreProcessingImpl();
+  EXPECT_FALSE(task.ValidationImpl());
+}
+
+TEST(borisov_s_strassen_all, NotEnoughDataCase) {
+  std::vector<double> in = {2.0, 2.0, 2.0, 2.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+
+  auto data = std::make_shared<ppc::core::TaskData>();
+  data->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+  data->inputs_count.emplace_back(in.size());
+  data->outputs.emplace_back(nullptr);
+  data->outputs_count.emplace_back(0);
+
+  borisov_s_strassen_all::ParallelStrassenMpiStl task(data);
+  task.PreProcessingImpl();
+  EXPECT_FALSE(task.ValidationImpl());
+}
+
+TEST(borisov_s_strassen_all, Rectangular16x17_Random) {
+  const int r = 16;
+  const int c = 17;
+  const int cb = 18;
+  auto a = GenerateRandomMatrix(r, c, 7777);
+  auto b = GenerateRandomMatrix(c, cb, 7777);
+  auto c_exp = MultiplyNaiveDouble(a, b, r, c, cb);
+
+  std::vector<double> in = {static_cast<double>(r), static_cast<double>(c), static_cast<double>(c),
+                            static_cast<double>(cb)};
+  in.insert(in.end(), a.begin(), a.end());
+  in.insert(in.end(), b.begin(), b.end());
+
+  auto out = test_utils::ExecuteTask(in, 2 + (r * cb));
+
+  if (test_utils::IsMaster()) {
+    EXPECT_DOUBLE_EQ(out[0], r);
+    EXPECT_DOUBLE_EQ(out[1], cb);
+    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
+  }
+}
+
+TEST(borisov_s_strassen_all, Rectangular19x23_Random) {
+  const int r = 19;
+  const int c = 23;
+  const int cb = 21;
+  auto a = GenerateRandomMatrix(r, c, 7777);
+  auto b = GenerateRandomMatrix(c, cb, 7777);
+  auto c_exp = MultiplyNaiveDouble(a, b, r, c, cb);
+
+  std::vector<double> in = {static_cast<double>(r), static_cast<double>(c), static_cast<double>(c),
+                            static_cast<double>(cb)};
+  in.insert(in.end(), a.begin(), a.end());
+  in.insert(in.end(), b.begin(), b.end());
+
+  auto out = test_utils::ExecuteTask(in, 2 + (r * cb));
+
+  if (test_utils::IsMaster()) {
+    EXPECT_DOUBLE_EQ(out[0], r);
+    EXPECT_DOUBLE_EQ(out[1], cb);
+    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
+  }
+}
+
+TEST(borisov_s_strassen_all, Rectangular32x64_Random) {
+  const int r = 32;
+  const int c = 64;
+  const int cb = 32;
+  auto a = GenerateRandomMatrix(r, c, 7777);
+  auto b = GenerateRandomMatrix(c, cb, 7777);
+  auto c_exp = MultiplyNaiveDouble(a, b, r, c, cb);
+
+  std::vector<double> in = {static_cast<double>(r), static_cast<double>(c), static_cast<double>(c),
+                            static_cast<double>(cb)};
+  in.insert(in.end(), a.begin(), a.end());
+  in.insert(in.end(), b.begin(), b.end());
+
+  auto out = test_utils::ExecuteTask(in, 2 + (r * cb));
+
+  if (test_utils::IsMaster()) {
+    EXPECT_DOUBLE_EQ(out[0], r);
+    EXPECT_DOUBLE_EQ(out[1], cb);
+    test_utils::ExpectVectorNear(c_exp, out.get(), 2);
   }
 }

--- a/tasks/all/borisov_s_strassen/perf_tests/main.cpp
+++ b/tasks/all/borisov_s_strassen/perf_tests/main.cpp
@@ -45,18 +45,23 @@ void GenerateRandomMatrix(int rows, int cols, std::vector<double>& matrix) {
 TEST(borisov_s_strassen_mpi_perf, pipeline_run) {
   boost::mpi::communicator world;
 
-  constexpr int kRowsA = 512, kColsA = 512;
-  constexpr int kRowsB = 512, kColsB = 512;
+  constexpr int kRowsA = 512;
+  constexpr int kColsA = 512;
+  constexpr int kRowsB = 512;
+  constexpr int kColsB = 512;
 
-  std::vector<double> A, B, in_buf, out_buf;
+  std::vector<double> a;
+  std::vector<double> b;
+  std::vector<double> in_buf;
+  std::vector<double> out_buf;
   if (world.rank() == 0) {
-    GenerateRandomMatrix(kRowsA, kColsA, A);
-    GenerateRandomMatrix(kRowsB, kColsB, B);
+    GenerateRandomMatrix(kRowsA, kColsA, a);
+    GenerateRandomMatrix(kRowsB, kColsB, b);
     in_buf = {static_cast<double>(kRowsA), static_cast<double>(kColsA), static_cast<double>(kRowsB),
               static_cast<double>(kColsB)};
-    in_buf.insert(in_buf.end(), A.begin(), A.end());
-    in_buf.insert(in_buf.end(), B.begin(), B.end());
-    out_buf.assign(2 + kRowsA * kColsB, 0.0);
+    in_buf.insert(in_buf.end(), a.begin(), a.end());
+    in_buf.insert(in_buf.end(), b.begin(), b.end());
+    out_buf.assign(2 + (kRowsA * kColsB), 0.0);
   }
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
@@ -83,28 +88,35 @@ TEST(borisov_s_strassen_mpi_perf, pipeline_run) {
   perf->PipelineRun(perf_attr, perf_results);
   if (world.rank() == 0) {
     ppc::core::Perf::PrintPerfStatistic(perf_results);
-    auto expected = MultiplyNaive(A, B, kRowsA, kColsA, kColsB);
+    auto expected = MultiplyNaive(a, b, kRowsA, kColsA, kColsB);
     std::vector<double> got(out_buf.begin() + 2, out_buf.end());
     ASSERT_EQ(expected.size(), got.size());
-    for (size_t i = 0; i < expected.size(); ++i) ASSERT_NEAR(expected[i], got[i], 1e-8);
+    for (size_t i = 0; i < expected.size(); ++i) {
+      ASSERT_NEAR(expected[i], got[i], 1e-8);
+    }
   }
 }
 
 TEST(borisov_s_strassen_mpi_perf, task_run) {
   boost::mpi::communicator world;
 
-  constexpr int kRowsA = 512, kColsA = 512;
-  constexpr int kRowsB = 512, kColsB = 512;
+  constexpr int kRowsA = 512;
+  constexpr int kColsA = 512;
+  constexpr int kRowsB = 512;
+  constexpr int kColsB = 512;
 
-  std::vector<double> A, B, in_buf, out_buf;
+  std::vector<double> a;
+  std::vector<double> b;
+  std::vector<double> in_buf;
+  std::vector<double> out_buf;
   if (world.rank() == 0) {
-    GenerateRandomMatrix(kRowsA, kColsA, A);
-    GenerateRandomMatrix(kRowsB, kColsB, B);
+    GenerateRandomMatrix(kRowsA, kColsA, a);
+    GenerateRandomMatrix(kRowsB, kColsB, b);
     in_buf = {static_cast<double>(kRowsA), static_cast<double>(kColsA), static_cast<double>(kRowsB),
               static_cast<double>(kColsB)};
-    in_buf.insert(in_buf.end(), A.begin(), A.end());
-    in_buf.insert(in_buf.end(), B.begin(), B.end());
-    out_buf.assign(2 + kRowsA * kColsB, 0.0);
+    in_buf.insert(in_buf.end(), a.begin(), a.end());
+    in_buf.insert(in_buf.end(), b.begin(), b.end());
+    out_buf.assign(2 + (kRowsA * kColsB), 0.0);
   }
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
@@ -131,9 +143,11 @@ TEST(borisov_s_strassen_mpi_perf, task_run) {
   perf->TaskRun(perf_attr, perf_results);
   if (world.rank() == 0) {
     ppc::core::Perf::PrintPerfStatistic(perf_results);
-    auto expected = MultiplyNaive(A, B, kRowsA, kColsA, kColsB);
+    auto expected = MultiplyNaive(a, b, kRowsA, kColsA, kColsB);
     std::vector<double> got(out_buf.begin() + 2, out_buf.end());
     ASSERT_EQ(expected.size(), got.size());
-    for (size_t i = 0; i < expected.size(); ++i) ASSERT_NEAR(expected[i], got[i], 1e-8);
+    for (size_t i = 0; i < expected.size(); ++i) {
+      ASSERT_NEAR(expected[i], got[i], 1e-8);
+    }
   }
 }

--- a/tasks/all/borisov_s_strassen/src/ops_all.cpp
+++ b/tasks/all/borisov_s_strassen/src/ops_all.cpp
@@ -169,20 +169,6 @@ bool ParallelStrassenMpiStl::PreProcessingImpl() {
 
     output_.resize(2 + (rowsA_ * colsB_));
   }
-
-  boost::mpi::broadcast(world_, rowsA_, 0);
-  boost::mpi::broadcast(world_, colsA_, 0);
-  boost::mpi::broadcast(world_, rowsB_, 0);
-  boost::mpi::broadcast(world_, colsB_, 0);
-  boost::mpi::broadcast(world_, m_, 0);
-
-  if (world_.rank() != 0) {
-    a_pad_.resize(m_ * m_);
-    b_pad_.resize(m_ * m_);
-  }
-  boost::mpi::broadcast(world_, a_pad_, 0);
-  boost::mpi::broadcast(world_, b_pad_, 0);
-
   return true;
 }
 
@@ -196,6 +182,19 @@ bool ParallelStrassenMpiStl::ValidationImpl() {
 }
 
 bool ParallelStrassenMpiStl::RunImpl() {
+  boost::mpi::broadcast(world_, rowsA_, 0);
+  boost::mpi::broadcast(world_, colsA_, 0);
+  boost::mpi::broadcast(world_, rowsB_, 0);
+  boost::mpi::broadcast(world_, colsB_, 0);
+  boost::mpi::broadcast(world_, m_, 0);
+
+  if (world_.rank() != 0) {
+    a_pad_.resize(m_ * m_);
+    b_pad_.resize(m_ * m_);
+  }
+  boost::mpi::broadcast(world_, a_pad_, 0);
+  boost::mpi::broadcast(world_, b_pad_, 0);
+
   if (m_ == 1) {
     if (world_.rank() == 0) {
       output_[0] = static_cast<double>(rowsA_);

--- a/tasks/all/borisov_s_strassen/src/ops_all.cpp
+++ b/tasks/all/borisov_s_strassen/src/ops_all.cpp
@@ -1,11 +1,11 @@
 #include "all/borisov_s_strassen/include/ops_all.hpp"
 
 #include <algorithm>
+#include <boost/serialization/vector.hpp> // NOLINT(*-include-cleaner)
 #include <cstddef>
 #include <thread>
 #include <vector>
 
-#include <boost/serialization/vector.hpp> // NOLINT(*-include-cleaner)
 #include "boost/mpi/collectives/broadcast.hpp"
 
 namespace borisov_s_strassen_all {

--- a/tasks/all/borisov_s_strassen/src/ops_all.cpp
+++ b/tasks/all/borisov_s_strassen/src/ops_all.cpp
@@ -1,11 +1,11 @@
-#include <algorithm>
+#include "all/borisov_s_strassen/include/ops_all.hpp"
 
-#include <boost/serialization/vector.hpp> // NOLINT(*-include-cleaner)
+#include <algorithm>
 #include <cstddef>
 #include <thread>
 #include <vector>
 
-#include "all/borisov_s_strassen/include/ops_all.hpp"
+#include <boost/serialization/vector.hpp> // NOLINT(*-include-cleaner)
 #include "boost/mpi/collectives/broadcast.hpp"
 
 namespace borisov_s_strassen_all {

--- a/tasks/all/borisov_s_strassen/src/ops_all.cpp
+++ b/tasks/all/borisov_s_strassen/src/ops_all.cpp
@@ -1,7 +1,7 @@
 #include "all/borisov_s_strassen/include/ops_all.hpp"
 
 #include <algorithm>
-#include <boost/serialization/vector.hpp> // NOLINT(*-include-cleaner)
+#include <boost/serialization/vector.hpp>  // NOLINT(*-include-cleaner)
 #include <cstddef>
 #include <thread>
 #include <vector>

--- a/tasks/all/borisov_s_strassen/src/ops_all.cpp
+++ b/tasks/all/borisov_s_strassen/src/ops_all.cpp
@@ -4,6 +4,7 @@
 #include <boost/serialization/vector.hpp>  // NOLINT(*-include-cleaner)
 #include <cstddef>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "boost/mpi/collectives/broadcast.hpp"

--- a/tasks/all/borisov_s_strassen/src/ops_all.cpp
+++ b/tasks/all/borisov_s_strassen/src/ops_all.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+
 #include <boost/serialization/vector.hpp> // NOLINT(*-include-cleaner)
 #include <cstddef>
 #include <thread>

--- a/tasks/all/borisov_s_strassen/src/ops_stl.cpp
+++ b/tasks/all/borisov_s_strassen/src/ops_stl.cpp
@@ -1,5 +1,5 @@
 #include <algorithm>
-#include <boost/serialization/vector.hpp>
+#include <boost/serialization/vector.hpp> // NOLINT(*-include-cleaner)
 #include <cstddef>
 #include <thread>
 #include <vector>

--- a/tasks/all/borisov_s_strassen/src/ops_stl.cpp
+++ b/tasks/all/borisov_s_strassen/src/ops_stl.cpp
@@ -1,0 +1,264 @@
+#include "all/borisov_s_strassen/include/ops_all.hpp"
+
+#include <algorithm>
+#include <boost/serialization/vector.hpp>
+#include <cstddef>
+#include <thread>
+#include <vector>
+
+#include "boost/mpi/collectives/broadcast.hpp"
+
+namespace borisov_s_strassen_all {
+namespace {
+
+std::vector<double> MultiplyNaive(const std::vector<double>& a, const std::vector<double>& b, int n) {
+  std::vector<double> c(n * n, 0.0);
+  for (int i = 0; i < n; ++i)
+    for (int j = 0; j < n; ++j) {
+      double s = 0.0;
+      for (int k = 0; k < n; ++k) s += a[(i * n) + k] * b[(k * n) + j];
+      c[(i * n) + j] = s;
+    }
+  return c;
+}
+
+std::vector<double> AddMatr(const std::vector<double>& a, const std::vector<double>& b, int n) {
+  std::vector<double> c(n * n);
+  for (int i = 0; i < n * n; ++i) c[i] = a[i] + b[i];
+  return c;
+}
+
+std::vector<double> SubMatr(const std::vector<double>& a, const std::vector<double>& b, int n) {
+  std::vector<double> c(n * n);
+  for (int i = 0; i < n * n; ++i) c[i] = a[i] - b[i];
+  return c;
+}
+
+std::vector<double> SubMatrix(const std::vector<double>& m, int n, int row, int col, int size) {
+  std::vector<double> SubMatr(size * size);
+  for (int i = 0; i < size; ++i) {
+    std::copy(m.begin() + (row + i) * n + col, m.begin() + (row + i) * n + col + size, SubMatr.begin() + i * size);
+  }
+  return SubMatr;
+}
+
+void SetSubMatrix(std::vector<double>& m, const std::vector<double>& SubMatr, int n, int row, int col, int size) {
+  for (int i = 0; i < size; ++i) {
+    std::copy(SubMatr.begin() + i * size, SubMatr.begin() + (i + 1) * size, m.begin() + (row + i) * n + col);
+  }
+}
+
+int NextPowerOfTwo(int n) {
+  int r = 1;
+  while (r < n) r <<= 1;
+  return r;
+}
+
+std::vector<double> StrassenRecursive(const std::vector<double>& a, const std::vector<double>& b, int n,
+                                      int depth = 0) {
+  const int parallel_depth = 2;
+  if (n <= 128) return MultiplyNaive(a, b, n);
+
+  int k = n / 2;
+  auto a11 = SubMatrix(a, n, 0, 0, k);
+  auto a12 = SubMatrix(a, n, 0, k, k);
+  auto a21 = SubMatrix(a, n, k, 0, k);
+  auto a22 = SubMatrix(a, n, k, k, k);
+  auto b11 = SubMatrix(b, n, 0, 0, k);
+  auto b12 = SubMatrix(b, n, 0, k, k);
+  auto b21 = SubMatrix(b, n, k, 0, k);
+  auto b22 = SubMatrix(b, n, k, k, k);
+
+  std::vector<double> m1, m2, m3, m4, m5, m6, m7;
+
+  if (depth < parallel_depth) {
+    std::thread t1([&] { m1 = StrassenRecursive(AddMatr(a11, a22, k), AddMatr(b11, b22, k), k, depth + 1); });
+    std::thread t2([&] { m2 = StrassenRecursive(AddMatr(a21, a22, k), b11, k, depth + 1); });
+    std::thread t3([&] { m3 = StrassenRecursive(a11, SubMatr(b12, b22, k), k, depth + 1); });
+    std::thread t4([&] { m4 = StrassenRecursive(a22, SubMatr(b21, b11, k), k, depth + 1); });
+    std::thread t5([&] { m5 = StrassenRecursive(AddMatr(a11, a12, k), b22, k, depth + 1); });
+    std::thread t6([&] { m6 = StrassenRecursive(SubMatr(a21, a11, k), AddMatr(b11, b12, k), k, depth + 1); });
+    std::thread t7([&] { m7 = StrassenRecursive(SubMatr(a12, a22, k), AddMatr(b21, b22, k), k, depth + 1); });
+    t1.join();
+    t2.join();
+    t3.join();
+    t4.join();
+    t5.join();
+    t6.join();
+    t7.join();
+  } else {
+    m1 = StrassenRecursive(AddMatr(a11, a22, k), AddMatr(b11, b22, k), k, depth + 1);
+    m2 = StrassenRecursive(AddMatr(a21, a22, k), b11, k, depth + 1);
+    m3 = StrassenRecursive(a11, SubMatr(b12, b22, k), k, depth + 1);
+    m4 = StrassenRecursive(a22, SubMatr(b21, b11, k), k, depth + 1);
+    m5 = StrassenRecursive(AddMatr(a11, a12, k), b22, k, depth + 1);
+    m6 = StrassenRecursive(SubMatr(a21, a11, k), AddMatr(b11, b12, k), k, depth + 1);
+    m7 = StrassenRecursive(SubMatr(a12, a22, k), AddMatr(b21, b22, k), k, depth + 1);
+  }
+
+  std::vector<double> c(n * n, 0.0);
+  auto c11 = AddMatr(SubMatr(AddMatr(m1, m4, k), m5, k), m7, k);
+  auto c12 = AddMatr(m3, m5, k);
+  auto c21 = AddMatr(m2, m4, k);
+  auto c22 = AddMatr(SubMatr(AddMatr(m1, m3, k), m2, k), m6, k);
+
+  SetSubMatrix(c, c11, n, 0, 0, k);
+  SetSubMatrix(c, c12, n, 0, k, k);
+  SetSubMatrix(c, c21, n, k, 0, k);
+  SetSubMatrix(c, c22, n, k, k, k);
+  return c;
+}
+
+}  // namespace
+
+bool ParallelStrassenMpiStl::PreProcessingImpl() {
+  if (world_.rank() == 0) {
+    size_t in_cnt = task_data->inputs_count[0];
+    auto* dbl = reinterpret_cast<double*>(task_data->inputs[0]);
+    input_.assign(dbl, dbl + in_cnt);
+
+    rowsA_ = static_cast<int>(input_[0]);
+    colsA_ = static_cast<int>(input_[1]);
+    rowsB_ = static_cast<int>(input_[2]);
+    colsB_ = static_cast<int>(input_[3]);
+
+    int max_dim = std::max({rowsA_, colsA_, colsB_});
+    m_ = NextPowerOfTwo(max_dim);
+
+    std::vector<double> a(rowsA_ * colsA_);
+    std::vector<double> b(rowsB_ * colsB_);
+    size_t off = 4;
+    for (int i = 0; i < rowsA_ * colsA_; ++i) a[i] = input_[off + i];
+    off += rowsA_ * colsA_;
+    for (int i = 0; i < rowsB_ * colsB_; ++i) b[i] = input_[off + i];
+
+    a_pad_.assign(m_ * m_, 0.0);
+    b_pad_.assign(m_ * m_, 0.0);
+    for (int i = 0; i < rowsA_; ++i)
+      for (int j = 0; j < colsA_; ++j) a_pad_[(i * m_) + j] = a[(i * colsA_) + j];
+    for (int i = 0; i < rowsB_; ++i)
+      for (int j = 0; j < colsB_; ++j) b_pad_[(i * m_) + j] = b[(i * colsB_) + j];
+
+    output_.resize(2 + rowsA_ * colsB_);
+  }
+
+  boost::mpi::broadcast(world_, rowsA_, 0);
+  boost::mpi::broadcast(world_, colsA_, 0);
+  boost::mpi::broadcast(world_, rowsB_, 0);
+  boost::mpi::broadcast(world_, colsB_, 0);
+  boost::mpi::broadcast(world_, m_, 0);
+
+  if (world_.rank() != 0) {
+    a_pad_.resize(m_ * m_);
+    b_pad_.resize(m_ * m_);
+  }
+  boost::mpi::broadcast(world_, a_pad_, 0);
+  boost::mpi::broadcast(world_, b_pad_, 0);
+
+  return true;
+}
+
+bool ParallelStrassenMpiStl::ValidationImpl() {
+  bool ok = true;
+  if (world_.rank() == 0) {
+    ok = (colsA_ == rowsB_) &&
+         (task_data->inputs_count[0] >= 4 + static_cast<size_t>(rowsA_ * colsA_ + rowsB_ * colsB_));
+  }
+  boost::mpi::broadcast(world_, ok, 0);
+  return ok;
+}
+
+bool ParallelStrassenMpiStl::RunImpl() {
+  if (m_ == 1) {
+    if (world_.rank() == 0) {
+      output_[0] = static_cast<double>(rowsA_);
+      output_[1] = static_cast<double>(colsB_);
+      output_[2] = a_pad_[0] * b_pad_[0];
+    }
+    world_.barrier();
+    return true;
+  }
+
+  constexpr int kNumP = 7;
+  int half = m_ / 2;
+  auto A11 = SubMatrix(a_pad_, m_, 0, 0, half);
+  auto A12 = SubMatrix(a_pad_, m_, 0, half, half);
+  auto A21 = SubMatrix(a_pad_, m_, half, 0, half);
+  auto A22 = SubMatrix(a_pad_, m_, half, half, half);
+  auto B11 = SubMatrix(b_pad_, m_, 0, 0, half);
+  auto B12 = SubMatrix(b_pad_, m_, 0, half, half);
+  auto B21 = SubMatrix(b_pad_, m_, half, 0, half);
+  auto B22 = SubMatrix(b_pad_, m_, half, half, half);
+
+  std::vector<std::vector<double>> local_P(kNumP);
+  for (int p = world_.rank(); p < kNumP; p += world_.size()) {
+    switch (p) {
+      case 0:
+        local_P[p] = StrassenRecursive(AddMatr(A11, A22, half), AddMatr(B11, B22, half), half);
+        break;
+      case 1:
+        local_P[p] = StrassenRecursive(AddMatr(A21, A22, half), B11, half);
+        break;
+      case 2:
+        local_P[p] = StrassenRecursive(A11, SubMatr(B12, B22, half), half);
+        break;
+      case 3:
+        local_P[p] = StrassenRecursive(A22, SubMatr(B21, B11, half), half);
+        break;
+      case 4:
+        local_P[p] = StrassenRecursive(AddMatr(A11, A12, half), B22, half);
+        break;
+      case 5:
+        local_P[p] = StrassenRecursive(SubMatr(A21, A11, half), AddMatr(B11, B12, half), half);
+        break;
+      case 6:
+        local_P[p] = StrassenRecursive(SubMatr(A12, A22, half), AddMatr(B21, B22, half), half);
+        break;
+      default:
+        break;
+    }
+  }
+
+  if (world_.rank() == 0) {
+    std::vector<std::vector<double>> P(kNumP);
+    for (int p = 0; p < kNumP; ++p) {
+      int owner = p % world_.size();
+      if (owner != 0) {
+        world_.recv(owner, p, P[p]);
+      } else {
+        P[p] = std::move(local_P[p]);
+      }
+    }
+
+    std::vector<double> C_pad(m_ * m_, 0.0);
+    auto C11 = AddMatr(SubMatr(AddMatr(P[0], P[3], half), P[4], half), P[6], half);
+    auto C12 = AddMatr(P[2], P[4], half);
+    auto C21 = AddMatr(P[1], P[3], half);
+    auto C22 = AddMatr(SubMatr(AddMatr(P[0], P[2], half), P[1], half), P[5], half);
+    SetSubMatrix(C_pad, C11, m_, 0, 0, half);
+    SetSubMatrix(C_pad, C12, m_, 0, half, half);
+    SetSubMatrix(C_pad, C21, m_, half, 0, half);
+    SetSubMatrix(C_pad, C22, m_, half, half, half);
+
+    output_[0] = static_cast<double>(rowsA_);
+    output_[1] = static_cast<double>(colsB_);
+    for (int i = 0; i < rowsA_; ++i)
+      for (int j = 0; j < colsB_; ++j) output_[2 + i * colsB_ + j] = C_pad[(i * m_) + j];
+  } else {
+    for (int p = world_.rank(); p < kNumP; p += world_.size()) world_.send(0, p, local_P[p]);
+  }
+
+  world_.barrier();
+  return true;
+}
+
+bool ParallelStrassenMpiStl::PostProcessingImpl() {
+  if (world_.rank() == 0) {
+    double* out = reinterpret_cast<double*>(task_data->outputs[0]);
+    std::copy(output_.begin(), output_.end(), out);
+  }
+
+  return true;
+}
+
+}  // namespace borisov_s_strassen_all

--- a/tasks/all/borisov_s_strassen/src/ops_stl.cpp
+++ b/tasks/all/borisov_s_strassen/src/ops_stl.cpp
@@ -1,11 +1,10 @@
-#include "all/borisov_s_strassen/include/ops_all.hpp"
-
 #include <algorithm>
 #include <boost/serialization/vector.hpp>
 #include <cstddef>
 #include <thread>
 #include <vector>
 
+#include "all/borisov_s_strassen/include/ops_all.hpp"
 #include "boost/mpi/collectives/broadcast.hpp"
 
 namespace borisov_s_strassen_all {

--- a/tasks/all/borisov_s_strassen/src/ops_stl.cpp
+++ b/tasks/all/borisov_s_strassen/src/ops_stl.cpp
@@ -285,7 +285,7 @@ bool ParallelStrassenMpiStl::RunImpl() {
 bool ParallelStrassenMpiStl::PostProcessingImpl() {
   if (world_.rank() == 0) {
     auto* out = reinterpret_cast<double*>(task_data->outputs[0]);
-    std::copy(output_.begin(), output_.end(), out);
+    std::ranges::copy(output_, out);
   }
 
   return true;

--- a/tasks/all/borisov_s_strassen/src/ops_stl.cpp
+++ b/tasks/all/borisov_s_strassen/src/ops_stl.cpp
@@ -12,51 +12,62 @@ namespace {
 
 std::vector<double> MultiplyNaive(const std::vector<double>& a, const std::vector<double>& b, int n) {
   std::vector<double> c(n * n, 0.0);
-  for (int i = 0; i < n; ++i)
+  for (int i = 0; i < n; ++i) {
     for (int j = 0; j < n; ++j) {
       double s = 0.0;
-      for (int k = 0; k < n; ++k) s += a[(i * n) + k] * b[(k * n) + j];
+      for (int k = 0; k < n; ++k) {
+        s += a[(i * n) + k] * b[(k * n) + j];
+      }
       c[(i * n) + j] = s;
     }
+  }
   return c;
 }
 
 std::vector<double> AddMatr(const std::vector<double>& a, const std::vector<double>& b, int n) {
   std::vector<double> c(n * n);
-  for (int i = 0; i < n * n; ++i) c[i] = a[i] + b[i];
+  for (int i = 0; i < n * n; ++i) {
+    c[i] = a[i] + b[i];
+  }
   return c;
 }
 
 std::vector<double> SubMatr(const std::vector<double>& a, const std::vector<double>& b, int n) {
   std::vector<double> c(n * n);
-  for (int i = 0; i < n * n; ++i) c[i] = a[i] - b[i];
+  for (int i = 0; i < n * n; ++i) {
+    c[i] = a[i] - b[i];
+  }
   return c;
 }
 
 std::vector<double> SubMatrix(const std::vector<double>& m, int n, int row, int col, int size) {
-  std::vector<double> SubMatr(size * size);
+  std::vector<double> sub_matr(size * size);
   for (int i = 0; i < size; ++i) {
-    std::copy(m.begin() + (row + i) * n + col, m.begin() + (row + i) * n + col + size, SubMatr.begin() + i * size);
+    std::copy(m.begin() + (row + i) * n + col, m.begin() + (row + i) * n + col + size, sub_matr.begin() + i * size);
   }
-  return SubMatr;
+  return sub_matr;
 }
 
-void SetSubMatrix(std::vector<double>& m, const std::vector<double>& SubMatr, int n, int row, int col, int size) {
+void SetSubMatrix(std::vector<double>& m, const std::vector<double>& sub_matr, int n, int row, int col, int size) {
   for (int i = 0; i < size; ++i) {
-    std::copy(SubMatr.begin() + i * size, SubMatr.begin() + (i + 1) * size, m.begin() + (row + i) * n + col);
+    std::copy(sub_matr.begin() + i * size, sub_matr.begin() + (i + 1) * size, m.begin() + (row + i) * n + col);
   }
 }
 
 int NextPowerOfTwo(int n) {
   int r = 1;
-  while (r < n) r <<= 1;
+  while (r < n) {
+    r <<= 1;
+  }
   return r;
 }
 
 std::vector<double> StrassenRecursive(const std::vector<double>& a, const std::vector<double>& b, int n,
                                       int depth = 0) {
   const int parallel_depth = 2;
-  if (n <= 128) return MultiplyNaive(a, b, n);
+  if (n <= 128) {
+    return MultiplyNaive(a, b, n);
+  }
 
   int k = n / 2;
   auto a11 = SubMatrix(a, n, 0, 0, k);
@@ -68,7 +79,13 @@ std::vector<double> StrassenRecursive(const std::vector<double>& a, const std::v
   auto b21 = SubMatrix(b, n, k, 0, k);
   auto b22 = SubMatrix(b, n, k, k, k);
 
-  std::vector<double> m1, m2, m3, m4, m5, m6, m7;
+  std::vector<double> m1;
+  std::vector<double> m2;
+  std::vector<double> m3;
+  std::vector<double> m4;
+  std::vector<double> m5;
+  std::vector<double> m6;
+  std::vector<double> m7;
 
   if (depth < parallel_depth) {
     std::thread t1([&] { m1 = StrassenRecursive(AddMatr(a11, a22, k), AddMatr(b11, b22, k), k, depth + 1); });
@@ -127,18 +144,28 @@ bool ParallelStrassenMpiStl::PreProcessingImpl() {
     std::vector<double> a(rowsA_ * colsA_);
     std::vector<double> b(rowsB_ * colsB_);
     size_t off = 4;
-    for (int i = 0; i < rowsA_ * colsA_; ++i) a[i] = input_[off + i];
+    for (int i = 0; i < rowsA_ * colsA_; ++i) {
+      a[i] = input_[off + i];
+    }
     off += rowsA_ * colsA_;
-    for (int i = 0; i < rowsB_ * colsB_; ++i) b[i] = input_[off + i];
+    for (int i = 0; i < rowsB_ * colsB_; ++i) {
+      b[i] = input_[off + i];
+    }
 
     a_pad_.assign(m_ * m_, 0.0);
     b_pad_.assign(m_ * m_, 0.0);
-    for (int i = 0; i < rowsA_; ++i)
-      for (int j = 0; j < colsA_; ++j) a_pad_[(i * m_) + j] = a[(i * colsA_) + j];
-    for (int i = 0; i < rowsB_; ++i)
-      for (int j = 0; j < colsB_; ++j) b_pad_[(i * m_) + j] = b[(i * colsB_) + j];
+    for (int i = 0; i < rowsA_; ++i) {
+      for (int j = 0; j < colsA_; ++j) {
+        a_pad_[(i * m_) + j] = a[(i * colsA_) + j];
+      }
+    }
+    for (int i = 0; i < rowsB_; ++i) {
+      for (int j = 0; j < colsB_; ++j) {
+        b_pad_[(i * m_) + j] = b[(i * colsB_) + j];
+      }
+    }
 
-    output_.resize(2 + rowsA_ * colsB_);
+    output_.resize(2 + (rowsA_ * colsB_));
   }
 
   boost::mpi::broadcast(world_, rowsA_, 0);
@@ -160,8 +187,7 @@ bool ParallelStrassenMpiStl::PreProcessingImpl() {
 bool ParallelStrassenMpiStl::ValidationImpl() {
   bool ok = true;
   if (world_.rank() == 0) {
-    ok = (colsA_ == rowsB_) &&
-         (task_data->inputs_count[0] >= 4 + static_cast<size_t>(rowsA_ * colsA_ + rowsB_ * colsB_));
+    ok = (task_data->inputs_count[0] >= 4 + static_cast<size_t>((rowsA_ * colsA_) + (rowsB_ * colsB_)));
   }
   boost::mpi::broadcast(world_, ok, 0);
   return ok;
@@ -180,38 +206,38 @@ bool ParallelStrassenMpiStl::RunImpl() {
 
   constexpr int kNumP = 7;
   int half = m_ / 2;
-  auto A11 = SubMatrix(a_pad_, m_, 0, 0, half);
-  auto A12 = SubMatrix(a_pad_, m_, 0, half, half);
-  auto A21 = SubMatrix(a_pad_, m_, half, 0, half);
-  auto A22 = SubMatrix(a_pad_, m_, half, half, half);
-  auto B11 = SubMatrix(b_pad_, m_, 0, 0, half);
-  auto B12 = SubMatrix(b_pad_, m_, 0, half, half);
-  auto B21 = SubMatrix(b_pad_, m_, half, 0, half);
-  auto B22 = SubMatrix(b_pad_, m_, half, half, half);
+  auto a11 = SubMatrix(a_pad_, m_, 0, 0, half);
+  auto a12 = SubMatrix(a_pad_, m_, 0, half, half);
+  auto a21 = SubMatrix(a_pad_, m_, half, 0, half);
+  auto a22 = SubMatrix(a_pad_, m_, half, half, half);
+  auto b11 = SubMatrix(b_pad_, m_, 0, 0, half);
+  auto b12 = SubMatrix(b_pad_, m_, 0, half, half);
+  auto b21 = SubMatrix(b_pad_, m_, half, 0, half);
+  auto b22 = SubMatrix(b_pad_, m_, half, half, half);
 
-  std::vector<std::vector<double>> local_P(kNumP);
+  std::vector<std::vector<double>> local_p(kNumP);
   for (int p = world_.rank(); p < kNumP; p += world_.size()) {
     switch (p) {
       case 0:
-        local_P[p] = StrassenRecursive(AddMatr(A11, A22, half), AddMatr(B11, B22, half), half);
+        local_p[p] = StrassenRecursive(AddMatr(a11, a22, half), AddMatr(b11, b22, half), half);
         break;
       case 1:
-        local_P[p] = StrassenRecursive(AddMatr(A21, A22, half), B11, half);
+        local_p[p] = StrassenRecursive(AddMatr(a21, a22, half), b11, half);
         break;
       case 2:
-        local_P[p] = StrassenRecursive(A11, SubMatr(B12, B22, half), half);
+        local_p[p] = StrassenRecursive(a11, SubMatr(b12, b22, half), half);
         break;
       case 3:
-        local_P[p] = StrassenRecursive(A22, SubMatr(B21, B11, half), half);
+        local_p[p] = StrassenRecursive(a22, SubMatr(b21, b11, half), half);
         break;
       case 4:
-        local_P[p] = StrassenRecursive(AddMatr(A11, A12, half), B22, half);
+        local_p[p] = StrassenRecursive(AddMatr(a11, a12, half), b22, half);
         break;
       case 5:
-        local_P[p] = StrassenRecursive(SubMatr(A21, A11, half), AddMatr(B11, B12, half), half);
+        local_p[p] = StrassenRecursive(SubMatr(a21, a11, half), AddMatr(b11, b12, half), half);
         break;
       case 6:
-        local_P[p] = StrassenRecursive(SubMatr(A12, A22, half), AddMatr(B21, B22, half), half);
+        local_p[p] = StrassenRecursive(SubMatr(a12, a22, half), AddMatr(b21, b22, half), half);
         break;
       default:
         break;
@@ -219,32 +245,37 @@ bool ParallelStrassenMpiStl::RunImpl() {
   }
 
   if (world_.rank() == 0) {
-    std::vector<std::vector<double>> P(kNumP);
-    for (int p = 0; p < kNumP; ++p) {
-      int owner = p % world_.size();
+    std::vector<std::vector<double>> p(kNumP);
+    for (int i = 0; i < kNumP; ++i) {
+      int owner = i % world_.size();
       if (owner != 0) {
-        world_.recv(owner, p, P[p]);
+        world_.recv(owner, i, p[i]);
       } else {
-        P[p] = std::move(local_P[p]);
+        p[i] = std::move(local_p[i]);
       }
     }
 
-    std::vector<double> C_pad(m_ * m_, 0.0);
-    auto C11 = AddMatr(SubMatr(AddMatr(P[0], P[3], half), P[4], half), P[6], half);
-    auto C12 = AddMatr(P[2], P[4], half);
-    auto C21 = AddMatr(P[1], P[3], half);
-    auto C22 = AddMatr(SubMatr(AddMatr(P[0], P[2], half), P[1], half), P[5], half);
-    SetSubMatrix(C_pad, C11, m_, 0, 0, half);
-    SetSubMatrix(C_pad, C12, m_, 0, half, half);
-    SetSubMatrix(C_pad, C21, m_, half, 0, half);
-    SetSubMatrix(C_pad, C22, m_, half, half, half);
+    std::vector<double> c_pad(m_ * m_, 0.0);
+    auto c11 = AddMatr(SubMatr(AddMatr(p[0], p[3], half), p[4], half), p[6], half);
+    auto c12 = AddMatr(p[2], p[4], half);
+    auto c21 = AddMatr(p[1], p[3], half);
+    auto c22 = AddMatr(SubMatr(AddMatr(p[0], p[2], half), p[1], half), p[5], half);
+    SetSubMatrix(c_pad, c11, m_, 0, 0, half);
+    SetSubMatrix(c_pad, c12, m_, 0, half, half);
+    SetSubMatrix(c_pad, c21, m_, half, 0, half);
+    SetSubMatrix(c_pad, c22, m_, half, half, half);
 
     output_[0] = static_cast<double>(rowsA_);
     output_[1] = static_cast<double>(colsB_);
-    for (int i = 0; i < rowsA_; ++i)
-      for (int j = 0; j < colsB_; ++j) output_[2 + i * colsB_ + j] = C_pad[(i * m_) + j];
+    for (int i = 0; i < rowsA_; ++i) {
+      for (int j = 0; j < colsB_; ++j) {
+        output_[2 + (i * colsB_) + j] = c_pad[(i * m_) + j];
+      }
+    }
   } else {
-    for (int p = world_.rank(); p < kNumP; p += world_.size()) world_.send(0, p, local_P[p]);
+    for (int p = world_.rank(); p < kNumP; p += world_.size()) {
+      world_.send(0, p, local_p[p]);
+    }
   }
 
   world_.barrier();
@@ -253,7 +284,7 @@ bool ParallelStrassenMpiStl::RunImpl() {
 
 bool ParallelStrassenMpiStl::PostProcessingImpl() {
   if (world_.rank() == 0) {
-    double* out = reinterpret_cast<double*>(task_data->outputs[0]);
+    auto* out = reinterpret_cast<double*>(task_data->outputs[0]);
     std::copy(output_.begin(), output_.end(), out);
   }
 


### PR DESCRIPTION
Параллелизация реализована в два уровня:

1. MPI-уровень
Корневой процесс раскладывает задачу верхнего уровня на семь
независимых произведений P₁…P₇ и распределяет их между
MPI-процессами по формуле owner = Pi % world_size.
Каждый процесс вычисляет только свои Pᵢ и передаёт результат
обратно root-процессу. 
Root-процесс получает все семь Pᵢ, формирует квадранты C₁₁…C₂₂,
собирает итоговую матрицу C.


2. STL-уровень
Внутри каждого MPI-процесса та же рекурсивная функция
StrassenRecursive с использованием std::thread
одновременного вычисления M₁…M₇