### PR TITLE
Шульпин Илья. Вариант 23. Технология MPI + STL. Построение выпуклой оболочки – проход Джарвиса.

### DIFF
--- a/tasks/all/shulpin_i_jarvis_passage/func_tests/main.cpp
+++ b/tasks/all/shulpin_i_jarvis_passage/func_tests/main.cpp
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <mpi.h>
 #include <vector>
 
 #include "all/shulpin_i_jarvis_passage/include/ops_all.hpp"

--- a/tasks/all/shulpin_i_jarvis_passage/func_tests/main.cpp
+++ b/tasks/all/shulpin_i_jarvis_passage/func_tests/main.cpp
@@ -1,8 +1,8 @@
 #include <gtest/gtest.h>
+#include <mpi.h>
 
 #include <cmath>
 #include <cstddef>
-#include <mpi.h>
 #include <vector>
 
 #include "all/shulpin_i_jarvis_passage/include/ops_all.hpp"

--- a/tasks/all/shulpin_i_jarvis_passage/func_tests/main.cpp
+++ b/tasks/all/shulpin_i_jarvis_passage/func_tests/main.cpp
@@ -1,0 +1,243 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+#include "all/shulpin_i_jarvis_passage/include/ops_all.hpp"
+#include "all/shulpin_i_jarvis_passage/include/test_modules.hpp"
+
+TEST(shulpin_i_jarvis_all, square_with_point) {
+  int rank{};
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  std::vector<shulpin_i_jarvis_all::Point> input;
+  std::vector<shulpin_i_jarvis_all::Point> expected;
+
+  if (rank == 0) {
+    input = {{0, 0}, {2, 0}, {2, 2}, {0, 2}, {1, 1}};
+    expected = {{0, 0}, {2, 0}, {2, 2}, {0, 2}};
+  }
+
+  shulpin_all_test_module::MainTestBody(input, expected);
+}
+
+TEST(shulpin_i_jarvis_all, ox_line) {
+  int rank{};
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  std::vector<shulpin_i_jarvis_all::Point> input;
+  std::vector<shulpin_i_jarvis_all::Point> expected;
+
+  if (rank == 0) {
+    input = {{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}};
+    expected = {{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}};
+  }
+
+  shulpin_all_test_module::MainTestBody(input, expected);
+}
+
+TEST(shulpin_i_jarvis_all, octagone) {
+  int rank{};
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  std::vector<shulpin_i_jarvis_all::Point> input;
+  std::vector<shulpin_i_jarvis_all::Point> expected;
+
+  if (rank == 0) {
+    input = {{1, 0}, {2, 0}, {3, 1}, {3, 2}, {2, 3}, {1, 3}, {0, 2}, {0, 1}};
+    expected = {{0, 1}, {1, 0}, {2, 0}, {3, 1}, {3, 2}, {2, 3}, {1, 3}, {0, 2}};
+  }
+
+  shulpin_all_test_module::MainTestBody(input, expected);
+}
+
+TEST(shulpin_i_jarvis_all, repeated_points) {
+  int rank{};
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  std::vector<shulpin_i_jarvis_all::Point> input;
+  std::vector<shulpin_i_jarvis_all::Point> expected;
+
+  if (rank == 0) {
+    input = {{0, 0}, {2, 0}, {2, 2}, {0, 2}, {2, 0}, {0, 0}};
+    expected = {{0, 0}, {2, 0}, {2, 2}, {0, 2}};
+  }
+
+  shulpin_all_test_module::MainTestBody(input, expected);
+}
+
+TEST(shulpin_i_jarvis_all, real_case) {
+  int rank{};
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  std::vector<shulpin_i_jarvis_all::Point> input;
+  std::vector<shulpin_i_jarvis_all::Point> expected;
+
+  if (rank == 0) {
+    input = {{1, 1}, {3, 2}, {5, 1}, {4, 3}, {2, 4}, {1, 3}, {3, 3}};
+    expected = {{1, 1}, {5, 1}, {4, 3}, {2, 4}, {1, 3}};
+  }
+
+  shulpin_all_test_module::MainTestBody(input, expected);
+}
+
+TEST(shulpin_i_jarvis_all, star_case) {
+  int rank{};
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  std::vector<shulpin_i_jarvis_all::Point> input;
+  std::vector<shulpin_i_jarvis_all::Point> expected;
+
+  if (rank == 0) {
+    // clang-format off
+    input = {
+        {0.0, 3.0},
+        {1.0, 1.0},
+        {3.0, 1.0},
+        {1.5, -0.5},
+        {2.5, -3.0},
+        {0.0, -1.5},
+        {-2.5, -3.0},
+        {-1.5, -0.5},
+        {-3.0, 1.0},
+        {-1.0, 1.0},
+        {0.0, 3.0}};
+    expected = {
+        {1, 1},
+        {5, 1},
+        {4, 3},
+        {2, 4},
+        {1, 3}};
+    // clang-format on
+  }
+
+  shulpin_all_test_module::MainTestBody(input, expected);
+}
+
+TEST(shulpin_i_jarvis_all, one_point_validation_false) {
+  int rank{};
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  std::vector<shulpin_i_jarvis_all::Point> input;
+  std::vector<shulpin_i_jarvis_all::Point> expected;
+
+  if (rank == 0) {
+    input = {{0, 0}};
+    expected = {{0, 0}};
+  }
+
+  shulpin_all_test_module::TestBodyFalse(input, expected);
+}
+
+TEST(shulpin_i_jarvis_all, three_points_validation_false) {
+  int rank{};
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  std::vector<shulpin_i_jarvis_all::Point> input;
+  std::vector<shulpin_i_jarvis_all::Point> expected;
+
+  if (rank == 0) {
+    input = {{1, 1}, {2, 2}};
+    expected = {{1, 1}, {2, 2}};
+  }
+
+  shulpin_all_test_module::TestBodyFalse(input, expected);
+}
+
+TEST(shulpin_i_jarvis_all, zero_points_validation_false) {
+  int rank{};
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  std::vector<shulpin_i_jarvis_all::Point> input;
+  std::vector<shulpin_i_jarvis_all::Point> expected;
+
+  if (rank == 0) {
+    input = {};
+    expected = {};
+  }
+
+  shulpin_all_test_module::TestBodyFalse(input, expected);
+}
+
+TEST(shulpin_i_jarvis_all, circle_r10_p10) {
+  int rank{};
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  std::vector<shulpin_i_jarvis_all::Point> input;
+  std::vector<shulpin_i_jarvis_all::Point> expected;
+
+  size_t num_points = 10;
+
+  if (rank == 0) {
+    shulpin_i_jarvis_all::Point center{0, 0};
+
+    double radius = 10.0;
+
+    input = shulpin_all_test_module::GeneratePointsInCircle(num_points, center, radius);
+    expected = input;
+  }
+  shulpin_all_test_module::TestBodyRandomCircle(input, expected, num_points);
+}
+
+TEST(shulpin_i_jarvis_all, circle_r10_p20) {
+  int rank{};
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  std::vector<shulpin_i_jarvis_all::Point> input;
+  std::vector<shulpin_i_jarvis_all::Point> expected;
+
+  size_t num_points = 20;
+
+  if (rank == 0) {
+    shulpin_i_jarvis_all::Point center{0, 0};
+
+    double radius = 10.0;
+
+    input = shulpin_all_test_module::GeneratePointsInCircle(num_points, center, radius);
+    expected = input;
+  }
+  shulpin_all_test_module::TestBodyRandomCircle(input, expected, num_points);
+}
+
+TEST(shulpin_i_jarvis_all, random_10_points) {
+  int rank{};
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  std::vector<shulpin_i_jarvis_all::Point> input;
+  std::vector<shulpin_i_jarvis_all::Point> expected;
+
+  size_t num_points = 10;
+
+  if (rank == 0) {
+    input = shulpin_all_test_module::GenerateRandomPoints(num_points);
+    expected = shulpin_all_test_module::ComputeConvexHull(input);
+  }
+
+  shulpin_all_test_module::RandomTestBody(input, expected);
+}
+
+TEST(shulpin_i_jarvis_all, random_50_points) {
+  int rank{};
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  std::vector<shulpin_i_jarvis_all::Point> input;
+  std::vector<shulpin_i_jarvis_all::Point> expected;
+
+  size_t num_points = 50;
+
+  if (rank == 0) {
+    input = shulpin_all_test_module::GenerateRandomPoints(num_points);
+    expected = shulpin_all_test_module::ComputeConvexHull(input);
+  }
+
+  shulpin_all_test_module::RandomTestBody(input, expected);
+}
+
+TEST(shulpin_i_jarvis_all, random_100_points) {
+  int rank{};
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  std::vector<shulpin_i_jarvis_all::Point> input;
+  std::vector<shulpin_i_jarvis_all::Point> expected;
+
+  size_t num_points = 100;
+
+  if (rank == 0) {
+    input = shulpin_all_test_module::GenerateRandomPoints(num_points);
+    expected = shulpin_all_test_module::ComputeConvexHull(input);
+  }
+
+  shulpin_all_test_module::RandomTestBody(input, expected);
+}

