### PR TITLE
Ануфриев Даниил. Задача 1. Вариант 11. Технология MPI + TBB. Вычисление многомерных интегралов с использованием многошаговой схемы (метод Симпсона). 

### DIFF
--- a/tasks/all/anufriev_d_integrals_simpson/func_tests/func_all.cpp
+++ b/tasks/all/anufriev_d_integrals_simpson/func_tests/func_all.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#define OMPI_SKIP_MPICXX
 #include <mpi.h>
 
 #include <cstdint>

--- a/tasks/all/anufriev_d_integrals_simpson/func_tests/func_all.cpp
+++ b/tasks/all/anufriev_d_integrals_simpson/func_tests/func_all.cpp
@@ -1,5 +1,5 @@
 #include <gtest/gtest.h>
-#include <mpi.h> // Добавляем MPI
+#include <mpi.h>
 
 #include <cstdint>
 #include <limits>
@@ -7,23 +7,23 @@
 #include <numbers>
 #include <vector>
 
-#include "core/task/include/task.hpp"
 #include "all/anufriev_d_integrals_simpson/include/ops_all.hpp"
+#include "core/task/include/task.hpp"
 
 namespace {
-  const double kPi = std::numbers::pi;
+const double kPi = std::numbers::pi;
 
-  std::shared_ptr<ppc::core::TaskData> MakeTaskData(const std::vector<double>& elements,
-                                                    std::vector<double>& out_buffer) {
-    auto task_data = std::make_shared<ppc::core::TaskData>();
-    auto* input_ptr = reinterpret_cast<uint8_t*>(const_cast<double*>(elements.data()));
-    auto* output_ptr = reinterpret_cast<uint8_t*>(out_buffer.data());
-    task_data->inputs.push_back(input_ptr);
-    task_data->inputs_count.push_back(static_cast<uint32_t>(elements.size() * sizeof(double)));
-    task_data->outputs.push_back(output_ptr);
-    task_data->outputs_count.push_back(static_cast<uint32_t>(out_buffer.size() * sizeof(double)));
-    return task_data;
-  }
+std::shared_ptr<ppc::core::TaskData> MakeTaskData(const std::vector<double>& elements,
+                                                  std::vector<double>& out_buffer) {
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  auto* input_ptr = reinterpret_cast<uint8_t*>(const_cast<double*>(elements.data()));
+  auto* output_ptr = reinterpret_cast<uint8_t*>(out_buffer.data());
+  task_data->inputs.push_back(input_ptr);
+  task_data->inputs_count.push_back(static_cast<uint32_t>(elements.size() * sizeof(double)));
+  task_data->outputs.push_back(output_ptr);
+  task_data->outputs_count.push_back(static_cast<uint32_t>(out_buffer.size() * sizeof(double)));
+  return task_data;
+}
 }  // namespace
 
 TEST(anufriev_d_integrals_simpson_all, test_1D_sin) {

--- a/tasks/all/anufriev_d_integrals_simpson/func_tests/func_all.cpp
+++ b/tasks/all/anufriev_d_integrals_simpson/func_tests/func_all.cpp
@@ -1,0 +1,255 @@
+#include <gtest/gtest.h>
+#include <mpi.h> // Добавляем MPI
+
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <numbers>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "all/anufriev_d_integrals_simpson/include/ops_all.hpp"
+
+namespace {
+  const double kPi = std::numbers::pi;
+
+  std::shared_ptr<ppc::core::TaskData> MakeTaskData(const std::vector<double>& elements,
+                                                    std::vector<double>& out_buffer) {
+    auto task_data = std::make_shared<ppc::core::TaskData>();
+    auto* input_ptr = reinterpret_cast<uint8_t*>(const_cast<double*>(elements.data()));
+    auto* output_ptr = reinterpret_cast<uint8_t*>(out_buffer.data());
+    task_data->inputs.push_back(input_ptr);
+    task_data->inputs_count.push_back(static_cast<uint32_t>(elements.size() * sizeof(double)));
+    task_data->outputs.push_back(output_ptr);
+    task_data->outputs_count.push_back(static_cast<uint32_t>(out_buffer.size() * sizeof(double)));
+    return task_data;
+  }
+}  // namespace
+
+TEST(anufriev_d_integrals_simpson_all, test_1D_sin) {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  std::vector<double> in = {1, 0.0, kPi / 2.0, 100, 1};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_all::IntegralsSimpsonAll task(td);
+
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+
+  if (rank == 0) {
+    double result = out_buffer[0];
+    EXPECT_NEAR(result, 1.0, 1e-3);
+  }
+}
+
+TEST(anufriev_d_integrals_simpson_all, test_2D_sum_of_squares) {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  std::vector<double> in = {2, 0.0, 1.0, 100, 0.0, 1.0, 100, 0};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_all::IntegralsSimpsonAll task(td);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+  if (rank == 0) {
+    double result = out_buffer[0];
+    EXPECT_NEAR(result, 2.0 / 3.0, 1e-3);
+  }
+}
+
+TEST(anufriev_d_integrals_simpson_all, test_2D_sin_cos) {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  std::vector<double> in = {2, 0.0, kPi / 2.0, 200, 0.0, kPi / 2.0, 200, 1};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_all::IntegralsSimpsonAll task(td);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+  if (rank == 0) {
+    double result = out_buffer[0];
+    EXPECT_NEAR(result, 1.0, 1e-3);
+  }
+}
+
+TEST(anufriev_d_integrals_simpson_all, test_unknown_func) {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  std::vector<double> in = {1, 0.0, 1.0, 2, 999};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_all::IntegralsSimpsonAll task(td);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+  if (rank == 0) {
+    double result = out_buffer[0];
+    EXPECT_DOUBLE_EQ(result, 0.0);
+  }
+}
+
+TEST(anufriev_d_integrals_simpson_all, test_invalid_empty_input_ptr) {
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.push_back(nullptr);
+  task_data->inputs_count.push_back(0);
+  std::vector<double> out_buffer(1, 0.0);
+  task_data->outputs.push_back(reinterpret_cast<uint8_t*>(out_buffer.data()));
+  task_data->outputs_count.push_back(sizeof(double));
+
+  anufriev_d_integrals_simpson_all::IntegralsSimpsonAll task(task_data);
+  ASSERT_FALSE(task.PreProcessingImpl());
+}
+
+TEST(anufriev_d_integrals_simpson_all, test_invalid_output_buffer) {
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  std::vector<double> in = {1, 0.0, 1.0, 2, 0};
+  task_data->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<double*>(in.data())));
+  task_data->inputs_count.push_back(in.size() * sizeof(double));
+  task_data->outputs.push_back(nullptr);
+  task_data->outputs_count.push_back(0);
+
+  anufriev_d_integrals_simpson_all::IntegralsSimpsonAll task(task_data);
+  ASSERT_FALSE(task.ValidationImpl());
+}
+
+TEST(anufriev_d_integrals_simpson_all, test_invalid_dimension_zero) {
+  std::vector<double> in = {0, 0.0, 1.0, 2, 999};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_all::IntegralsSimpsonAll task(td);
+  EXPECT_FALSE(task.PreProcessingImpl());
+}
+
+TEST(anufriev_d_integrals_simpson_all, test_invalid_dimension_negative) {
+  std::vector<double> in = {-1, 0.0, 1.0, 2, 999};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_all::IntegralsSimpsonAll task(td);
+  EXPECT_FALSE(task.PreProcessingImpl());
+}
+
+TEST(anufriev_d_integrals_simpson_all, test_invalid_not_enough_data) {
+  std::vector<double> in = {2, 0.0, 1.0, 200};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_all::IntegralsSimpsonAll task(td);
+  EXPECT_FALSE(task.PreProcessingImpl());
+}
+
+TEST(anufriev_d_integrals_simpson_all, test_invalid_odd_n) {
+  std::vector<double> in = {1, 0.0, 1.0, 3, 0};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_all::IntegralsSimpsonAll task(td);
+  EXPECT_FALSE(task.PreProcessingImpl());
+}
+
+TEST(anufriev_d_integrals_simpson_all, test_invalid_negative_n) {
+  std::vector<double> in = {1, 0.0, 1.0, -2, 0};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_all::IntegralsSimpsonAll task(td);
+  EXPECT_FALSE(task.PreProcessingImpl());
+}
+
+TEST(anufriev_d_integrals_simpson_all, test_no_output_buffer_in_taskdata) {
+  std::vector<double> in = {1, 0.0, 1.0, 2, 0};
+  auto td = std::make_shared<ppc::core::TaskData>();
+  td->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<double*>(in.data())));
+  td->inputs_count.push_back(static_cast<std::uint32_t>(in.size() * sizeof(double)));
+  anufriev_d_integrals_simpson_all::IntegralsSimpsonAll task(td);
+  EXPECT_FALSE(task.Validation());
+}
+
+TEST(anufriev_d_integrals_simpson_all, test_invalid_n_not_integer) {
+  std::vector<double> in = {1, 0.0, 1.0, 100.5, 0};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_all::IntegralsSimpsonAll task(td);
+  EXPECT_FALSE(task.PreProcessingImpl());
+}
+
+TEST(anufriev_d_integrals_simpson_all, test_invalid_n_too_large) {
+  std::vector<double> in = {1, 0.0, 1.0, static_cast<double>(std::numeric_limits<int>::max()) + 10.0, 0};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_all::IntegralsSimpsonAll task(td);
+  EXPECT_FALSE(task.PreProcessingImpl());
+}
+
+TEST(anufriev_d_integrals_simpson_all, test_invalid_func_code_not_integer) {
+  std::vector<double> in = {1, 0.0, 1.0, 100, 1.5};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_all::IntegralsSimpsonAll task(td);
+  EXPECT_FALSE(task.PreProcessingImpl());
+}
+
+TEST(anufriev_d_integrals_simpson_all, test_invalid_func_code_too_large) {
+  std::vector<double> in = {1, 0.0, 1.0, 100, static_cast<double>(std::numeric_limits<int>::max()) + 10.0};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_all::IntegralsSimpsonAll task(td);
+  EXPECT_FALSE(task.PreProcessingImpl());
+}
+
+TEST(anufriev_d_integrals_simpson_all, test_invalid_func_code_too_small) {
+  std::vector<double> in = {1, 0.0, 1.0, 100, static_cast<double>(std::numeric_limits<int>::min()) - 10.0};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_all::IntegralsSimpsonAll task(td);
+  EXPECT_FALSE(task.PreProcessingImpl());
+}
+
+TEST(anufriev_d_integrals_simpson_all, test_a_greater_than_b) {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  std::vector<double> in = {1, 1.0, 0.0, 100, 0};
+  std::vector<double> out_buffer(1, 0.0);
+  auto td = MakeTaskData(in, out_buffer);
+  anufriev_d_integrals_simpson_all::IntegralsSimpsonAll task(td);
+  ASSERT_TRUE(task.Validation());
+  ASSERT_TRUE(task.PreProcessing());
+  ASSERT_TRUE(task.Run());
+  ASSERT_TRUE(task.PostProcessing());
+  if (rank == 0) {
+    double result = out_buffer[0];
+    EXPECT_NEAR(result, -1.0 / 3.0, 1e-3);
+  }
+}
+
+TEST(anufriev_d_integrals_simpson_all, test_invalid_empty_output_count) {
+  std::vector<double> in = {1, 0.0, 1.0, 2, 0};
+  std::vector<double> out_buf(1);
+  auto td = std::make_shared<ppc::core::TaskData>();
+  td->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<double*>(in.data())));
+  td->inputs_count.push_back(static_cast<std::uint32_t>(in.size() * sizeof(double)));
+  td->outputs.push_back(reinterpret_cast<uint8_t*>(out_buf.data()));
+  anufriev_d_integrals_simpson_all::IntegralsSimpsonAll task(td);
+  EXPECT_FALSE(task.ValidationImpl());
+}
+
+TEST(anufriev_d_integrals_simpson_all, test_invalid_small_output_count) {
+  std::vector<double> in = {1, 0.0, 1.0, 2, 0};
+  std::vector<double> out_buf(1);
+  auto td = std::make_shared<ppc::core::TaskData>();
+  td->inputs.push_back(reinterpret_cast<uint8_t*>(const_cast<double*>(in.data())));
+  td->inputs_count.push_back(static_cast<std::uint32_t>(in.size() * sizeof(double)));
+  td->outputs.push_back(reinterpret_cast<uint8_t*>(out_buf.data()));
+  td->outputs_count.push_back(sizeof(double) - 1);
+  anufriev_d_integrals_simpson_all::IntegralsSimpsonAll task(td);
+  EXPECT_FALSE(task.ValidationImpl());
+}

