### PR TITLE
Козлова Екатерина. Вариант 28. MPI+OMP. Повышение контраста полутонового изображения посредством линейной растяжки гистограммы

### DIFF
--- a/tasks/all/kozlova_e_contrast_enhancement/func_tests/func_all.cpp
+++ b/tasks/all/kozlova_e_contrast_enhancement/func_tests/func_all.cpp
@@ -34,7 +34,7 @@ std::shared_ptr<ppc::core::TaskData> CreateTaskData(std::vector<uint8_t>& in, st
 }
 
 void TestRun(std::vector<uint8_t> in, std::vector<uint8_t> out, size_t width, size_t height,
-             boost::mpi::communicator world) {
+             const boost::mpi::communicator& world) {
   std::shared_ptr<ppc::core::TaskData> task_data_all = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
     task_data_all = CreateTaskData(in, out, width, height);
@@ -60,7 +60,7 @@ void TestRun(std::vector<uint8_t> in, std::vector<uint8_t> out, size_t width, si
 }
 
 void TestValidation(std::vector<uint8_t> in, std::vector<uint8_t> out, size_t width, size_t height,
-                    boost::mpi::communicator world) {
+                    const boost::mpi::communicator& world) {
   std::shared_ptr<ppc::core::TaskData> task_data_all = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
     task_data_all = CreateTaskData(in, out, width, height);

--- a/tasks/all/kozlova_e_contrast_enhancement/func_tests/func_all.cpp
+++ b/tasks/all/kozlova_e_contrast_enhancement/func_tests/func_all.cpp
@@ -1,0 +1,117 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <boost/mpi/communicator.hpp>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+#include "all/kozlova_e_contrast_enhancement/include/ops_all.hpp"
+#include "core/task/include/task.hpp"
+
+namespace {
+
+std::vector<uint8_t> GenerateVector(int length) {
+  std::vector<uint8_t> vec(length);
+  for (int i = 0; i < length; ++i) {
+    vec[i] = rand() % 256;
+  }
+  return vec;
+}
+
+std::shared_ptr<ppc::core::TaskData> CreateTaskData(std::vector<uint8_t>& in, std::vector<uint8_t>& out, size_t width,
+                                                    size_t height) {
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(in.data());
+  task_data->inputs_count.emplace_back(in.size());
+  task_data->inputs_count.emplace_back(width);
+  task_data->inputs_count.emplace_back(height);
+  task_data->outputs.emplace_back(out.data());
+  task_data->outputs_count.emplace_back(out.size());
+
+  return task_data;
+}
+
+void TestRun(std::vector<uint8_t> in, std::vector<uint8_t> out, size_t width, size_t height,
+             boost::mpi::communicator world) {
+  std::shared_ptr<ppc::core::TaskData> task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_all = CreateTaskData(in, out, width, height);
+  }
+
+  kozlova_e_contrast_enhancement_all::TestTaskAll test_task_all(task_data_all);
+
+  ASSERT_TRUE(test_task_all.Validation());
+  test_task_all.PreProcessing();
+  test_task_all.Run();
+  test_task_all.PostProcessing();
+
+  uint8_t min_value = *std::ranges::min_element(in);
+  uint8_t max_value = *std::ranges::max_element(in);
+  if (world.rank() == 0) {
+    for (size_t i = 0; i < in.size(); ++i) {
+      uint8_t expected = (max_value == min_value)
+                             ? in[i]
+                             : static_cast<uint8_t>(((in[i] - min_value) / double(max_value - min_value)) * 255);
+      EXPECT_EQ(out[i], expected);
+    }
+  }
+}
+
+void TestValidation(std::vector<uint8_t> in, std::vector<uint8_t> out, size_t width, size_t height,
+                    boost::mpi::communicator world) {
+  std::shared_ptr<ppc::core::TaskData> task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_all = CreateTaskData(in, out, width, height);
+  }
+  kozlova_e_contrast_enhancement_all::TestTaskAll test_task_all(task_data_all);
+  if (world.rank() == 0) {
+    ASSERT_FALSE(test_task_all.Validation());
+  }
+}
+
+}  // namespace
+
+TEST(kozlova_e_contrast_enhancement_all, test_1st_image) {
+  boost::mpi::communicator world;
+  std::vector<uint8_t> in{10, 0, 50, 100, 200, 34};
+  std::vector<uint8_t> out(6, 0);
+  TestRun(in, out, 2, 3, world);
+}
+
+TEST(kozlova_e_contrast_enhancement_all, test_large_image) {
+  boost::mpi::communicator world;
+  std::vector<uint8_t> in = GenerateVector(400);
+  std::vector<uint8_t> out(400, 0);
+  TestRun(in, out, 10, 40, world);
+}
+
+TEST(kozlova_e_contrast_enhancement_all, test_empty_input) {
+  boost::mpi::communicator world;
+  TestValidation({}, {}, 0, 0, world);
+}
+
+TEST(kozlova_e_contrast_enhancement_all, test_same_values_input) {
+  boost::mpi::communicator world;
+  std::vector<uint8_t> in(6, 100);
+  std::vector<uint8_t> out(6, 0);
+  TestRun(in, out, 2, 3, world);
+}
+
+TEST(kozlova_e_contrast_enhancement_all, test_difference_input) {
+  boost::mpi::communicator world;
+  std::vector<uint8_t> in{10, 20, 30, 100, 200, 250};
+  std::vector<uint8_t> out(6, 0);
+  TestRun(in, out, 2, 3, world);
+}
+
+TEST(kozlova_e_contrast_enhancement_all, test_incorrect_input_size) {
+  boost::mpi::communicator world;
+  TestValidation({3, 3, 3}, {}, 3, 1, world);
+}
+
+TEST(kozlova_e_contrast_enhancement_all, test_incorrect_input_width) {
+  boost::mpi::communicator world;
+  TestValidation({3, 3, 3, 3}, {0, 0, 0, 0}, 3, 1, world);
+}