--- a/tasks/all/shulpin_i_jarvis_passage/include/ops_all.hpp
+++ b/tasks/all/shulpin_i_jarvis_passage/include/ops_all.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <mpi.h>
+
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace shulpin_i_jarvis_all {
+
+struct Point {
+  double x, y;
+  Point() : x(0), y(0) {}
+  Point(double x_coordinate, double y_coordinate) : x(x_coordinate), y(y_coordinate) {}
+
+  bool operator==(const Point& other) const { return x == other.x && y == other.y; }
+};
+
+struct PointHash {
+  size_t operator()(const shulpin_i_jarvis_all::Point& p) const {
+    size_t hx = std::hash<double>{}(p.x);
+    size_t hy = std::hash<double>{}(p.y);
+    return hx ^ (hy << 1);
+  }
+};
+
+struct PointEqual {
+  bool operator()(const Point& a, const Point& b) const { return a.x == b.x && a.y == b.y; }
+};
+
+class JarvisSequential : public ppc::core::Task {
+ public:
+  explicit JarvisSequential(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+  static void MakeJarvisPassage(std::vector<shulpin_i_jarvis_all::Point>& input,
+                                std::vector<shulpin_i_jarvis_all::Point>& output);
+
+ private:
+  std::vector<shulpin_i_jarvis_all::Point> input_seq_, output_seq_;
+};
+
+class JarvisALLParallel : public ppc::core::Task {
+ public:
+  explicit JarvisALLParallel(std::shared_ptr<ppc::core::TaskData> task_data) : Task(std::move(task_data)) {
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank_);
+    MPI_Comm_size(MPI_COMM_WORLD, &world_size_);
+  }
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+  void MakeJarvisPassageALL(std::vector<shulpin_i_jarvis_all::Point>& input,
+                            std::vector<shulpin_i_jarvis_all::Point>& output);
+
+ private:
+  int rank_;
+  int world_size_;
+  std::vector<shulpin_i_jarvis_all::Point> input_stl_, output_stl_;
+};
+
+}  // namespace shulpin_i_jarvis_all

--- a/tasks/all/shulpin_i_jarvis_passage/include/ops_all.hpp
+++ b/tasks/all/shulpin_i_jarvis_passage/include/ops_all.hpp
@@ -56,7 +56,7 @@ class JarvisALLParallel : public ppc::core::Task {
   bool RunImpl() override;
   bool PostProcessingImpl() override;
   void MakeJarvisPassageALL(std::vector<shulpin_i_jarvis_all::Point>& input,
-                            std::vector<shulpin_i_jarvis_all::Point>& output);
+                            std::vector<shulpin_i_jarvis_all::Point>& output) const;
 
  private:
   int rank_;

--- a/tasks/all/shulpin_i_jarvis_passage/include/ops_all.hpp
+++ b/tasks/all/shulpin_i_jarvis_passage/include/ops_all.hpp
@@ -56,7 +56,7 @@ class JarvisALLParallel : public ppc::core::Task {
   bool RunImpl() override;
   bool PostProcessingImpl() override;
   void MakeJarvisPassageALL(std::vector<shulpin_i_jarvis_all::Point>& input,
-                            std::vector<shulpin_i_jarvis_all::Point>& output) const;
+                            std::vector<shulpin_i_jarvis_all::Point>& output);
 
  private:
   int rank_;