--- a/tasks/all/anufriev_d_integrals_simpson/include/ops_all.hpp
+++ b/tasks/all/anufriev_d_integrals_simpson/include/ops_all.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#define OMPI_SKIP_MPICXX
 #include <mpi.h>
 
 #include <utility>

--- a/tasks/all/anufriev_d_integrals_simpson/include/ops_all.hpp
+++ b/tasks/all/anufriev_d_integrals_simpson/include/ops_all.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <mpi.h>
+
 #include <utility>
 #include <vector>
-#include <mpi.h>
 
 #include "core/task/include/task.hpp"
 

--- a/tasks/all/anufriev_d_integrals_simpson/include/ops_all.hpp
+++ b/tasks/all/anufriev_d_integrals_simpson/include/ops_all.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+#include <mpi.h>
+
+#include "core/task/include/task.hpp"
+
+namespace anufriev_d_integrals_simpson_all {
+
+class IntegralsSimpsonAll : public ppc::core::Task {
+ public:
+  explicit IntegralsSimpsonAll(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  int dimension_{};
+
+  std::vector<double> a_, b_;
+  std::vector<int> n_;
+  int func_code_{};
+  double result_{};
+
+  [[nodiscard]] double FunctionN(const std::vector<double>& coords) const;
+};
+
+}  // namespace anufriev_d_integrals_simpson_all

--- a/tasks/all/anufriev_d_integrals_simpson/include/ops_all.hpp
+++ b/tasks/all/anufriev_d_integrals_simpson/include/ops_all.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-#define OMPI_SKIP_MPICXX
-#include <mpi.h>
-
 #include <utility>
 #include <vector>
 

--- a/tasks/all/anufriev_d_integrals_simpson/perf_tests/perf_all.cpp
+++ b/tasks/all/anufriev_d_integrals_simpson/perf_tests/perf_all.cpp
@@ -22,9 +22,9 @@ TEST(anufriev_d_integrals_simpson_all, test_pipeline_run) {
 
   if (rank == 0) {
     task_data_all->inputs.push_back(reinterpret_cast<uint8_t*>(in.data()));
-    task_data_all->inputs_count.push_back(static_cast<std::uint32_t>(in.size() * sizeof(double)));
+    task_data_all->inputs_count.push_back(static_cast<uint32_t>(in.size() * sizeof(double)));
     task_data_all->outputs.push_back(reinterpret_cast<uint8_t*>(out.data()));
-    task_data_all->outputs_count.push_back(static_cast<std::uint32_t>(out.size() * sizeof(double)));
+    task_data_all->outputs_count.push_back(static_cast<uint32_t>(out.size() * sizeof(double)));
   }
 
   auto task_all = std::make_shared<anufriev_d_integrals_simpson_all::IntegralsSimpsonAll>(task_data_all);
@@ -61,9 +61,9 @@ TEST(anufriev_d_integrals_simpson_all, test_task_run) {
   auto task_data_all = std::make_shared<ppc::core::TaskData>();
   if (rank == 0) {
     task_data_all->inputs.push_back(reinterpret_cast<uint8_t*>(in.data()));
-    task_data_all->inputs_count.push_back(static_cast<std::uint32_t>(in.size() * sizeof(double)));
+    task_data_all->inputs_count.push_back(static_cast<uint32_t>(in.size() * sizeof(double)));
     task_data_all->outputs.push_back(reinterpret_cast<uint8_t*>(out.data()));
-    task_data_all->outputs_count.push_back(static_cast<std::uint32_t>(out.size() * sizeof(double)));
+    task_data_all->outputs_count.push_back(static_cast<uint32_t>(out.size() * sizeof(double)));
   }
 
   auto task_all = std::make_shared<anufriev_d_integrals_simpson_all::IntegralsSimpsonAll>(task_data_all);

--- a/tasks/all/anufriev_d_integrals_simpson/perf_tests/perf_all.cpp
+++ b/tasks/all/anufriev_d_integrals_simpson/perf_tests/perf_all.cpp
@@ -6,10 +6,9 @@
 #include <memory>
 #include <vector>
 
+#include "all/anufriev_d_integrals_simpson/include/ops_all.hpp"
 #include "core/perf/include/perf.hpp"
 #include "core/task/include/task.hpp"
-
-#include "all/anufriev_d_integrals_simpson/include/ops_all.hpp"
 
 TEST(anufriev_d_integrals_simpson_all, test_pipeline_run) {
   int rank = 0;
@@ -26,7 +25,6 @@ TEST(anufriev_d_integrals_simpson_all, test_pipeline_run) {
     task_data_all->outputs.push_back(reinterpret_cast<uint8_t*>(out.data()));
     task_data_all->outputs_count.push_back(static_cast<std::uint32_t>(out.size() * sizeof(double)));
   }
-
 
   auto task_all = std::make_shared<anufriev_d_integrals_simpson_all::IntegralsSimpsonAll>(task_data_all);
 
@@ -60,7 +58,7 @@ TEST(anufriev_d_integrals_simpson_all, test_task_run) {
   std::vector<double> out(1, 0.0);
 
   auto task_data_all = std::make_shared<ppc::core::TaskData>();
-   if (rank == 0) {
+  if (rank == 0) {
     task_data_all->inputs.push_back(reinterpret_cast<uint8_t*>(in.data()));
     task_data_all->inputs_count.push_back(static_cast<std::uint32_t>(in.size() * sizeof(double)));
     task_data_all->outputs.push_back(reinterpret_cast<uint8_t*>(out.data()));

--- a/tasks/all/anufriev_d_integrals_simpson/perf_tests/perf_all.cpp
+++ b/tasks/all/anufriev_d_integrals_simpson/perf_tests/perf_all.cpp
@@ -1,0 +1,92 @@
+#include <gtest/gtest.h>
+#include <mpi.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+
+#include "all/anufriev_d_integrals_simpson/include/ops_all.hpp"
+
+TEST(anufriev_d_integrals_simpson_all, test_pipeline_run) {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  std::vector<double> in = {2, 0.0, 1.0, 2000, 0.0, 1.0, 2000, 0};
+  std::vector<double> out(1, 0.0);
+
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+
+  if (rank == 0) {
+    task_data_all->inputs.push_back(reinterpret_cast<uint8_t*>(in.data()));
+    task_data_all->inputs_count.push_back(static_cast<std::uint32_t>(in.size() * sizeof(double)));
+    task_data_all->outputs.push_back(reinterpret_cast<uint8_t*>(out.data()));
+    task_data_all->outputs_count.push_back(static_cast<std::uint32_t>(out.size() * sizeof(double)));
+  }
+
+
+  auto task_all = std::make_shared<anufriev_d_integrals_simpson_all::IntegralsSimpsonAll>(task_data_all);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+
+  const auto t_global_start = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t_global_start).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(task_all);
+
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+
+  if (rank == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
+    double result = out[0];
+    EXPECT_NEAR(result, 2.0 / 3.0, 1e-3);
+  }
+}
+
+TEST(anufriev_d_integrals_simpson_all, test_task_run) {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  std::vector<double> in = {2, 0.0, 1.0, 2000, 0.0, 1.0, 2000, 0};
+  std::vector<double> out(1, 0.0);
+
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+   if (rank == 0) {
+    task_data_all->inputs.push_back(reinterpret_cast<uint8_t*>(in.data()));
+    task_data_all->inputs_count.push_back(static_cast<std::uint32_t>(in.size() * sizeof(double)));
+    task_data_all->outputs.push_back(reinterpret_cast<uint8_t*>(out.data()));
+    task_data_all->outputs_count.push_back(static_cast<std::uint32_t>(out.size() * sizeof(double)));
+  }
+
+  auto task_all = std::make_shared<anufriev_d_integrals_simpson_all::IntegralsSimpsonAll>(task_data_all);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+
+  const auto t_global_start = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t_global_start).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(task_all);
+
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+
+  if (rank == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
+    double result = out[0];
+    EXPECT_NEAR(result, 2.0 / 3.0, 1e-3);
+  }
+}

--- a/tasks/all/anufriev_d_integrals_simpson/perf_tests/perf_all.cpp
+++ b/tasks/all/anufriev_d_integrals_simpson/perf_tests/perf_all.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#define OMPI_SKIP_MPICXX
 #include <mpi.h>
 
 #include <chrono>

--- a/tasks/all/anufriev_d_integrals_simpson/src/ops_all.cpp
+++ b/tasks/all/anufriev_d_integrals_simpson/src/ops_all.cpp
@@ -1,5 +1,6 @@
 #include "all/anufriev_d_integrals_simpson/include/ops_all.hpp"
 
+#define OMPI_SKIP_MPICXX
 #include <mpi.h>
 #include <oneapi/tbb/blocked_range.h>
 #include <oneapi/tbb/parallel_reduce.h>

--- a/tasks/all/anufriev_d_integrals_simpson/src/ops_all.cpp
+++ b/tasks/all/anufriev_d_integrals_simpson/src/ops_all.cpp
@@ -9,7 +9,6 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
-#include <exception>
 #include <limits>
 #include <memory>
 #include <vector>
@@ -346,16 +345,12 @@ bool IntegralsSimpsonAll::PostProcessingImpl() {
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
   if (rank == 0) {
-    try {
-      if (task_data == nullptr || task_data->outputs.empty() || task_data->outputs[0] == nullptr ||
-          task_data->outputs_count.empty() || task_data->outputs_count[0] < sizeof(double)) {
-        return false;
-      }
-      auto* out_ptr = reinterpret_cast<double*>(task_data->outputs[0]);
-      out_ptr[0] = result_;
-    } catch (const std::exception& e) {
+    if (task_data == nullptr || task_data->outputs.empty() || task_data->outputs[0] == nullptr ||
+        task_data->outputs_count.empty() || task_data->outputs_count[0] < sizeof(double)) {
       return false;
     }
+    auto* out_ptr = reinterpret_cast<double*>(task_data->outputs[0]);
+    out_ptr[0] = result_;
   }
   return true;
 }

--- a/tasks/all/anufriev_d_integrals_simpson/src/ops_all.cpp
+++ b/tasks/all/anufriev_d_integrals_simpson/src/ops_all.cpp
@@ -1,16 +1,16 @@
 #include "all/anufriev_d_integrals_simpson/include/ops_all.hpp"
 
+#include <mpi.h>
 #include <oneapi/tbb/blocked_range.h>
 #include <oneapi/tbb/parallel_reduce.h>
-#include <mpi.h>
 
 #include <cmath>
 #include <cstddef>
 #include <exception>
 #include <iostream>
 #include <limits>
-#include <vector>
 #include <numeric>
+#include <vector>
 
 namespace {
 
@@ -48,7 +48,7 @@ double IntegralsSimpsonAll::FunctionN(const std::vector<double>& coords) const {
       return val;
     }
     default:
-    return 0.0;
+      return 0.0;
   }
 }
 
@@ -84,7 +84,7 @@ bool IntegralsSimpsonAll::PreProcessingImpl() {
           }
         }
       }
-        
+
       if (root_status == 1) {
         a_.resize(dimension_);
         b_.resize(dimension_);
@@ -95,16 +95,18 @@ bool IntegralsSimpsonAll::PreProcessingImpl() {
           a_[i] = in_ptr[idx_ptr++];
           b_[i] = in_ptr[idx_ptr++];
           double n_double = in_ptr[idx_ptr++];
-          if (std::floor(n_double) != n_double || n_double > static_cast<double>(std::numeric_limits<int>::max()) || n_double <= 0.0 || (static_cast<int>(n_double) % 2 != 0) ) {
-            root_status = 0; break;
+          if (std::floor(n_double) != n_double || n_double > static_cast<double>(std::numeric_limits<int>::max()) ||
+              n_double <= 0.0 || (static_cast<int>(n_double) % 2 != 0) ) {
+            root_status = 0;
+            break;
           }
           n_[i] = static_cast<int>(n_double);
         }
         if (root_status == 1) {
           double func_code_double = in_ptr[idx_ptr];
           if (std::floor(func_code_double) != func_code_double ||
-            func_code_double > static_cast<double>(std::numeric_limits<int>::max()) ||
-            func_code_double < static_cast<double>(std::numeric_limits<int>::min())) {
+              func_code_double > static_cast<double>(std::numeric_limits<int>::max()) ||
+              func_code_double < static_cast<double>(std::numeric_limits<int>::min())) {
             root_status = 0;
           } else {
             func_code_ = static_cast<int>(func_code_double);
@@ -132,13 +134,13 @@ bool IntegralsSimpsonAll::PreProcessingImpl() {
   MPI_Bcast(b_.data(), dimension_, MPI_DOUBLE, 0, MPI_COMM_WORLD);
   MPI_Bcast(n_.data(), dimension_, MPI_INT, 0, MPI_COMM_WORLD);
   MPI_Bcast(&func_code_, 1, MPI_INT, 0, MPI_COMM_WORLD);
-  
+
   if (rank != 0) {
-      for (int val_n : n_) {
-          if (val_n <= 0 || (val_n % 2) != 0) {
-              return false;
-          }
+    for (int val_n : n_) {
+      if (val_n <= 0 || (val_n % 2) != 0) {
+        return false;
       }
+    }
   }
 
   result_ = 0.0;
@@ -179,18 +181,18 @@ bool IntegralsSimpsonAll::RunImpl() {
     size_t points_in_dim = static_cast<size_t>(n_[i]) + 1;
 
     if (total_points > std::numeric_limits<size_t>::max() / points_in_dim) {
-      return false; 
+      return false;
     }
     total_points *= points_in_dim;
   }
 
   if (total_points == 0 && dimension_ > 0) {
-      result_ = 0.0;
+    result_ = 0.0;
   }
 
   size_t points_per_rank_base = total_points / static_cast<size_t>(world_size);
   size_t remainder_points = total_points % static_cast<size_t>(world_size);
-  
+
   size_t local_start_k;
   size_t num_points_for_this_rank;
 
@@ -202,7 +204,7 @@ bool IntegralsSimpsonAll::RunImpl() {
     local_start_k = static_cast<size_t>(rank) * points_per_rank_base + remainder_points;
   }
   size_t local_end_k = local_start_k + num_points_for_this_rank;
-  
+
   if (total_points == 0) {
     local_start_k = 0;
     local_end_k = 0;
@@ -210,29 +212,29 @@ bool IntegralsSimpsonAll::RunImpl() {
 
   double local_sum = 0.0;
   if (local_start_k < local_end_k) {
-      local_sum = tbb::parallel_reduce(
-          tbb::blocked_range<size_t>(local_start_k, local_end_k), 0.0,
-          [&](const tbb::blocked_range<size_t>& r, double running_sum) {
-            std::vector<double> coords(dimension_);
-            std::vector<int> current_idx(dimension_);
+    local_sum = tbb::parallel_reduce(
+        tbb::blocked_range<size_t>(local_start_k, local_end_k), 0.0,
+        [&](const tbb::blocked_range<size_t>& r, double running_sum) {
+          std::vector<double> coords(dimension_);
+          std::vector<int> current_idx(dimension_);
 
-            for (size_t k = r.begin(); k != r.end(); ++k) {
-              double current_coeff_prod = 1.0;
-              size_t current_k = k;
-              for (int dim_idx = 0; dim_idx < dimension_; ++dim_idx) {
-                size_t points_in_this_dim = static_cast<size_t>(n_[dim_idx]) + 1;
-                size_t index_in_this_dim = current_k % points_in_this_dim;
-                current_idx[dim_idx] = static_cast<int>(index_in_this_dim);
-                current_k /= points_in_this_dim;
+          for (size_t k = r.begin(); k != r.end(); ++k) {
+            double current_coeff_prod = 1.0;
+            size_t current_k = k;
+            for (int dim_idx = 0; dim_idx < dimension_; ++dim_idx) {
+              size_t points_in_this_dim = static_cast<size_t>(n_[dim_idx]) + 1;
+              size_t index_in_this_dim = current_k % points_in_this_dim;
+              current_idx[dim_idx] = static_cast<int>(index_in_this_dim);
+              current_k /= points_in_this_dim;
 
-                coords[dim_idx] = a_[dim_idx] + current_idx[dim_idx] * steps[dim_idx];
-                current_coeff_prod *= SimpsonCoeff(current_idx[dim_idx], n_[dim_idx]);
-              }
-              running_sum += current_coeff_prod * FunctionN(coords);
-            }
-            return running_sum;
-          },
-          [](double x, double y) { return x + y; });
+              coords[dim_idx] = a_[dim_idx] + current_idx[dim_idx] * steps[dim_idx];
+              current_coeff_prod *= SimpsonCoeff(current_idx[dim_idx], n_[dim_idx]);
+             }
+            running_sum += current_coeff_prod * FunctionN(coords);
+          }
+          return running_sum;
+        },
+        [](double x, double y) { return x + y; });
   }
 
   double global_sum = 0.0;
@@ -243,7 +245,7 @@ bool IntegralsSimpsonAll::RunImpl() {
   } else {
     result_ = local_sum;
   }
-  
+
   return true;
 }
 
@@ -254,10 +256,10 @@ bool IntegralsSimpsonAll::PostProcessingImpl() {
 
   if (rank == 0) {
     try {
-      if (task_data->outputs.empty() || task_data->outputs[0] == nullptr ||
-          task_data->outputs_count.empty() || task_data->outputs_count[0] < sizeof(double)) {
-          std::cerr << "Error: Output buffer not properly set up for rank 0 during PostProcessing.\n";
-          return false;
+      if (task_data->outputs.empty() || task_data->outputs[0] == nullptr || task_data->outputs_count.empty() ||
+          task_data->outputs_count[0] < sizeof(double)) {
+        std::cerr << "Error: Output buffer not properly set up for rank 0 during PostProcessing.\n";
+        return false;
       }
       auto* out_ptr = reinterpret_cast<double*>(task_data->outputs[0]);
       out_ptr[0] = result_;

--- a/tasks/all/anufriev_d_integrals_simpson/src/ops_all.cpp
+++ b/tasks/all/anufriev_d_integrals_simpson/src/ops_all.cpp
@@ -96,7 +96,7 @@ bool IntegralsSimpsonAll::PreProcessingImpl() {
           b_[i] = in_ptr[idx_ptr++];
           double n_double = in_ptr[idx_ptr++];
           if (std::floor(n_double) != n_double || n_double > static_cast<double>(std::numeric_limits<int>::max()) ||
-              n_double <= 0.0 || (static_cast<int>(n_double) % 2 != 0) ) {
+              n_double <= 0.0 || (static_cast<int>(n_double) % 2 != 0)) {
             root_status = 0;
             break;
           }
@@ -229,7 +229,7 @@ bool IntegralsSimpsonAll::RunImpl() {
 
               coords[dim_idx] = a_[dim_idx] + current_idx[dim_idx] * steps[dim_idx];
               current_coeff_prod *= SimpsonCoeff(current_idx[dim_idx], n_[dim_idx]);
-             }
+            }
             running_sum += current_coeff_prod * FunctionN(coords);
           }
           return running_sum;
@@ -248,7 +248,6 @@ bool IntegralsSimpsonAll::RunImpl() {
 
   return true;
 }
-
 
 bool IntegralsSimpsonAll::PostProcessingImpl() {
   int rank = 0;

--- a/tasks/all/anufriev_d_integrals_simpson/src/ops_all.cpp
+++ b/tasks/all/anufriev_d_integrals_simpson/src/ops_all.cpp
@@ -154,7 +154,7 @@ bool IntegralsSimpsonAll::ValidationImpl() {
 
   if (rank == 0) {
     if (task_data == nullptr) {
-        validation_status_root = 0;
+      validation_status_root = 0;
     } else if (task_data->outputs.empty() || task_data->outputs[0] == nullptr) {
       validation_status_root = 0;
     } else if (task_data->outputs_count.empty() || task_data->outputs_count[0] < sizeof(double)) {
@@ -165,7 +165,6 @@ bool IntegralsSimpsonAll::ValidationImpl() {
   MPI_Bcast(&validation_status_root, 1, MPI_INT, 0, MPI_COMM_WORLD);
 
   return (validation_status_root == 1);
-}rn true;
 }
 
 bool IntegralsSimpsonAll::RunImpl() {

--- a/tasks/all/anufriev_d_integrals_simpson/src/ops_all.cpp
+++ b/tasks/all/anufriev_d_integrals_simpson/src/ops_all.cpp
@@ -98,9 +98,8 @@ struct RunParameters {
   bool success = true;
 };
 
-RunParameters CalculateRunParameters(int p_dimension, const std::vector<int>& p_n,
-                                     const std::vector<double>& p_a, const std::vector<double>& p_b,
-                                     std::vector<double>& p_steps) {
+RunParameters CalculateRunParameters(int p_dimension, const std::vector<int>& p_n, const std::vector<double>& p_a,
+                                     const std::vector<double>& p_b, std::vector<double>& p_steps) {
   RunParameters params;
   if (p_dimension == 0) {
     params.total_points = 0;
@@ -136,7 +135,7 @@ struct MpiWorkDistribution {
 MpiWorkDistribution DistributeWorkAmongMpiRanks(size_t p_total_points, int p_rank, int p_world_size) {
   MpiWorkDistribution dist;
   if (p_total_points == 0 || p_world_size == 0) {
-    return dist; 
+    return dist;
   }
 
   size_t points_per_rank_base = p_total_points / static_cast<size_t>(p_world_size);
@@ -148,7 +147,7 @@ MpiWorkDistribution DistributeWorkAmongMpiRanks(size_t p_total_points, int p_ran
   } else {
     dist.num_points_for_this_rank = points_per_rank_base;
     dist.local_start_k = remainder_points * (points_per_rank_base + 1) + 
-                            (static_cast<size_t>(p_rank) - remainder_points) * points_per_rank_base;
+                         (static_cast<size_t>(p_rank) - remainder_points) * points_per_rank_base;
   }
   dist.local_end_k = dist.local_start_k + dist.num_points_for_this_rank;
 

--- a/tasks/all/anufriev_d_integrals_simpson/src/ops_all.cpp
+++ b/tasks/all/anufriev_d_integrals_simpson/src/ops_all.cpp
@@ -146,7 +146,7 @@ MpiWorkDistribution DistributeWorkAmongMpiRanks(size_t p_total_points, int p_ran
     dist.local_start_k = static_cast<size_t>(p_rank) * (points_per_rank_base + 1);
   } else {
     dist.num_points_for_this_rank = points_per_rank_base;
-    dist.local_start_k = remainder_points * (points_per_rank_base + 1) + 
+    dist.local_start_k = remainder_points * (points_per_rank_base + 1) +
                          (static_cast<size_t>(p_rank) - remainder_points) * points_per_rank_base;
   }
   dist.local_end_k = dist.local_start_k + dist.num_points_for_this_rank;

--- a/tasks/all/anufriev_d_integrals_simpson/src/ops_all.cpp
+++ b/tasks/all/anufriev_d_integrals_simpson/src/ops_all.cpp
@@ -1,0 +1,272 @@
+#include "all/anufriev_d_integrals_simpson/include/ops_all.hpp"
+
+#include <oneapi/tbb/blocked_range.h>
+#include <oneapi/tbb/parallel_reduce.h>
+#include <mpi.h>
+
+#include <cmath>
+#include <cstddef>
+#include <exception>
+#include <iostream>
+#include <limits>
+#include <vector>
+#include <numeric>
+
+namespace {
+
+int SimpsonCoeff(int i, int n) {
+  if (i == 0 || i == n) {
+    return 1;
+  }
+  if (i % 2 != 0) {
+    return 4;
+  }
+  return 2;
+}
+}  // namespace
+
+namespace anufriev_d_integrals_simpson_all {
+
+double IntegralsSimpsonAll::FunctionN(const std::vector<double>& coords) const {
+  switch (func_code_) {
+    case 0: {
+      double s = 0.0;
+      for (double c : coords) {
+        s += c * c;
+      }
+      return s;
+    }
+    case 1: {
+      double val = 1.0;
+      for (size_t i = 0; i < coords.size(); i++) {
+        if (i % 2 == 0) {
+          val *= std::sin(coords[i]);
+        } else {
+          val *= std::cos(coords[i]);
+        }
+      }
+      return val;
+    }
+    default:
+    return 0.0;
+  }
+}
+
+bool IntegralsSimpsonAll::PreProcessingImpl() {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  int root_status = 1;
+
+  if (rank == 0) {
+    if (task_data->inputs.empty() || task_data->inputs[0] == nullptr) {
+      root_status = 0;
+    }
+
+    if (root_status == 1) {
+      auto* in_ptr = reinterpret_cast<double*>(task_data->inputs[0]);
+      size_t in_size_bytes = task_data->inputs_count[0];
+      size_t num_doubles = in_size_bytes / sizeof(double);
+
+      if (num_doubles < 1) {
+        root_status = 0;
+      }
+
+      if (root_status == 1) {
+        int d_parsed = static_cast<int>(in_ptr[0]);
+        if (d_parsed <= 0) {
+          root_status = 0;
+        } else {
+          dimension_ = d_parsed;
+          size_t required_elements = 1 + static_cast<size_t>(3 * dimension_) + 1;
+          if (num_doubles < required_elements) {
+            root_status = 0;
+          }
+        }
+      }
+        
+      if (root_status == 1) {
+        a_.resize(dimension_);
+        b_.resize(dimension_);
+        n_.resize(dimension_);
+
+        int idx_ptr = 1;
+        for (int i = 0; i < dimension_; i++) {
+          a_[i] = in_ptr[idx_ptr++];
+          b_[i] = in_ptr[idx_ptr++];
+          double n_double = in_ptr[idx_ptr++];
+          if (std::floor(n_double) != n_double || n_double > static_cast<double>(std::numeric_limits<int>::max()) || n_double <= 0.0 || (static_cast<int>(n_double) % 2 != 0) ) {
+            root_status = 0; break;
+          }
+          n_[i] = static_cast<int>(n_double);
+        }
+        if (root_status == 1) {
+          double func_code_double = in_ptr[idx_ptr];
+          if (std::floor(func_code_double) != func_code_double ||
+            func_code_double > static_cast<double>(std::numeric_limits<int>::max()) ||
+            func_code_double < static_cast<double>(std::numeric_limits<int>::min())) {
+            root_status = 0;
+          } else {
+            func_code_ = static_cast<int>(func_code_double);
+          }
+        }
+      }
+    }
+  }
+
+  MPI_Bcast(&root_status, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  if (root_status == 0) {
+    return false;
+  }
+
+  MPI_Bcast(&dimension_, 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+  if (rank != 0) {
+    if (dimension_ <= 0) return false;
+    a_.resize(dimension_);
+    b_.resize(dimension_);
+    n_.resize(dimension_);
+  }
+
+  MPI_Bcast(a_.data(), dimension_, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Bcast(b_.data(), dimension_, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Bcast(n_.data(), dimension_, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&func_code_, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  
+  if (rank != 0) {
+      for (int val_n : n_) {
+          if (val_n <= 0 || (val_n % 2) != 0) {
+              return false;
+          }
+      }
+  }
+
+  result_ = 0.0;
+  return true;
+}
+
+bool IntegralsSimpsonAll::ValidationImpl() {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  if (rank == 0) {
+    if (task_data->outputs.empty() || task_data->outputs[0] == nullptr) {
+      return false;
+    }
+    if (task_data->outputs_count.empty() || task_data->outputs_count[0] < sizeof(double)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool IntegralsSimpsonAll::RunImpl() {
+  int rank = 0;
+  int world_size = 1;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+
+  std::vector<double> steps(dimension_);
+  size_t total_points = 1;
+  double coeff_mult = 1.0;
+
+  for (int i = 0; i < dimension_; i++) {
+    if (n_[i] == 0) {
+      return false;
+    }
+    steps[i] = (b_[i] - a_[i]) / n_[i];
+    coeff_mult *= steps[i] / 3.0;
+    size_t points_in_dim = static_cast<size_t>(n_[i]) + 1;
+
+    if (total_points > std::numeric_limits<size_t>::max() / points_in_dim) {
+      return false; 
+    }
+    total_points *= points_in_dim;
+  }
+
+  if (total_points == 0 && dimension_ > 0) {
+      result_ = 0.0;
+  }
+
+  size_t points_per_rank_base = total_points / static_cast<size_t>(world_size);
+  size_t remainder_points = total_points % static_cast<size_t>(world_size);
+  
+  size_t local_start_k;
+  size_t num_points_for_this_rank;
+
+  if (static_cast<size_t>(rank) < remainder_points) {
+    num_points_for_this_rank = points_per_rank_base + 1;
+    local_start_k = static_cast<size_t>(rank) * num_points_for_this_rank;
+  } else {
+    num_points_for_this_rank = points_per_rank_base;
+    local_start_k = static_cast<size_t>(rank) * points_per_rank_base + remainder_points;
+  }
+  size_t local_end_k = local_start_k + num_points_for_this_rank;
+  
+  if (total_points == 0) {
+    local_start_k = 0;
+    local_end_k = 0;
+  }
+
+  double local_sum = 0.0;
+  if (local_start_k < local_end_k) {
+      local_sum = tbb::parallel_reduce(
+          tbb::blocked_range<size_t>(local_start_k, local_end_k), 0.0,
+          [&](const tbb::blocked_range<size_t>& r, double running_sum) {
+            std::vector<double> coords(dimension_);
+            std::vector<int> current_idx(dimension_);
+
+            for (size_t k = r.begin(); k != r.end(); ++k) {
+              double current_coeff_prod = 1.0;
+              size_t current_k = k;
+              for (int dim_idx = 0; dim_idx < dimension_; ++dim_idx) {
+                size_t points_in_this_dim = static_cast<size_t>(n_[dim_idx]) + 1;
+                size_t index_in_this_dim = current_k % points_in_this_dim;
+                current_idx[dim_idx] = static_cast<int>(index_in_this_dim);
+                current_k /= points_in_this_dim;
+
+                coords[dim_idx] = a_[dim_idx] + current_idx[dim_idx] * steps[dim_idx];
+                current_coeff_prod *= SimpsonCoeff(current_idx[dim_idx], n_[dim_idx]);
+              }
+              running_sum += current_coeff_prod * FunctionN(coords);
+            }
+            return running_sum;
+          },
+          [](double x, double y) { return x + y; });
+  }
+
+  double global_sum = 0.0;
+  MPI_Reduce(&local_sum, &global_sum, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+
+  if (rank == 0) {
+    result_ = coeff_mult * global_sum;
+  } else {
+    result_ = local_sum;
+  }
+  
+  return true;
+}
+
+
+bool IntegralsSimpsonAll::PostProcessingImpl() {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  if (rank == 0) {
+    try {
+      if (task_data->outputs.empty() || task_data->outputs[0] == nullptr ||
+          task_data->outputs_count.empty() || task_data->outputs_count[0] < sizeof(double)) {
+          std::cerr << "Error: Output buffer not properly set up for rank 0 during PostProcessing.\n";
+          return false;
+      }
+      auto* out_ptr = reinterpret_cast<double*>(task_data->outputs[0]);
+      out_ptr[0] = result_;
+    } catch (const std::exception& e) {
+      std::cerr << "Error during PostProcessing on rank 0: " << e.what() << '\n';
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace anufriev_d_integrals_simpson_all

--- a/tasks/all/anufriev_d_integrals_simpson/src/ops_all.cpp
+++ b/tasks/all/anufriev_d_integrals_simpson/src/ops_all.cpp
@@ -150,16 +150,22 @@ bool IntegralsSimpsonAll::PreProcessingImpl() {
 bool IntegralsSimpsonAll::ValidationImpl() {
   int rank = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  int validation_status_root = 1;
 
   if (rank == 0) {
-    if (task_data->outputs.empty() || task_data->outputs[0] == nullptr) {
-      return false;
-    }
-    if (task_data->outputs_count.empty() || task_data->outputs_count[0] < sizeof(double)) {
-      return false;
+    if (task_data == nullptr) {
+        validation_status_root = 0;
+    } else if (task_data->outputs.empty() || task_data->outputs[0] == nullptr) {
+      validation_status_root = 0;
+    } else if (task_data->outputs_count.empty() || task_data->outputs_count[0] < sizeof(double)) {
+      validation_status_root = 0;
     }
   }
-  return true;
+
+  MPI_Bcast(&validation_status_root, 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+  return (validation_status_root == 1);
+}rn true;
 }
 
 bool IntegralsSimpsonAll::RunImpl() {

--- a/tasks/all/anufriev_d_integrals_simpson/src/ops_all.cpp
+++ b/tasks/all/anufriev_d_integrals_simpson/src/ops_all.cpp
@@ -121,7 +121,6 @@ double IntegralsSimpsonAll::FunctionN(const std::vector<double>& coords) const {
   }
 }
 
-
 bool IntegralsSimpsonAll::PreProcessingImpl() {
   int rank = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -241,7 +240,7 @@ bool IntegralsSimpsonAll::RunImpl() {
   if (total_points > 0) {
     size_t points_per_rank_base = total_points / static_cast<size_t>(world_size);
     size_t remainder_points = total_points % static_cast<size_t>(world_size);
-    
+
     if (static_cast<size_t>(rank) < remainder_points) {
       num_points_for_this_rank = points_per_rank_base + 1;
       local_start_k = static_cast<size_t>(rank) * num_points_for_this_rank;
@@ -250,7 +249,7 @@ bool IntegralsSimpsonAll::RunImpl() {
       local_start_k = static_cast<size_t>(rank) * points_per_rank_base + remainder_points;
     }
     local_end_k = local_start_k + num_points_for_this_rank;
-    
+
     if (local_end_k > total_points) {
       local_end_k = total_points;
     }


### PR DESCRIPTION
## Гибридная оптимизация вычисления интегралов методом Симпсона с использованием MPI и TBB
Этот Pull Request развивает предыдущую TBB-оптимизацию многомерной интеграции методом Симпсона, добавляя уровень распределенных вычислений с использованием MPI. Это позволяет масштабировать решение на кластерные системы и многоузловые архитектуры, сохраняя при этом эффективность TBB для распараллеливания внутри каждого узла.
### Основные изменения и стратегия гибридной MPI + TBB реализации:
* Двухуровневое распараллеливание:
** MPI для межпроцессного взаимодействия: Основной объем вычислений (общее количество узлов сетки интегрирования) распределяется между несколькими MPI-процессами. Каждый процесс отвечает за вычисление интеграла на своем выделенном поддиапазоне узлов.
** TBB для внутрипроцессного параллелизма: Внутри каждого MPI-процесса для обработки его локальной части узлов используется tbb::parallel_reduce, как и в предыдущей TBB-версии. Это позволяет эффективно использовать все доступные ядра на каждом узле.
* Распределение общей сетки между MPI-процессами:
** Общее количество узлов во всех измерениях (total_points) вычисляется, как и ранее.
** Этот общий диапазон узлов (от 0 до total_points - 1) делится между всеми запущенными MPI-процессами. Каждый процесс получает свой уникальный, непересекающийся поддиапазон линейных индексов k, который он будет обрабатывать.
* Обработка входных данных и инициализация:
** Головной (root) MPI-процесс (обычно rank 0) отвечает за чтение и валидацию начальных параметров задачи (размерность, пределы интегрирования, количество шагов, код функции) из task_data.
** Эти параметры затем рассылаются всем остальным MPI-процессам с использованием MPI_Bcast. Это гарантирует, что все процессы имеют одинаковые исходные данные для своей части вычислений.
* Локальные вычисления с tbb::parallel_reduce на каждом MPI-процессе:
** Каждый MPI-процесс применяет tbb::parallel_reduce к своему локальному диапазону линейных индексов k.
* Логика преобразования линейного индекса k в многомерный индекс idx и вычисления координат, коэффициентов Симпсона и значения функции остается такой же, как в чисто TBB-версии, но теперь она выполняется параллельно (с помощью TBB) внутри каждого MPI-процесса для его части работы.
** В результате tbb::parallel_reduce каждый MPI-процесс получает локальную сумму вкладов от узлов своего поддиапазона.
* Глобальная редукция результатов с помощью MPI:
** После того как все MPI-процессы вычислили свои локальные суммы, используется операция MPI_Reduce (с операцией MPI_SUM) для сбора всех локальных сумм на головной (root) процесс.
** Головной процесс получает итоговую глобальную сумму всех вкладов.
* Вычисление и вывод финального результата:
** Головной MPI-процесс умножает полученную глобальную сумму на общий коэффициент (coeff_mult, включающий шаги и коэффициент 1/3 из формулы Симпсона) для получения окончательного значения интеграла.
** Только головной процесс записывает финальный результат в выходные данные task_data.