### PR TITLE
revert "Disable plekhanov_d_dijkstra_all"

### DIFF
--- a/tasks/all/plekhanov_d_dijkstra/func_tests/main.cpp
+++ b/tasks/all/plekhanov_d_dijkstra/func_tests/main.cpp
@@ -1,0 +1,248 @@
+#include <gtest/gtest.h>
+
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
+#include <functional>
+#include <memory>
+#include <queue>
+#include <utility>
+#include <vector>
+
+#include "all/plekhanov_d_dijkstra/include/ops_all.hpp"
+#include "core/task/include/task.hpp"
+
+namespace plekhanov_d_dijkstra_all {
+
+namespace {
+template <typename ExpectedResultType>
+void ValidateTaskSuccess(TestTaskALL &test_task, std::vector<int> &distances,
+                         const std::vector<ExpectedResultType> &expected_result) {
+  ASSERT_TRUE(test_task.Run());
+  test_task.PostProcessing();
+  if (test_task.GetRank() == 0) {
+    for (size_t i = 0; i < distances.size(); ++i) {
+      EXPECT_EQ(distances[i], expected_result[i]);
+    }
+  }
+}
+
+template <typename ExpectedResultType>
+void ExecuteAndValidateTask(std::shared_ptr<ppc::core::TaskData> &task_data, std::vector<int> &distances,
+                            const std::vector<ExpectedResultType> &expected_result, bool expect_success) {
+  TestTaskALL test_task(task_data);
+  ASSERT_TRUE(test_task.Validation());
+  test_task.PreProcessing();
+
+  if (expect_success) {
+    ValidateTaskSuccess(test_task, distances, expected_result);
+  } else {
+    ASSERT_FALSE(test_task.Run());
+  }
+}
+
+std::vector<int> ConvertToGraphData(const std::vector<std::vector<std::pair<size_t, int>>> &adj_list) {
+  std::vector<int> graph_data;
+  for (const auto &vertex_edges : adj_list) {
+    for (const auto &edge : vertex_edges) {
+      graph_data.push_back(static_cast<int>(edge.first));
+      graph_data.push_back(edge.second);
+    }
+    graph_data.push_back(-1);
+  }
+  return graph_data;
+}
+
+template <typename ExpectedResultType>
+void RunTest(const std::vector<std::vector<std::pair<size_t, int>>> &adj_list, size_t start_vertex,
+             const std::vector<ExpectedResultType> &expected_result, bool expect_success = true) {
+  const size_t k_num_vertices = adj_list.size();
+  std::vector<int> distances(k_num_vertices, INT_MAX);
+  std::vector<int> graph_data = ConvertToGraphData(adj_list);
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(graph_data.data()));
+  task_data_all->inputs_count.emplace_back(graph_data.size());
+  task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&start_vertex));
+  task_data_all->inputs_count.emplace_back(sizeof(start_vertex));
+  task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(distances.data()));
+  task_data_all->outputs_count.emplace_back(k_num_vertices);
+
+  ExecuteAndValidateTask(task_data_all, distances, expected_result, expect_success);
+}
+
+void RunValidationFailureTest() {
+  std::vector<int> graph_data;
+  size_t start_vertex = 0;
+  size_t num_vertices = 0;
+  std::vector<int> distances(num_vertices, INT_MAX);
+
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(graph_data.data()));
+  task_data_all->inputs_count.emplace_back(graph_data.size());
+  task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&start_vertex));
+  task_data_all->inputs_count.emplace_back(sizeof(start_vertex));
+  task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(distances.data()));
+  task_data_all->outputs_count.emplace_back(num_vertices);
+
+  TestTaskALL test_task_all(task_data_all);
+  if (test_task_all.GetRank() == 0) {
+    ASSERT_FALSE(test_task_all.Validation());
+  }
+}
+
+std::vector<std::vector<std::pair<size_t, int>>> GenerateRandomGraph(size_t num_vertices) {
+  srand(static_cast<unsigned int>(time(nullptr)));
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list(num_vertices);
+  for (size_t i = 0; i < num_vertices; ++i) {
+    for (size_t j = 0; j < num_vertices; ++j) {
+      if (i != j) {
+        if (rand() % 3 == 0) {
+          int weight = (rand() % 10) + 1;
+          adj_list[i].emplace_back(j, weight);
+        }
+      }
+    }
+  }
+  return adj_list;
+}
+
+std::vector<int> CalculateExpectedResult(const std::vector<std::vector<std::pair<size_t, int>>> &adj_list,
+                                         size_t start_vertex) {
+  size_t n = adj_list.size();
+  const int inf = INT_MAX;
+  std::vector<int> distances(n, inf);
+  distances[start_vertex] = 0;
+
+  using Pii = std::pair<int, size_t>;
+  std::priority_queue<Pii, std::vector<Pii>, std::greater<>> pq;
+  pq.emplace(0, start_vertex);
+
+  while (!pq.empty()) {
+    auto [d, u] = pq.top();
+    pq.pop();
+
+    if (d != distances[u]) {
+      continue;
+    }
+
+    for (const auto &edge : adj_list[u]) {
+      size_t v = edge.first;
+      int weight = edge.second;
+      if (distances[u] != inf && (distances[u] + weight < distances[v])) {
+        distances[v] = distances[u] + weight;
+        pq.emplace(distances[v], v);
+      }
+    }
+  }
+  return distances;
+}
+
+}  // namespace
+
+}  // namespace plekhanov_d_dijkstra_all
+
+TEST(plekhanov_d_dijkstra_all, test_dijkstra_Simple_Path_Graph) {
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list = {
+      {{1, 1}}, {{0, 1}, {2, 2}}, {{1, 2}, {3, 3}}, {{2, 3}, {4, 4}}, {{3, 4}}};
+  std::vector<int> expected = {0, 1, 3, 6, 10};
+  plekhanov_d_dijkstra_all::RunTest(adj_list, 0, expected);
+}
+
+TEST(plekhanov_d_dijkstra_all, test_dijkstra_Complete_Graph) {
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list = {{{1, 10}, {2, 3}, {3, 20}, {4, 7}},
+                                                               {{0, 10}, {2, 5}, {3, 4}, {4, 11}},
+                                                               {{0, 3}, {1, 5}, {3, 2}, {4, 6}},
+                                                               {{0, 20}, {1, 4}, {2, 2}, {4, 8}},
+                                                               {{0, 7}, {1, 11}, {2, 6}, {3, 8}}};
+  std::vector<int> expected = {3, 5, 0, 2, 6};
+  plekhanov_d_dijkstra_all::RunTest(adj_list, 2, expected);
+}
+
+TEST(plekhanov_d_dijkstra_all, test_dijkstra_Disconnected_Graph) {
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list = {{{1, 5}, {2, 3}}, {{0, 5}, {2, 1}}, {{0, 3}, {1, 1}},
+                                                               {{4, 2}, {5, 8}}, {{3, 2}, {5, 1}}, {{3, 8}, {4, 1}}};
+  std::vector<int> expected = {0, 4, 3, INT_MAX, INT_MAX, INT_MAX};
+  plekhanov_d_dijkstra_all::RunTest(adj_list, 0, expected);
+}
+
+TEST(plekhanov_d_dijkstra_all, test_dijkstra_Large_Sparse_Graph) {
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list = {
+      {{1, 4}, {2, 2}}, {{3, 5}, {4, 10}}, {{5, 3}, {6, 2}}, {{7, 4}}, {{8, 11}},
+      {{8, 1}},         {{9, 3}},          {{9, 5}},         {{9, 7}}, {}};
+
+  std::vector<int> expected = {0, 4, 2, 9, 14, 5, 4, 13, 6, 7};
+  plekhanov_d_dijkstra_all::RunTest(adj_list, 0, expected);
+}
+
+TEST(plekhanov_d_dijkstra_all, test_dijkstra_validation_failure) {
+  plekhanov_d_dijkstra_all::RunValidationFailureTest();
+}
+
+TEST(plekhanov_d_dijkstra_all, test_dijkstra_Directed_Graph) {
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list = {{{1, 2}, {2, 4}}, {{2, 1}, {3, 7}}, {{3, 3}}, {}};
+  std::vector<int> expected = {0, 2, 3, 6};
+  plekhanov_d_dijkstra_all::RunTest(adj_list, 0, expected);
+}
+
+TEST(plekhanov_d_dijkstra_all, test_dijkstra_SelfLoops) {
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list = {
+      {{0, 0}, {1, 2}}, {{1, 0}, {2, 3}}, {{2, 0}, {3, 1}}, {{3, 0}}};
+  std::vector<int> expected = {0, 2, 5, 6};
+  plekhanov_d_dijkstra_all::RunTest(adj_list, 0, expected);
+}
+
+TEST(plekhanov_d_dijkstra_all, test_dijkstra_Multigraph) {
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list = {{{1, 10}, {1, 3}}, {{2, 5}}, {{3, 2}, {3, 8}}, {}};
+  std::vector<int> expected = {0, 3, 8, 10};
+  plekhanov_d_dijkstra_all::RunTest(adj_list, 0, expected);
+}
+
+TEST(plekhanov_d_dijkstra_all, test_dijkstra_Dense_Graph) {
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list = {{{1, 2}, {2, 9}, {3, 4}},
+                                                               {{0, 2}, {2, 1}, {3, 7}, {4, 3}},
+                                                               {{0, 9}, {1, 1}, {4, 5}},
+                                                               {{0, 4}, {1, 7}, {4, 6}},
+                                                               {{1, 3}, {2, 5}, {3, 6}}};
+  std::vector<int> expected = {0, 2, 3, 4, 5};
+  plekhanov_d_dijkstra_all::RunTest(adj_list, 0, expected);
+}
+
+TEST(plekhanov_d_dijkstra_all, test_dijkstra_Cyclic_Graph) {
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list = {{{1, 1}}, {{2, 2}}, {{0, 4}, {3, 1}}, {}};
+  std::vector<int> expected = {0, 1, 3, 4};
+  plekhanov_d_dijkstra_all::RunTest(adj_list, 0, expected);
+}
+
+TEST(plekhanov_d_dijkstra_all, test_dijkstra_EqualOptimalPaths) {
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list = {{{1, 5}, {2, 5}}, {{3, 5}}, {{3, 5}}, {}};
+  std::vector<int> expected = {0, 5, 5, 10};
+  plekhanov_d_dijkstra_all::RunTest(adj_list, 0, expected);
+}
+
+TEST(plekhanov_d_dijkstra_all, test_dijkstra_Negative_Edges) {
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list = {{{1, 4}, {2, -2}}, {{0, 4}, {2, 3}}, {{0, -2}, {1, 3}}};
+  std::vector<int> expected = {0, 0, 0};
+  plekhanov_d_dijkstra_all::RunTest(adj_list, 0, expected, false);
+}
+
+TEST(plekhanov_d_dijkstra_all, test_dijkstra_Random_Graph_10) {
+  size_t num_vertices = 10;
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list =
+      plekhanov_d_dijkstra_all::GenerateRandomGraph(num_vertices);
+  size_t start_vertex = 0;
+  std::vector<int> expected = plekhanov_d_dijkstra_all::CalculateExpectedResult(adj_list, start_vertex);
+
+  plekhanov_d_dijkstra_all::RunTest(adj_list, start_vertex, expected);
+}
+
+TEST(plekhanov_d_dijkstra_all, test_dijkstra_Random_Graph_150) {
+  size_t num_vertices = 150;
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list =
+      plekhanov_d_dijkstra_all::GenerateRandomGraph(num_vertices);
+  size_t start_vertex = 0;
+  std::vector<int> expected = plekhanov_d_dijkstra_all::CalculateExpectedResult(adj_list, start_vertex);
+
+  plekhanov_d_dijkstra_all::RunTest(adj_list, start_vertex, expected);
+}