--- a/tasks/all/shulpin_i_jarvis_passage/include/test_modules.hpp
+++ b/tasks/all/shulpin_i_jarvis_passage/include/test_modules.hpp
@@ -1,0 +1,33 @@
+#include <cstddef>
+#include <vector>
+
+#include "all/shulpin_i_jarvis_passage/include/ops_all.hpp"
+
+namespace shulpin_all_test_module {
+void VerifyResults(const std::vector<shulpin_i_jarvis_all::Point> &expected,
+                   const std::vector<shulpin_i_jarvis_all::Point> &result_tbb);
+
+void MainTestBody(std::vector<shulpin_i_jarvis_all::Point> &input, std::vector<shulpin_i_jarvis_all::Point> &expected);
+
+std::vector<shulpin_i_jarvis_all::Point> GeneratePointsInCircle(size_t num_points,
+                                                                const shulpin_i_jarvis_all::Point &center,
+                                                                double radius);
+
+void TestBodyRandomCircle(std::vector<shulpin_i_jarvis_all::Point> &input,
+                          std::vector<shulpin_i_jarvis_all::Point> &expected, size_t &num_points);
+
+void TestBodyFalse(std::vector<shulpin_i_jarvis_all::Point> &input, std::vector<shulpin_i_jarvis_all::Point> &expected);
+
+int Orientation(const shulpin_i_jarvis_all::Point &p, const shulpin_i_jarvis_all::Point &q,
+                const shulpin_i_jarvis_all::Point &r);
+
+std::vector<shulpin_i_jarvis_all::Point> ComputeConvexHull(std::vector<shulpin_i_jarvis_all::Point> raw_points);
+
+std::vector<shulpin_i_jarvis_all::Point> GenerateRandomPoints(size_t num_points);
+
+void RandomTestBody(std::vector<shulpin_i_jarvis_all::Point> &input,
+                    std::vector<shulpin_i_jarvis_all::Point> &expected);
+
+std::vector<shulpin_i_jarvis_all::Point> PerfRandomGenerator(size_t num_points, int from, int to);
+
+}  // namespace shulpin_all_test_module

--- a/tasks/all/shulpin_i_jarvis_passage/perf_tests/main.cpp
+++ b/tasks/all/shulpin_i_jarvis_passage/perf_tests/main.cpp
@@ -1,0 +1,117 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "all/shulpin_i_jarvis_passage/include/ops_all.hpp"
+#include "all/shulpin_i_jarvis_passage/include/test_modules.hpp"
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "mpi.h"
+
+constexpr int k_ = 100;
+constexpr int kBound = 1000;
+
+TEST(shulpin_i_jarvis_all, test_pipeline_run) {
+  int rank{};
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  size_t num_points = 5000000;
+
+  std::vector<shulpin_i_jarvis_all::Point> hull = {};
+  std::vector<shulpin_i_jarvis_all::Point> input = {};
+
+  if (rank == 0) {
+    hull = {{-kBound, -kBound}, {-kBound, kBound}, {kBound, kBound}, {kBound, -kBound}};
+    input = shulpin_all_test_module::PerfRandomGenerator(num_points, -kBound + k_, kBound - k_);
+    input.insert(input.end(), hull.begin(), hull.end());
+  }
+
+  std::vector<shulpin_i_jarvis_all::Point> out(input.size());
+
+  auto task_data_par = std::make_shared<ppc::core::TaskData>();
+
+  if (rank == 0) {
+    task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_par->inputs_count.emplace_back(input.size());
+    task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_par->outputs_count.emplace_back(out.size());
+  }
+  auto test_task_all = std::make_shared<shulpin_i_jarvis_all::JarvisALLParallel>(task_data_par);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_all);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+
+  if (rank == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
+    for (size_t i = 0; i < hull.size(); ++i) {
+      EXPECT_EQ(hull[i].x, out[i].x);
+      EXPECT_EQ(hull[i].y, out[i].y);
+    }
+  }
+}
+
+TEST(shulpin_i_jarvis_all, test_task_run) {
+  int rank{};
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  size_t num_points = 5000000;
+
+  std::vector<shulpin_i_jarvis_all::Point> hull = {};
+  std::vector<shulpin_i_jarvis_all::Point> input = {};
+
+  if (rank == 0) {
+    hull = {{-kBound, -kBound}, {-kBound, kBound}, {kBound, kBound}, {kBound, -kBound}};
+    input = shulpin_all_test_module::PerfRandomGenerator(num_points, -kBound + k_, kBound - k_);
+    input.insert(input.end(), hull.begin(), hull.end());
+  }
+
+  std::vector<shulpin_i_jarvis_all::Point> out(input.size());
+
+  auto task_data_par = std::make_shared<ppc::core::TaskData>();
+
+  if (rank == 0) {
+    task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_par->inputs_count.emplace_back(input.size());
+    task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_par->outputs_count.emplace_back(out.size());
+  }
+  auto test_task_all = std::make_shared<shulpin_i_jarvis_all::JarvisALLParallel>(task_data_par);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_all);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+
+  if (rank == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
+    for (size_t i = 0; i < hull.size(); ++i) {
+      EXPECT_EQ(hull[i].x, out[i].x);
+      EXPECT_EQ(hull[i].y, out[i].y);
+    }
+  }
+}