--- a/tasks/all/kozlova_e_contrast_enhancement/include/ops_all.hpp
+++ b/tasks/all/kozlova_e_contrast_enhancement/include/ops_all.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <boost/mpi/communicator.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kozlova_e_contrast_enhancement_all {
+
+class TestTaskAll : public ppc::core::Task {
+ public:
+  explicit TestTaskAll(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<uint8_t> input_;
+  size_t width_ = 0;
+  size_t height_ = 0;
+  std::vector<uint8_t> output_;
+  boost::mpi::communicator world_;
+};
+
+}  // namespace kozlova_e_contrast_enhancement_all

--- a/tasks/all/kozlova_e_contrast_enhancement/perf_tests/perf_all.cpp
+++ b/tasks/all/kozlova_e_contrast_enhancement/perf_tests/perf_all.cpp
@@ -19,7 +19,7 @@ std::vector<uint8_t> GenerateVector(size_t length);
 std::vector<uint8_t> GenerateVector(size_t length) {
   std::vector<uint8_t> vec;
   vec.reserve(length);
-  for (int i = 0; i < length; ++i) {
+  for (size_t i = 0; i < length; ++i) {
     vec.push_back(rand() % 256);
   }
   return vec;

--- a/tasks/all/kozlova_e_contrast_enhancement/perf_tests/perf_all.cpp
+++ b/tasks/all/kozlova_e_contrast_enhancement/perf_tests/perf_all.cpp
@@ -73,7 +73,7 @@ TEST(kozlova_e_contrast_enhancement_all, test_pipeline_run) {
     uint8_t max_value = *std::ranges::max_element(in);
 
     for (size_t i = 0; i < in.size(); ++i) {
-      uint8_t expected = static_cast<uint8_t>(((in[i] - min_value) / (double)(max_value - min_value)) * 255);
+      auto expected = static_cast<uint8_t>(((in[i] - min_value) / (double)(max_value - min_value)) * 255);
       expected = std::clamp((int)expected, 0, 255);
       EXPECT_EQ(out[i], expected);
     }
@@ -127,7 +127,7 @@ TEST(kozlova_e_contrast_enhancement_all, test_task_run) {
     uint8_t max_value = *std::ranges::max_element(in);
 
     for (size_t i = 0; i < in.size(); ++i) {
-      uint8_t expected = static_cast<uint8_t>(((in[i] - min_value) / (double)(max_value - min_value)) * 255);
+      auto expected = static_cast<uint8_t>(((in[i] - min_value) / (double)(max_value - min_value)) * 255);
       expected = std::clamp((int)expected, 0, 255);
       EXPECT_EQ(out[i], expected);
     }

--- a/tasks/all/kozlova_e_contrast_enhancement/perf_tests/perf_all.cpp
+++ b/tasks/all/kozlova_e_contrast_enhancement/perf_tests/perf_all.cpp
@@ -1,0 +1,135 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <boost/mpi/communicator.hpp>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+#include "all/kozlova_e_contrast_enhancement/include/ops_all.hpp"
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+
+namespace {
+std::vector<uint8_t> GenerateVector(size_t length);
+
+std::vector<uint8_t> GenerateVector(size_t length) {
+  std::vector<uint8_t> vec;
+  vec.reserve(length);
+  for (int i = 0; i < length; ++i) {
+    vec.push_back(rand() % 256);
+  }
+  return vec;
+}
+}  // namespace
+
+TEST(kozlova_e_contrast_enhancement_all, test_pipeline_run) {
+  constexpr size_t kSize = 19875000;
+  size_t width = 7500;
+  size_t height = 2650;
+  boost::mpi::communicator world;
+  // Create data
+  std::vector<uint8_t> in;
+  std::vector<uint8_t> out(kSize, 0);
+
+  // Create task_data
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    in = GenerateVector(kSize);
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    task_data_all->inputs_count.emplace_back(in.size());
+    task_data_all->inputs_count.emplace_back(width);
+    task_data_all->inputs_count.emplace_back(height);
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
+  }
+
+  // Create Task
+  auto test_task_alluential = std::make_shared<kozlova_e_contrast_enhancement_all::TestTaskAll>(task_data_all);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_alluential);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  if (world.rank() == 0) {
+    uint8_t min_value = *std::ranges::min_element(in);
+    uint8_t max_value = *std::ranges::max_element(in);
+
+    for (size_t i = 0; i < in.size(); ++i) {
+      uint8_t expected = static_cast<uint8_t>(((in[i] - min_value) / (double)(max_value - min_value)) * 255);
+      expected = std::clamp((int)expected, 0, 255);
+      EXPECT_EQ(out[i], expected);
+    }
+  }
+}
+
+TEST(kozlova_e_contrast_enhancement_all, test_task_run) {
+  constexpr size_t kSize = 19875000;
+  size_t width = 7500;
+  size_t height = 2650;
+  boost::mpi::communicator world;
+  // Create data
+  std::vector<uint8_t> in;
+  std::vector<uint8_t> out(kSize, 0);
+
+  // Create task_data
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    in = GenerateVector(kSize);
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+    task_data_all->inputs_count.emplace_back(in.size());
+    task_data_all->inputs_count.emplace_back(width);
+    task_data_all->inputs_count.emplace_back(height);
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
+  }
+
+  // Create Task
+  auto test_task_alluential = std::make_shared<kozlova_e_contrast_enhancement_all::TestTaskAll>(task_data_all);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_alluential);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  if (world.rank() == 0) {
+    uint8_t min_value = *std::ranges::min_element(in);
+    uint8_t max_value = *std::ranges::max_element(in);
+
+    for (size_t i = 0; i < in.size(); ++i) {
+      uint8_t expected = static_cast<uint8_t>(((in[i] - min_value) / (double)(max_value - min_value)) * 255);
+      expected = std::clamp((int)expected, 0, 255);
+      EXPECT_EQ(out[i], expected);
+    }
+  }
+}

--- a/tasks/all/kozlova_e_contrast_enhancement/src/ops_all.cpp
+++ b/tasks/all/kozlova_e_contrast_enhancement/src/ops_all.cpp
@@ -1,0 +1,118 @@
+#include "all/kozlova_e_contrast_enhancement/include/ops_all.hpp"
+
+#include <algorithm>
+#include <boost/mpi/collectives/all_reduce.hpp>
+#include <boost/mpi/collectives/broadcast.hpp>
+#include <boost/mpi/collectives/gatherv.hpp>
+#include <boost/mpi/collectives/scatterv.hpp>
+#include <boost/serialization/vector.hpp>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <thread>
+#include <vector>
+
+#include "core/util/include/util.hpp"
+
+bool kozlova_e_contrast_enhancement_all::TestTaskAll::PreProcessingImpl() {
+  if (world_.rank() == 0) {
+    auto *input_ptr = reinterpret_cast<uint8_t *>(task_data->inputs[0]);
+    size_t size = task_data->inputs_count[0];
+    width_ = task_data->inputs_count[1];
+    height_ = task_data->inputs_count[2];
+    output_.resize(size, 0);
+    input_.resize(size);
+    std::copy(input_ptr, input_ptr + size, input_.begin());
+  }
+
+  return true;
+}
+
+bool kozlova_e_contrast_enhancement_all::TestTaskAll::ValidationImpl() {
+  if (world_.rank() == 0) {
+    size_t size = task_data->inputs_count[0];
+    size_t check_width = task_data->inputs_count[1];
+    size_t check_height = task_data->inputs_count[2];
+    return size == task_data->outputs_count[0] && size > 0 && (size % 2 == 0) && check_width >= 1 &&
+           check_height >= 1 && (size == check_height * check_width);
+  } else
+    return true;
+}
+
+bool kozlova_e_contrast_enhancement_all::TestTaskAll::RunImpl() {
+  int rank = world_.rank();
+  int proc_count = world_.size();
+
+  size_t input_size;
+  if (rank == 0) {
+    input_size = input_.size();
+  }
+
+  boost::mpi::broadcast(world_, input_size, 0);
+  input_.resize(input_size);
+  boost::mpi::broadcast(world_, input_.data(), input_.size(), 0);
+
+  int local_size = input_size / proc_count;
+  int remainder = input_size % proc_count;
+  std::vector<int> counts(proc_count, local_size);
+  for (int i = 0; i < remainder; ++i) {
+    counts[i]++;
+  }
+
+  std::vector<int> displs(proc_count, 0);
+  for (int i = 1; i < proc_count; ++i) {
+    displs[i] = displs[i - 1] + counts[i - 1];
+  }
+
+  std::vector<uint8_t> local_input(counts[rank]);
+
+  boost::mpi::scatterv(world_, input_.data(), counts, displs, local_input.data(), counts[rank], 0);
+
+  uint8_t local_min = 255;
+  uint8_t local_max = 0;
+  if (!local_input.empty()) {
+    local_min = *std::min_element(local_input.begin(), local_input.end());
+    local_max = *std::max_element(local_input.begin(), local_input.end());
+  }
+
+  uint8_t global_min, global_max;
+
+  boost::mpi::all_reduce(world_, local_min, global_min, boost::mpi::minimum<uint8_t>());
+  boost::mpi::all_reduce(world_, local_max, global_max, boost::mpi::maximum<uint8_t>());
+  boost::mpi::broadcast(world_, global_max, 0);
+  boost::mpi::broadcast(world_, global_min, 0);
+
+  std::vector<uint8_t> local_output(local_input.size());
+
+  if (global_min == global_max) {
+    std::copy(local_input.begin(), local_input.end(), local_output.begin());
+  } else {
+#pragma omp parallel for schedule(static)
+    for (int i = 0; i < static_cast<int>(local_input.size()); ++i) {
+      local_output[i] = static_cast<uint8_t>(((local_input[i] - global_min) / (double)(global_max - global_min)) * 255);
+      local_output[i] = std::clamp(static_cast<int>(local_output[i]), 0, 255);
+    }
+  }
+
+  std::vector<uint8_t> gathered;
+  if (rank == 0) {
+    gathered.resize(input_size);
+  }
+
+  boost::mpi::gatherv(world_, local_output.data(), counts[rank], gathered.data(), counts, displs, 0);
+
+  if (rank == 0) {
+    output_ = std::move(gathered);
+  }
+
+  return rank == 0;
+}
+
+bool kozlova_e_contrast_enhancement_all::TestTaskAll::PostProcessingImpl() {
+  if (world_.rank() == 0) {
+    for (size_t i = 0; i < output_.size(); ++i) {
+      reinterpret_cast<uint8_t *>(task_data->outputs[0])[i] = output_[i];
+    }
+  }
+  return true;
+}

--- a/tasks/all/kozlova_e_contrast_enhancement/src/ops_all.cpp
+++ b/tasks/all/kozlova_e_contrast_enhancement/src/ops_all.cpp
@@ -73,8 +73,8 @@ bool kozlova_e_contrast_enhancement_all::TestTaskAll::RunImpl() {
     local_max = *std::ranges::max_element(local_input);
   }
 
-  uint8_t global_min;
-  uint8_t global_max;
+  uint8_t global_min = 0;
+  uint8_t global_max = 0;
 
   boost::mpi::all_reduce(world_, local_min, global_min, boost::mpi::minimum<uint8_t>());
   boost::mpi::all_reduce(world_, local_max, global_max, boost::mpi::maximum<uint8_t>());


### PR DESCRIPTION
Полутоновое изображение представлено вектором целых чисел. Значения пикселей масштабируются на весь диапазон от 0 до 255. Для этого каждый процесс находит минимум и максимум яркости в своей части данных, после чего используются коллективные операции boost::mpi::all_reduce для вычисления глобальных границ. Передача и сбор данных между процессами выполняются с помощью boost::mpi::broadcast, boost::mpi::scatterv и boost::mpi::gatherv. Повышение контраста выполняется параллельно с использованием директивы #pragma omp parallel for schedule(static).