--- a/tasks/all/plekhanov_d_dijkstra/include/ops_all.hpp
+++ b/tasks/all/plekhanov_d_dijkstra/include/ops_all.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <boost/mpi/communicator.hpp>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace plekhanov_d_dijkstra_all {
+
+class TestTaskALL : public ppc::core::Task {
+ public:
+  explicit TestTaskALL(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+  [[nodiscard]] int GetRank() const { return world_.rank(); }
+
+ private:
+  boost::mpi::communicator world_;
+  std::vector<int> graph_data_;
+  std::vector<int> distances_;
+  size_t start_vertex_;
+  size_t num_vertices_;
+  static const int kEndOfVertexList;
+};
+
+}  // namespace plekhanov_d_dijkstra_all

--- a/tasks/all/plekhanov_d_dijkstra/perf_tests/main.cpp
+++ b/tasks/all/plekhanov_d_dijkstra/perf_tests/main.cpp
@@ -1,0 +1,171 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
+#include <functional>
+#include <memory>
+#include <queue>
+#include <utility>
+#include <vector>
+
+#include "all/plekhanov_d_dijkstra/include/ops_all.hpp"
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+
+namespace plekhanov_d_dijkstra_all {
+
+namespace {
+
+std::vector<std::vector<std::pair<size_t, int>>> static CreateRandomAdjacencyList(size_t num_vertices);
+std::vector<int> static CalculateExpectedResult(const std::vector<std::vector<std::pair<size_t, int>>> &adj_list,
+                                                size_t start_vertex);
+
+std::vector<std::vector<std::pair<size_t, int>>> CreateRandomAdjacencyList(size_t num_vertices) {
+  srand(static_cast<unsigned int>(time(nullptr)));
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list(num_vertices);
+  for (size_t i = 0; i < num_vertices; ++i) {
+    for (size_t j = 0; j < num_vertices; ++j) {
+      if (i != j) {
+        if (rand() % 3 == 0) {
+          int weight = (rand() % 10) + 1;
+          adj_list[i].emplace_back(j, weight);
+        }
+      }
+    }
+  }
+  return adj_list;
+}
+
+std::vector<int> CalculateExpectedResult(const std::vector<std::vector<std::pair<size_t, int>>> &adj_list,
+                                         size_t start_vertex) {
+  size_t n = adj_list.size();
+  const int inf = INT_MAX;
+  std::vector<int> distances(n, inf);
+  distances[start_vertex] = 0;
+
+  using Pii = std::pair<int, size_t>;
+  std::priority_queue<Pii, std::vector<Pii>, std::greater<>> pq;
+  pq.emplace(0, start_vertex);
+
+  while (!pq.empty()) {
+    auto [d, u] = pq.top();
+    pq.pop();
+
+    if (d != distances[u]) {
+      continue;
+    }
+
+    for (const auto &edge : adj_list[u]) {
+      size_t v = edge.first;
+      int weight = edge.second;
+      if (distances[u] != inf && (distances[u] + weight < distances[v])) {
+        distances[v] = distances[u] + weight;
+        pq.emplace(distances[v], v);
+      }
+    }
+  }
+  return distances;
+}
+
+}  // namespace
+
+}  // namespace plekhanov_d_dijkstra_all
+
+TEST(plekhanov_d_dijkstra_all, test_pipeline_run) {
+  constexpr size_t kNumVertices = 3000;
+  size_t start_vertex = 0;
+
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list =
+      plekhanov_d_dijkstra_all::CreateRandomAdjacencyList(kNumVertices);
+
+  std::vector<int> graph_data;
+  for (const auto &vertex_edges : adj_list) {
+    for (const auto &edge : vertex_edges) {
+      graph_data.push_back(static_cast<int>(edge.first));
+      graph_data.push_back(edge.second);
+    }
+    graph_data.push_back(-1);
+  }
+
+  std::vector<int> distances(kNumVertices, INT_MAX);
+
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(graph_data.data()));
+  task_data_all->inputs_count.emplace_back(graph_data.size());
+  task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&start_vertex));
+  task_data_all->inputs_count.emplace_back(sizeof(start_vertex));
+  task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(distances.data()));
+  task_data_all->outputs_count.emplace_back(kNumVertices);
+
+  auto test_task_all = std::make_shared<plekhanov_d_dijkstra_all::TestTaskALL>(task_data_all);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_all);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  std::vector<int> expected = plekhanov_d_dijkstra_all::CalculateExpectedResult(adj_list, start_vertex);
+  if (test_task_all->GetRank() == 0) {
+    EXPECT_EQ(distances, expected);
+  }
+}
+
+TEST(plekhanov_d_dijkstra_all, test_task_run) {
+  constexpr size_t kNumVertices = 3000;
+  size_t start_vertex = 0;
+
+  std::vector<std::vector<std::pair<size_t, int>>> adj_list =
+      plekhanov_d_dijkstra_all::CreateRandomAdjacencyList(kNumVertices);
+
+  std::vector<int> graph_data;
+  for (const auto &vertex_edges : adj_list) {
+    for (const auto &edge : vertex_edges) {
+      graph_data.push_back(static_cast<int>(edge.first));
+      graph_data.push_back(edge.second);
+    }
+    graph_data.push_back(-1);
+  }
+
+  std::vector<int> distances(kNumVertices, INT_MAX);
+
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(graph_data.data()));
+  task_data_all->inputs_count.emplace_back(graph_data.size());
+  task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&start_vertex));
+  task_data_all->inputs_count.emplace_back(sizeof(start_vertex));
+  task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(distances.data()));
+  task_data_all->outputs_count.emplace_back(kNumVertices);
+
+  auto test_task_all = std::make_shared<plekhanov_d_dijkstra_all::TestTaskALL>(task_data_all);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_all);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  std::vector<int> expected = plekhanov_d_dijkstra_all::CalculateExpectedResult(adj_list, start_vertex);
+  if (test_task_all->GetRank() == 0) {
+    EXPECT_EQ(distances, expected);
+  }
+}