--- a/tasks/all/shulpin_i_jarvis_passage/src/ops_all.cpp
+++ b/tasks/all/shulpin_i_jarvis_passage/src/ops_all.cpp
@@ -131,7 +131,7 @@ bool shulpin_i_jarvis_all::JarvisSequential::PostProcessingImpl() {
   return true;
 }
 
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+// NOLINTNEXTLINE(readability-function-cognitive-complexity, readability-make-member-function-const)
 void shulpin_i_jarvis_all::JarvisALLParallel::MakeJarvisPassageALL(
     std::vector<shulpin_i_jarvis_all::Point>& input_jar, std::vector<shulpin_i_jarvis_all::Point>& output_jar) {
   output_jar.clear();
@@ -141,7 +141,7 @@ void shulpin_i_jarvis_all::JarvisALLParallel::MakeJarvisPassageALL(
   MPI_Type_commit(&mpi_point);
 
   size_t n = input_jar.size();
-  MPI_Bcast(&n, 1, MPI_UnSIGnED_LOnG, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&n, 1, MPI_UNSIGNED_LONG, 0, MPI_COMM_WORLD);
 
   if (rank_ != 0) {
     input_jar.resize(n);
@@ -158,7 +158,7 @@ void shulpin_i_jarvis_all::JarvisALLParallel::MakeJarvisPassageALL(
       }
     }
   }
-  MPI_Bcast(&most_left, 1, MPI_UnSIGnED_LOnG, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&most_left, 1, MPI_UNSIGNED_LONG, 0, MPI_COMM_WORLD);
   Point min_point = input_jar[most_left];
 
   std::vector<int> counts(world_size_);
@@ -184,7 +184,7 @@ void shulpin_i_jarvis_all::JarvisALLParallel::MakeJarvisPassageALL(
 
   Point prev_point = min_point;
   Point next_point;
-  int num_threads = ppc::util::GetPPCnumThreads();
+  int num_threads = ppc::util::GetPPCNumThreads();
 
   bool done = false;
 

--- a/tasks/all/shulpin_i_jarvis_passage/src/ops_all.cpp
+++ b/tasks/all/shulpin_i_jarvis_passage/src/ops_all.cpp
@@ -1,10 +1,11 @@
 #include "all/shulpin_i_jarvis_passage/include/ops_all.hpp"
 
+#include <mpi.h>
+
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <cstring>
-#include <mpi.h>
 #include <thread>
 #include <unordered_set>
 #include <vector>
@@ -46,7 +47,8 @@ shulpin_i_jarvis_all::Point FindLocalCandidate(const shulpin_i_jarvis_all::Point
   };
 
   std::vector<std::thread> threads;
-  threads.reserve(num_threads); 
+  threads.reserve(num_threads);
+
   for (int t = 0; t < num_threads; ++t) {
     threads.emplace_back(worker, t);
   }

--- a/tasks/all/shulpin_i_jarvis_passage/src/ops_all.cpp
+++ b/tasks/all/shulpin_i_jarvis_passage/src/ops_all.cpp
@@ -147,7 +147,7 @@ void shulpin_i_jarvis_all::JarvisALLParallel::MakeJarvisPassageALL(
     input_jar.resize(n);
   }
 
-  MPI_Bcast(input_jar.data(), n, mpi_point, 0, MPI_COMM_WORLD);
+  MPI_Bcast(input_jar.data(), static_cast<int>(n), mpi_point, 0, MPI_COMM_WORLD);
 
   size_t most_left = 0;
   if (rank_ == 0) {

--- a/tasks/all/shulpin_i_jarvis_passage/src/ops_all.cpp
+++ b/tasks/all/shulpin_i_jarvis_passage/src/ops_all.cpp
@@ -1,0 +1,385 @@
+#include "all/shulpin_i_jarvis_passage/include/ops_all.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <condition_variable>
+#include <cstddef>
+#include <cstring>
+#include <mutex>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
+#include "core/util/include/util.hpp"
+
+namespace {
+int Orientation(const shulpin_i_jarvis_all::Point& p, const shulpin_i_jarvis_all::Point& q,
+                const shulpin_i_jarvis_all::Point& r) {
+  double val = ((q.y - p.y) * (r.x - q.x)) - ((q.x - p.x) * (r.y - q.y));
+  if (std::fabs(val) < 1e-9) {
+    return 0;
+  }
+  return (val > 0) ? 1 : 2;
+}
+
+shulpin_i_jarvis_all::Point findLocalCandidate(const shulpin_i_jarvis_all::Point& current,
+                                               const std::vector<shulpin_i_jarvis_all::Point>& points,
+                                               int num_threads) {
+  std::vector<shulpin_i_jarvis_all::Point> local_cand(num_threads, points.front());
+
+  auto worker = [&](int tid) {
+    size_t chunk = points.size() / num_threads;
+    size_t start = tid * chunk;
+    size_t end = (tid == num_threads - 1 ? points.size() : start + chunk);
+    shulpin_i_jarvis_all::Point& candidate = local_cand[tid];
+    for (size_t i = start; i < end; ++i) {
+      const auto& p = points[i];
+      if (p == current) continue;
+      double cross = ((p.y - current.y) * (candidate.x - current.x)) - ((p.x - current.x) * (candidate.y - current.y));
+      double d_p = std::pow(p.x - current.x, 2) + std::pow(p.y - current.y, 2);
+      double d_c = std::pow(candidate.x - current.x, 2) + std::pow(candidate.y - current.y, 2);
+      if (cross > 0 || (cross == 0 && d_p > d_c)) {
+        candidate = p;
+      }
+    }
+  };
+
+  std::vector<std::thread> threads;
+  for (int t = 0; t < num_threads; ++t) {
+    threads.emplace_back(worker, t);
+  }
+  for (auto& th : threads) {
+    if (th.joinable()) th.join();
+  }
+
+  shulpin_i_jarvis_all::Point best = local_cand[0];
+  for (int t = 1; t < num_threads; ++t) {
+    const auto& cand = local_cand[t];
+    double cross = ((cand.y - current.y) * (best.x - current.x)) - ((cand.x - current.x) * (best.y - current.y));
+    double d_c = std::pow(cand.x - current.x, 2) + std::pow(cand.y - current.y, 2);
+    double d_b = std::pow(best.x - current.x, 2) + std::pow(best.y - current.y, 2);
+    if (cross > 0 || (cross == 0 && d_c > d_b)) {
+      best = cand;
+    }
+  }
+  return best;
+}
+
+}  // namespace
+
+void shulpin_i_jarvis_all::JarvisSequential::MakeJarvisPassage(std::vector<shulpin_i_jarvis_all::Point>& input_jar,
+                                                               std::vector<shulpin_i_jarvis_all::Point>& output_jar) {
+  size_t total = input_jar.size();
+  output_jar.clear();
+
+  size_t start = 0;
+  for (size_t i = 1; i < total; ++i) {
+    if (input_jar[i].x < input_jar[start].x ||
+        (input_jar[i].x == input_jar[start].x && input_jar[i].y < input_jar[start].y)) {
+      start = i;
+    }
+  }
+
+  size_t active = start;
+  do {
+    output_jar.emplace_back(input_jar[active]);
+    size_t candidate = (active + 1) % total;
+
+    for (size_t index = 0; index < total; ++index) {
+      if (Orientation(input_jar[active], input_jar[index], input_jar[candidate]) == 2) {
+        candidate = index;
+      }
+    }
+
+    active = candidate;
+  } while (active != start);
+}
+
+bool shulpin_i_jarvis_all::JarvisSequential::PreProcessingImpl() {
+  std::vector<shulpin_i_jarvis_all::Point> tmp_input;
+
+  auto* tmp_data = reinterpret_cast<shulpin_i_jarvis_all::Point*>(task_data->inputs[0]);
+  size_t tmp_size = task_data->inputs_count[0];
+  tmp_input.assign(tmp_data, tmp_data + tmp_size);
+
+  input_seq_ = tmp_input;
+
+  size_t output_size = task_data->outputs_count[0];
+  output_seq_.resize(output_size);
+
+  return true;
+}
+
+bool shulpin_i_jarvis_all::JarvisSequential::ValidationImpl() {
+  return (task_data->inputs_count[0] >= 3) && (task_data->inputs[0] != nullptr);
+}
+
+bool shulpin_i_jarvis_all::JarvisSequential::RunImpl() {
+  MakeJarvisPassage(input_seq_, output_seq_);
+  return true;
+}
+
+bool shulpin_i_jarvis_all::JarvisSequential::PostProcessingImpl() {
+  auto* result = reinterpret_cast<Point*>(task_data->outputs[0]);
+  std::ranges::copy(output_seq_.begin(), output_seq_.end(), result);
+  return true;
+}
+
+// this whole nolint block is for NOLINT(readability-function-cognitive-complexity). using it as end-of-line comment
+// doesn't work. all other linter warnings have been resolved
+// NOLINTBEGIN
+/*
+void shulpin_i_jarvis_all::JarvisSTLParallel::MakeJarvisPassageSTL(
+    std::vector<shulpin_i_jarvis_all::Point>& input_jar, std::vector<shulpin_i_jarvis_all::Point>& output_jar) {
+  output_jar.clear();
+
+  std::unordered_set<Point, PointHash, PointEqual> unique_points;
+
+  size_t most_left = 0;
+  for (size_t i = 1; i < input_jar.size(); ++i) {
+    if (input_jar[i].x < input_jar[most_left].x ||
+        (input_jar[i].x == input_jar[most_left].x && input_jar[i].y < input_jar[most_left].y)) {
+      most_left = i;
+    }
+  }
+
+  const Point& min_point = input_jar[most_left];
+  std::vector<Point> convex_hull = {min_point};
+  Point prev_point = min_point;
+  Point next_point;
+
+  int num_threads = ppc::util::GetPPCNumThreads();
+  int chunk_size = static_cast<int>(input_jar.size() / num_threads);
+
+  std::vector<std::thread> threads;
+  std::vector<Point> candidates(num_threads, input_jar[0]);
+  std::vector<bool> thread_ready(num_threads, false);
+  std::vector<bool> thread_done(num_threads, false);
+  std::mutex mtx;
+  std::condition_variable cv;
+  bool stop = false;
+
+  auto findNextPointThread = [&](int tid) {
+    while (true) {
+      std::unique_lock<std::mutex> lock(mtx);
+      cv.wait(lock, [&] { return thread_ready[tid] || stop; });
+
+      if (stop) {
+        return;
+      }
+
+      int start = tid * chunk_size;
+      int end = (tid == num_threads - 1) ? static_cast<int>(input_jar.size()) : (tid + 1) * chunk_size;
+      Point candidate = input_jar[start];
+
+      for (int i = start; i < end; ++i) {
+        const auto& point = input_jar[i];
+        if (point == prev_point) {
+          continue;
+        }
+
+        double cross_product = ((point.y - prev_point.y) * (candidate.x - prev_point.x)) -
+                               ((point.x - prev_point.x) * (candidate.y - prev_point.y));
+        double dist1 = std::pow(point.x - prev_point.x, 2) + std::pow(point.y - prev_point.y, 2);
+        double dist2 = std::pow(candidate.x - prev_point.x, 2) + std::pow(candidate.y - prev_point.y, 2);
+
+        if (cross_product > 0 || (cross_product == 0 && dist1 > dist2)) {
+          candidate = point;
+        }
+      }
+
+      candidates[tid] = candidate;
+      thread_ready[tid] = false;
+      thread_done[tid] = true;
+      cv.notify_all();
+    }
+  };
+
+  for (int i = 0; i < num_threads; ++i) {
+    threads.emplace_back(findNextPointThread, i);
+  }
+
+  do {
+    next_point = input_jar[0];
+
+    {
+      std::unique_lock<std::mutex> lock(mtx);
+      for (int i = 0; i < num_threads; ++i) {
+        thread_ready[i] = true;
+        thread_done[i] = false;
+      }
+    }
+    cv.notify_all();
+
+    {
+      std::unique_lock<std::mutex> lock(mtx);
+      cv.wait(lock, [&] {
+        return std::ranges::all_of(thread_done.begin(), thread_done.end(), [](bool done) { return done; });
+      });
+    }
+
+    for (const auto& candidate : candidates) {
+      double cross_product = ((candidate.y - prev_point.y) * (next_point.x - prev_point.x)) -
+                             ((candidate.x - prev_point.x) * (next_point.y - prev_point.y));
+      double dist1 = std::pow(candidate.x - prev_point.x, 2) + std::pow(candidate.y - prev_point.y, 2);
+      double dist2 = std::pow(next_point.x - prev_point.x, 2) + std::pow(next_point.y - prev_point.y, 2);
+      if (cross_product > 0 || (cross_product == 0 && dist1 > dist2)) {
+        next_point = candidate;
+      }
+    }
+
+    if (unique_points.find(next_point) == unique_points.end()) {
+      output_jar.push_back(next_point);
+      unique_points.insert(next_point);
+    }
+
+    prev_point = next_point;
+
+  } while (next_point != min_point);
+
+  {
+    std::unique_lock<std::mutex> lock(mtx);
+    stop = true;
+    cv.notify_all();
+  }
+
+  for (auto& thread : threads) {
+    if (thread.joinable()) {
+      thread.join();
+    }
+  }
+}
+*/
+// NOLINTEND
+void shulpin_i_jarvis_all::JarvisALLParallel::MakeJarvisPassageALL(
+    std::vector<shulpin_i_jarvis_all::Point>& input_jar, std::vector<shulpin_i_jarvis_all::Point>& output_jar) {
+  output_jar.clear();
+
+  MPI_Datatype MPI_POINT;
+  MPI_Type_contiguous(2, MPI_DOUBLE, &MPI_POINT);
+  MPI_Type_commit(&MPI_POINT);
+
+  size_t N = input_jar.size();
+  MPI_Bcast(&N, 1, MPI_UNSIGNED_LONG, 0, MPI_COMM_WORLD);
+
+  if (rank_ != 0) {
+    input_jar.resize(N);
+  }
+
+  MPI_Bcast(input_jar.data(), N, MPI_POINT, 0, MPI_COMM_WORLD);
+
+  size_t most_left = 0;
+  if (rank_ == 0) {
+    for (size_t i = 1; i < N; ++i) {
+      if (input_jar[i].x < input_jar[most_left].x ||
+          (input_jar[i].x == input_jar[most_left].x && input_jar[i].y < input_jar[most_left].y)) {
+        most_left = i;
+      }
+    }
+  }
+  MPI_Bcast(&most_left, 1, MPI_UNSIGNED_LONG, 0, MPI_COMM_WORLD);
+  Point min_point = input_jar[most_left];
+
+  std::vector<int> counts(world_size_), displs(world_size_);
+  int base = static_cast<int>(N / world_size_);
+  int rem = static_cast<int>(N % world_size_);
+  int offset = 0;
+  for (int i = 0; i < world_size_; ++i) {
+    counts[i] = base + (i < rem ? 1 : 0);
+    displs[i] = offset;
+    offset += counts[i];
+  }
+
+  std::vector<Point> local_points(counts[rank_]);
+  MPI_Scatterv(input_jar.data(), counts.data(), displs.data(), MPI_POINT, local_points.data(), counts[rank_], MPI_POINT,
+               0, MPI_COMM_WORLD);
+
+  std::unordered_set<Point, PointHash, PointEqual> unique_points;
+  if (rank_ == 0) {
+    output_jar.push_back(min_point);
+    unique_points.insert(min_point);
+  }
+
+  Point prev_point = min_point;
+  Point next_point;
+  int num_threads = ppc::util::GetPPCNumThreads();
+
+  bool done = false;
+
+  do {
+    MPI_Bcast(&prev_point, 1, MPI_POINT, 0, MPI_COMM_WORLD);
+
+    Point local_candidate = findLocalCandidate(prev_point, local_points, num_threads);
+
+    std::vector<Point> all_cand;
+    if (rank_ == 0) {
+      all_cand.resize(world_size_);
+    }
+    MPI_Gather(&local_candidate, 1, MPI_POINT, all_cand.data(), 1, MPI_POINT, 0, MPI_COMM_WORLD);
+
+    if (rank_ == 0) {
+      next_point = all_cand[0];
+      for (int i = 1; i < world_size_; ++i) {
+        const auto& cand = all_cand[i];
+        double cross = ((cand.y - prev_point.y) * (next_point.x - prev_point.x)) -
+                       ((cand.x - prev_point.x) * (next_point.y - prev_point.y));
+        double d_c = std::pow(cand.x - prev_point.x, 2) + std::pow(cand.y - prev_point.y, 2);
+        double d_n = std::pow(next_point.x - prev_point.x, 2) + std::pow(next_point.y - prev_point.y, 2);
+        if (cross > 0 || (cross == 0 && d_c > d_n)) {
+          next_point = cand;
+        }
+      }
+
+      done = (next_point == min_point);
+
+      if (!done && unique_points.find(next_point) == unique_points.end()) {
+        output_jar.push_back(next_point);
+        unique_points.insert(next_point);
+      }
+    }
+
+    MPI_Bcast(&next_point, 1, MPI_POINT, 0, MPI_COMM_WORLD);
+    MPI_Bcast(&done, 1, MPI_C_BOOL, 0, MPI_COMM_WORLD);
+
+    prev_point = next_point;
+
+  } while (!done);
+
+  MPI_Type_free(&MPI_POINT);
+}
+
+bool shulpin_i_jarvis_all::JarvisALLParallel::PreProcessingImpl() {
+  if (rank_ == 0) {
+    std::vector<shulpin_i_jarvis_all::Point> tmp_input;
+
+    auto* tmp_data = reinterpret_cast<shulpin_i_jarvis_all::Point*>(task_data->inputs[0]);
+    size_t tmp_size = task_data->inputs_count[0];
+    tmp_input.assign(tmp_data, tmp_data + tmp_size);
+
+    input_stl_ = tmp_input;
+
+    size_t output_size = task_data->outputs_count[0];
+    output_stl_.resize(output_size);
+  }
+  return true;
+}
+
+bool shulpin_i_jarvis_all::JarvisALLParallel::ValidationImpl() {
+  if (rank_ == 0) {
+    return (task_data->inputs_count[0] >= 3) && (task_data->inputs[0] != nullptr);
+  }
+  return true;
+}
+
+bool shulpin_i_jarvis_all::JarvisALLParallel::RunImpl() {
+  MakeJarvisPassageALL(input_stl_, output_stl_);
+  return true;
+}
+
+bool shulpin_i_jarvis_all::JarvisALLParallel::PostProcessingImpl() {
+  if (rank_ == 0) {
+    auto* result = reinterpret_cast<Point*>(task_data->outputs[0]);
+    std::ranges::copy(output_stl_.begin(), output_stl_.end(), result);
+  }
+  return true;
+}

--- a/tasks/all/shulpin_i_jarvis_passage/src/test_modules.cpp
+++ b/tasks/all/shulpin_i_jarvis_passage/src/test_modules.cpp
@@ -1,0 +1,269 @@
+#include "all/shulpin_i_jarvis_passage/include/test_modules.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <numbers>
+#include <random>
+#include <unordered_set>
+#include <vector>
+
+#include "all/shulpin_i_jarvis_passage/include/ops_all.hpp"
+#include "core/task/include/task.hpp"
+
+void shulpin_all_test_module::VerifyResults(const std::vector<shulpin_i_jarvis_all::Point> &expected,
+                                            const std::vector<shulpin_i_jarvis_all::Point> &result_tbb) {
+  for (const auto &p : result_tbb) {
+    bool found = false;
+    for (const auto &q : expected) {
+      if (std::fabs(p.x - q.x) < 1e-9 && std::fabs(p.y - q.y) < 1e-9) {
+        found = true;
+        break;
+      }
+    }
+    ASSERT_TRUE(found);
+  }
+}
+
+void shulpin_all_test_module::MainTestBody(std::vector<shulpin_i_jarvis_all::Point> &input,
+                                           std::vector<shulpin_i_jarvis_all::Point> &expected) {
+  int rank{};
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  std::vector<shulpin_i_jarvis_all::Point> result_seq(expected.size());
+  std::vector<shulpin_i_jarvis_all::Point> result_tbb(expected.size());
+
+  auto task_data_par = std::make_shared<ppc::core::TaskData>();
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  if (rank == 0) {
+    task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_seq->inputs_count.emplace_back(static_cast<uint32_t>(input.size()));
+
+    task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result_seq.data()));
+    task_data_seq->outputs_count.emplace_back(static_cast<uint32_t>(result_seq.size()));
+
+    shulpin_i_jarvis_all::JarvisSequential seq_task(task_data_seq);
+    ASSERT_EQ(seq_task.Validation(), true);
+    seq_task.PreProcessing();
+    seq_task.Run();
+    seq_task.PostProcessing();
+
+    task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_par->inputs_count.emplace_back(static_cast<uint32_t>(input.size()));
+
+    task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(result_tbb.data()));
+    task_data_par->outputs_count.emplace_back(static_cast<uint32_t>(result_tbb.size()));
+  }
+
+  shulpin_i_jarvis_all::JarvisALLParallel all_task(task_data_par);
+  ASSERT_EQ(all_task.Validation(), true);
+  all_task.PreProcessing();
+  all_task.Run();
+  all_task.PostProcessing();
+
+  if (rank == 0) {
+    shulpin_all_test_module::VerifyResults(result_seq, result_tbb);
+  }
+}
+
+std::vector<shulpin_i_jarvis_all::Point> shulpin_all_test_module::GeneratePointsInCircle(
+    size_t num_points, const shulpin_i_jarvis_all::Point &center, double radius) {
+  std::vector<shulpin_i_jarvis_all::Point> points;
+  for (size_t i = 0; i < num_points; ++i) {
+    double angle = 2.0 * std::numbers::pi * static_cast<double>(i) / static_cast<double>(num_points);
+    double x = center.x + (radius * std::cos(angle));
+    double y = center.y + (radius * std::sin(angle));
+    points.emplace_back(x, y);
+  }
+  return points;
+}
+
+void shulpin_all_test_module::TestBodyRandomCircle(std::vector<shulpin_i_jarvis_all::Point> &input,
+                                                   std::vector<shulpin_i_jarvis_all::Point> &expected,
+                                                   size_t &num_points) {
+  int rank{};
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  std::vector<shulpin_i_jarvis_all::Point> result_seq(expected.size());
+  std::vector<shulpin_i_jarvis_all::Point> result_tbb(expected.size());
+
+  auto task_data_par = std::make_shared<ppc::core::TaskData>();
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  if (rank == 0) {
+    task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_seq->inputs_count.emplace_back(static_cast<uint32_t>(input.size()));
+
+    task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result_seq.data()));
+    task_data_seq->outputs_count.emplace_back(static_cast<uint32_t>(result_seq.size()));
+
+    shulpin_i_jarvis_all::JarvisSequential seq_task(task_data_seq);
+    ASSERT_EQ(seq_task.Validation(), true);
+    seq_task.PreProcessing();
+    seq_task.Run();
+    seq_task.PostProcessing();
+
+    task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_par->inputs_count.emplace_back(static_cast<uint32_t>(input.size()));
+
+    task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(result_tbb.data()));
+    task_data_par->outputs_count.emplace_back(static_cast<uint32_t>(result_tbb.size()));
+  }
+
+  shulpin_i_jarvis_all::JarvisALLParallel all_task(task_data_par);
+  ASSERT_EQ(all_task.Validation(), true);
+  all_task.PreProcessing();
+  all_task.Run();
+  all_task.PostProcessing();
+
+  if (rank == 0) {
+    shulpin_all_test_module::VerifyResults(result_seq, result_tbb);
+  }
+}
+
+void shulpin_all_test_module::TestBodyFalse(std::vector<shulpin_i_jarvis_all::Point> &input,
+                                            std::vector<shulpin_i_jarvis_all::Point> &expected) {
+  int rank{};
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  std::vector<shulpin_i_jarvis_all::Point> result_tbb(expected.size());
+
+  auto task_data_par = std::make_shared<ppc::core::TaskData>();
+  task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_par->inputs_count.emplace_back(static_cast<uint32_t>(input.size()));
+
+  task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(result_tbb.data()));
+  task_data_par->outputs_count.emplace_back(static_cast<uint32_t>(result_tbb.size()));
+
+  shulpin_i_jarvis_all::JarvisALLParallel all_task(task_data_par);
+  if (rank == 0) {
+    ASSERT_EQ(all_task.Validation(), false);
+  }
+}
+
+std::vector<shulpin_i_jarvis_all::Point> shulpin_all_test_module::ComputeConvexHull(
+    std::vector<shulpin_i_jarvis_all::Point> raw_points) {
+  std::vector<shulpin_i_jarvis_all::Point> convex_shell{};
+  std::unordered_set<shulpin_i_jarvis_all::Point, shulpin_i_jarvis_all::PointHash, shulpin_i_jarvis_all::PointEqual>
+      unique_points;
+
+  size_t most_left = 0;
+  for (size_t i = 1; i < raw_points.size(); ++i) {
+    if (raw_points[i].x < raw_points[most_left].x ||
+        (raw_points[i].x == raw_points[most_left].x && raw_points[i].y < raw_points[most_left].y)) {
+      most_left = i;
+    }
+  }
+
+  const shulpin_i_jarvis_all::Point &min_point = raw_points[most_left];
+  shulpin_i_jarvis_all::Point prev_point = min_point;
+  shulpin_i_jarvis_all::Point next_point;
+
+  convex_shell.push_back(min_point);
+  unique_points.insert(min_point);
+
+  do {
+    next_point = raw_points[0];
+
+    for (const auto &point : raw_points) {
+      if (point == prev_point) {
+        continue;
+      }
+
+      double cross_product = ((point.y - prev_point.y) * (next_point.x - prev_point.x)) -
+                             ((point.x - prev_point.x) * (next_point.y - prev_point.y));
+      double dist1 = std::pow(point.x - prev_point.x, 2) + std::pow(point.y - prev_point.y, 2);
+      double dist2 = std::pow(next_point.x - prev_point.x, 2) + std::pow(next_point.y - prev_point.y, 2);
+
+      if (cross_product > 0 || (cross_product == 0 && dist1 > dist2)) {
+        next_point = point;
+      }
+    }
+
+    if (unique_points.find(next_point) == unique_points.end()) {
+      convex_shell.push_back(next_point);
+      unique_points.insert(next_point);
+    }
+
+    prev_point = next_point;
+
+  } while (next_point != min_point);
+  return convex_shell;
+}
+
+std::vector<shulpin_i_jarvis_all::Point> shulpin_all_test_module::GenerateRandomPoints(size_t num_points) {
+  std::vector<shulpin_i_jarvis_all::Point> points;
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> dist(-10000, 10000);
+
+  for (size_t i = 0; i < num_points; ++i) {
+    int x = dist(gen);
+    int y = dist(gen);
+    points.emplace_back(static_cast<double>(x), static_cast<double>(y));
+  }
+
+  return points;
+}
+
+void shulpin_all_test_module::RandomTestBody(std::vector<shulpin_i_jarvis_all::Point> &input,
+                                             std::vector<shulpin_i_jarvis_all::Point> &expected) {
+  int rank{};
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  std::vector<shulpin_i_jarvis_all::Point> result_seq(expected.size());
+  std::vector<shulpin_i_jarvis_all::Point> result_tbb(expected.size());
+
+  auto task_data_par = std::make_shared<ppc::core::TaskData>();
+  auto task_data_seq = std::make_shared<ppc::core::TaskData>();
+
+  if (rank == 0) {
+    task_data_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_seq->inputs_count.emplace_back(static_cast<uint32_t>(input.size()));
+
+    task_data_seq->outputs.emplace_back(reinterpret_cast<uint8_t *>(result_seq.data()));
+    task_data_seq->outputs_count.emplace_back(static_cast<uint32_t>(result_seq.size()));
+
+    shulpin_i_jarvis_all::JarvisSequential seq_task(task_data_seq);
+    ASSERT_EQ(seq_task.Validation(), true);
+    seq_task.PreProcessing();
+    seq_task.Run();
+    seq_task.PostProcessing();
+
+    task_data_par->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_par->inputs_count.emplace_back(static_cast<uint32_t>(input.size()));
+
+    task_data_par->outputs.emplace_back(reinterpret_cast<uint8_t *>(result_tbb.data()));
+    task_data_par->outputs_count.emplace_back(static_cast<uint32_t>(result_tbb.size()));
+  }
+
+  shulpin_i_jarvis_all::JarvisALLParallel all_task(task_data_par);
+  ASSERT_EQ(all_task.Validation(), true);
+  all_task.PreProcessing();
+  all_task.Run();
+  all_task.PostProcessing();
+
+  if (rank == 0) {
+    shulpin_all_test_module::VerifyResults(result_seq, result_tbb);
+  }
+}
+
+std::vector<shulpin_i_jarvis_all::Point> shulpin_all_test_module::PerfRandomGenerator(size_t num_points, int from,
+                                                                                      int to) {
+  std::vector<shulpin_i_jarvis_all::Point> points;
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> dist(from, to);
+
+  for (size_t i = 0; i < num_points; ++i) {
+    int x = dist(gen);
+    int y = dist(gen);
+    points.emplace_back(static_cast<double>(x), static_cast<double>(y));
+  }
+
+  return points;
+}