--- a/tasks/all/plekhanov_d_dijkstra/src/ops_all.cpp
+++ b/tasks/all/plekhanov_d_dijkstra/src/ops_all.cpp
@@ -1,0 +1,197 @@
+#include "all/plekhanov_d_dijkstra/include/ops_all.hpp"
+
+#include <omp.h>
+
+#include <algorithm>
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/collectives/all_reduce.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/operations.hpp>
+#include <boost/serialization/vector.hpp>  // NOLINT(misc-include-cleaner)
+#include <climits>
+#include <cstddef>
+#include <cstdlib>
+#include <functional>
+#include <utility>
+#include <vector>
+
+namespace {
+
+bool ConvertGraphToAdjacencyList(const std::vector<int>& graph_data, size_t num_vertices,
+                                 std::vector<std::vector<std::pair<int, int>>>& graph) {
+  graph.assign(num_vertices, {});
+  size_t current_vertex = 0;
+  size_t i = 0;
+  while (i < graph_data.size() && current_vertex < num_vertices) {
+    if (graph_data[i] == -1) {
+      current_vertex++;
+      i++;
+      continue;
+    }
+    if (i + 1 >= graph_data.size()) {
+      break;
+    }
+    size_t dest = graph_data[i];
+    int weight = graph_data[i + 1];
+    if (weight < 0) {
+      return false;
+    }
+    if (dest < num_vertices) {
+      graph[current_vertex].emplace_back(static_cast<int>(dest), weight);
+    }
+    i += 2;
+  }
+  return true;
+}
+
+void ProcessLocalChunk(const std::vector<std::vector<std::pair<int, int>>>& adj_list, std::vector<int>& local_dist,
+                       size_t start, size_t end, bool& updated) {
+  const int inf = INT_MAX;
+#pragma omp parallel for schedule(dynamic)
+  for (int u = static_cast<int>(start); u < static_cast<int>(end); ++u) {
+    if (local_dist[u] == inf) {
+      continue;
+    }
+
+    for (const auto& [neighbor, weight] : adj_list[u]) {
+      int new_dist = local_dist[u] + weight;
+      if (new_dist < local_dist[neighbor]) {
+#pragma omp critical
+        {
+          if (new_dist < local_dist[neighbor]) {
+            local_dist[neighbor] = new_dist;
+            updated = true;
+          }
+        }
+      }
+    }
+  }
+}
+
+void UpdateLocalDistances(const std::vector<int>& global_dist, std::vector<int>& local_dist, bool& updated) {
+#pragma omp parallel for
+  for (int i = 0; i < static_cast<int>(local_dist.size()); ++i) {
+    if (global_dist[i] < local_dist[i]) {
+      local_dist[i] = global_dist[i];
+      updated = true;
+    }
+  }
+}
+
+void ProcessAllVertices(const std::vector<std::vector<std::pair<int, int>>>& adj_list, std::vector<int>& local_dist,
+                        bool& updated) {
+  const int inf = INT_MAX;
+#pragma omp parallel for schedule(dynamic)
+  for (int u = 0; u < static_cast<int>(local_dist.size()); ++u) {
+    if (local_dist[u] == inf) {
+      continue;
+    }
+
+    for (const auto& [neighbor, weight] : adj_list[u]) {
+      int new_dist = local_dist[u] + weight;
+      if (new_dist < local_dist[neighbor]) {
+#pragma omp critical
+        {
+          if (new_dist < local_dist[neighbor]) {
+            local_dist[neighbor] = new_dist;
+            updated = true;
+          }
+        }
+      }
+    }
+  }
+}
+
+bool CheckGlobalUpdate(const boost::mpi::communicator& world, bool local_updated) {
+  int local_updated_int = local_updated ? 1 : 0;
+  int global_updated = 0;
+  boost::mpi::all_reduce(world, local_updated_int, global_updated, std::plus<>());
+  return (global_updated > 0);
+}
+
+void UpdateFinalDistances(const boost::mpi::communicator& world, const std::vector<int>& local_dist,
+                          std::vector<int>& distances) {
+  std::vector<int> final_dist(local_dist.size());
+  boost::mpi::all_reduce(world, local_dist.data(), static_cast<int>(local_dist.size()), final_dist.data(),
+                         boost::mpi::minimum<int>());
+
+#pragma omp parallel for
+  for (int i = 0; i < static_cast<int>(distances.size()); ++i) {
+    distances[i] = final_dist[i];
+  }
+}
+
+}  // namespace
+
+const int plekhanov_d_dijkstra_all::TestTaskALL::kEndOfVertexList = -1;
+
+bool plekhanov_d_dijkstra_all::TestTaskALL::PreProcessingImpl() {
+  unsigned int input_size = task_data->inputs_count[0];
+  auto* in_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
+  graph_data_.assign(in_ptr, in_ptr + input_size);
+  num_vertices_ = task_data->outputs_count[0];
+  distances_.assign(num_vertices_, INT_MAX);
+
+  if (task_data->inputs.size() > 1 && task_data->inputs[1] != nullptr) {
+    start_vertex_ = *reinterpret_cast<int*>(task_data->inputs[1]);
+  } else {
+    start_vertex_ = 0;
+  }
+  distances_[start_vertex_] = 0;
+  return true;
+}
+
+bool plekhanov_d_dijkstra_all::TestTaskALL::ValidationImpl() {
+  if (world_.rank() == 0) {
+    return !task_data->inputs_count.empty() && task_data->inputs_count[0] > 0 && !task_data->outputs_count.empty() &&
+           task_data->outputs_count[0] > 0;
+  }
+  return true;
+}
+
+bool plekhanov_d_dijkstra_all::TestTaskALL::RunImpl() {
+  std::vector<std::vector<std::pair<int, int>>> adj_list(num_vertices_);
+  if (!ConvertGraphToAdjacencyList(graph_data_, num_vertices_, adj_list)) {
+    return false;
+  }
+
+  const int inf = INT_MAX;
+  std::vector<int> local_dist(num_vertices_, inf);
+  local_dist[start_vertex_] = 0;
+
+  const size_t chunk_size = (num_vertices_ + world_.size() - 1) / world_.size();
+  const size_t start = world_.rank() * chunk_size;
+  const size_t end = std::min(start + chunk_size, num_vertices_);
+
+  bool updated = true;
+  size_t iteration = 0;
+  const size_t max_iterations = num_vertices_;
+
+  while (updated && iteration < max_iterations) {
+    updated = false;
+    iteration++;
+
+    ProcessLocalChunk(adj_list, local_dist, start, end, updated);
+
+    std::vector<int> global_dist(num_vertices_);
+    boost::mpi::all_reduce(world_, local_dist.data(), static_cast<int>(num_vertices_), global_dist.data(),
+                           boost::mpi::minimum<int>());
+
+    UpdateLocalDistances(global_dist, local_dist, updated);
+    ProcessAllVertices(adj_list, local_dist, updated);
+    updated = CheckGlobalUpdate(world_, updated);
+  }
+
+  ::UpdateFinalDistances(world_, local_dist, distances_);
+  return true;
+}
+
+bool plekhanov_d_dijkstra_all::TestTaskALL::PostProcessingImpl() {
+  if (world_.rank() == 0) {
+    auto* output = reinterpret_cast<int*>(task_data->outputs[0]);
+    for (size_t i = 0; i < distances_.size(); ++i) {
+      output[i] = distances_[i];
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
Падения тестов связаны с тем, что в некоторых работах не освобождается коммуникатор.