--- a/tasks/all/shulpin_i_jarvis_passage/src/test_modules.cpp
+++ b/tasks/all/shulpin_i_jarvis_passage/src/test_modules.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <mpi.h>
 #include <numbers>
 #include <random>
 #include <unordered_set>

--- a/tasks/all/shulpin_i_jarvis_passage/src/test_modules.cpp
+++ b/tasks/all/shulpin_i_jarvis_passage/src/test_modules.cpp
@@ -1,12 +1,12 @@
 #include "all/shulpin_i_jarvis_passage/include/test_modules.hpp"
 
 #include <gtest/gtest.h>
+#include <mpi.h>
 
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <mpi.h>
 #include <numbers>
 #include <random>
 #include <unordered_set>


### PR DESCRIPTION
**Описание алгоритма**
Вспомогательная функция FindLocalCandidate
 - Делит весь вектор точек на num_threads равных чанков.
 - Каждый поток независимо сканирует свой диапазон, выбирая «лучшего» кандидата на следующий шаг выпуклой оболочки по критерию:
 - - поворот против часовой стрелки (cross > 0),
 - - при коллинеарности — большая квадратная дистанция до текущей точки.
 - Результаты каждого потока записываются в общий массив local_cand, после чего внутри функции снова применяется та же логика сравнения для выбора единственного локального кандидата.

Основная функция MakeJarvisPassageALL
- Инициализация MPI
 - - Создаётся и регистрируется пользовательский тип mpi_point для структуры Point.
 - - Все ранги получают размер входного массива через MPI_Bcast.
 - Поиск стартовой точки
 - - Ранг 0 находит наиболее левую (а при равенстве — наиболее нижнюю) точку, объявляет её первой и транслирует остальным.
 - Распределение данных
 - - С помощью MPI_Scatterv входной массив точек разбивается по рангам, каждый получает свой local_points.
 - Основной цикл Джарвиса
 - - Ранг 0 транслирует всем предыдущую выбранную точку prev_point.
 - - На каждом ранге запускается FindLocalCandidate(prev_point, local_points, num_threads).
 - - Все локальные кандидаты собираются на ранге 0 через MPI_Gather в массив all_cand.
 - - Ранг 0 выбирает глобального «next_point» по тому же правилу ориентации + дистанции.
 - - Если next_point ещё не был добавлен в output_jar, он туда добавляется, а флаг done остаётся false. Если же он совпадает с начальной точкой, done = true.
 - - Флаги next_point и done снова рассылаются всем рангам (MPI_Bcast), после чего цикл повторяется или завершается.
 - Освобождение ресурсов
 - - Тип mpi_point удаляется через MPI_Type_free.