### PR TITLE
Ополин Дмитрий. Вариант 18. Технология MPI+TBB. Поразрядная сортировка для целых чисел с четно-нечетным слиянием Бэтчера.

### DIFF
--- a/tasks/all/opolin_d_radix_sort_batcher_merge/func_tests/func_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/func_tests/func_all.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <boost/mpi/communicator.hpp>
+
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/func_tests/func_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/func_tests/func_all.cpp
@@ -1,8 +1,7 @@
 #include <gtest/gtest.h>
 
-#include <boost/mpi/communicator.hpp>
-
 #include <algorithm>
+#include <boost/mpi/communicator.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <memory>

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/func_tests/func_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/func_tests/func_all.cpp
@@ -7,8 +7,8 @@
 #include <random>
 #include <vector>
 
-#include "core/task/include/task.hpp"
 #include "all/opolin_d_radix_sort_batcher_merge/include/ops_all.hpp"
+#include "core/task/include/task.hpp"
 
 namespace opolin_d_radix_batcher_sort_all {
 namespace {

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/func_tests/func_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/func_tests/func_all.cpp
@@ -132,7 +132,7 @@ TEST(opolin_d_radix_batcher_sort_all, test_negative_values) {
   expected = {-34, -12, -7, -4, -2};
   std::vector<int> out(size, 0);
   auto task_data_all = std::make_shared<ppc::core::TaskData>();
- if (world.rank() == 0) {
+  if (world.rank() == 0) {
     task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
     task_data_all->inputs_count.emplace_back(out.size());
     task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/func_tests/func_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/func_tests/func_all.cpp
@@ -1,0 +1,320 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "all/opolin_d_radix_sort_batcher_merge/include/ops_all.hpp"
+
+namespace opolin_d_radix_batcher_sort_all {
+namespace {
+void GenDataRadixSort(size_t size, std::vector<int> &vec, std::vector<int> &expected) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> dis(-1000, 1000);
+  vec.clear();
+  expected.clear();
+  vec.reserve(size);
+  for (size_t i = 0; i < size; ++i) {
+    vec.push_back(dis(gen));
+  }
+  expected = vec;
+  std::ranges::sort(expected);
+}
+}  // namespace
+}  // namespace opolin_d_radix_batcher_sort_all
+
+TEST(opolin_d_radix_batcher_sort_all, test_size_3) {
+  boost::mpi::communicator world;
+  int size = 3;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {2, 1, 10};
+  expected = {1, 2, 10};
+
+  std::vector<int> out(size, 0);
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_all->inputs_count.emplace_back(out.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
+  }
+  auto test_task_all = std::make_shared<opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll>(task_data_all);
+  ASSERT_EQ(test_task_all->Validation(), true);
+  test_task_all->PreProcessing();
+  test_task_all->Run();
+  test_task_all->PostProcessing();
+  if (world.rank() == 0) {
+    ASSERT_EQ(out, expected);
+  }
+}
+
+TEST(opolin_d_radix_batcher_sort_all, test_size_6) {
+  boost::mpi::communicator world;
+  int size = 6;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {3, 1, 7, 0, 12, 2};
+  expected = {0, 1, 2, 3, 7, 12};
+  std::vector<int> out(size, 0);
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_all->inputs_count.emplace_back(out.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
+  }
+  auto test_task_all = std::make_shared<opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll>(task_data_all);
+  ASSERT_EQ(test_task_all->Validation(), true);
+  test_task_all->PreProcessing();
+  test_task_all->Run();
+  test_task_all->PostProcessing();
+  if (world.rank() == 0) {
+    ASSERT_EQ(out, expected);
+  }
+}
+
+TEST(opolin_d_radix_batcher_sort_all, test_empty) {
+  boost::mpi::communicator world;
+  int size = 0;
+  std::vector<int> expected;
+  std::vector<int> input;
+  std::vector<int> out;
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_all->inputs_count.emplace_back(out.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
+  }
+  auto test_task_all = std::make_shared<opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll>(task_data_all);
+  if (world.rank() == 0) {
+    ASSERT_EQ(test_task_all->Validation(), false);
+  }
+}
+
+TEST(opolin_d_radix_batcher_sort_all, test_one_element) {
+  boost::mpi::communicator world;
+  int size = 1;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {31};
+  expected = {31};
+  std::vector<int> out(size, 0);
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_all->inputs_count.emplace_back(out.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
+  }
+  auto test_task_all = std::make_shared<opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll>(task_data_all);
+  ASSERT_EQ(test_task_all->Validation(), true);
+  test_task_all->PreProcessing();
+  test_task_all->Run();
+  test_task_all->PostProcessing();
+  if (world.rank() == 0) {
+    ASSERT_EQ(out, expected);
+  }
+}
+
+TEST(opolin_d_radix_batcher_sort_all, test_negative_values) {
+  boost::mpi::communicator world;
+  int size = 5;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {-12, -4, -7, -2, -34};
+  expected = {-34, -12, -7, -4, -2};
+  std::vector<int> out(size, 0);
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+ if (world.rank() == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_all->inputs_count.emplace_back(out.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
+  }
+  auto test_task_all = std::make_shared<opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll>(task_data_all);
+  ASSERT_EQ(test_task_all->Validation(), true);
+  test_task_all->PreProcessing();
+  test_task_all->Run();
+  test_task_all->PostProcessing();
+  if (world.rank() == 0) {
+    ASSERT_EQ(out, expected);
+  }
+}
+
+TEST(opolin_d_radix_batcher_sort_all, test_sorted) {
+  boost::mpi::communicator world;
+  int size = 5;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {0, 1, 2, 6, 7};
+  expected = {0, 1, 2, 6, 7};
+
+  std::vector<int> out(size, 0);
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_all->inputs_count.emplace_back(out.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
+  }
+  auto test_task_all = std::make_shared<opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll>(task_data_all);
+  ASSERT_EQ(test_task_all->Validation(), true);
+  test_task_all->PreProcessing();
+  test_task_all->Run();
+  test_task_all->PostProcessing();
+  if (world.rank() == 0) {
+    ASSERT_EQ(out, expected);
+  }
+}
+
+TEST(opolin_d_radix_batcher_sort_all, test_equal_values) {
+  boost::mpi::communicator world;
+  int size = 3;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {2, 2, 2};
+  expected = {2, 2, 2};
+  std::vector<int> out(size, 0);
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_all->inputs_count.emplace_back(out.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
+  }
+  auto test_task_all = std::make_shared<opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll>(task_data_all);
+  ASSERT_EQ(test_task_all->Validation(), true);
+  test_task_all->PreProcessing();
+  test_task_all->Run();
+  test_task_all->PostProcessing();
+  if (world.rank() == 0) {
+    ASSERT_EQ(out, expected);
+  }
+}
+
+TEST(opolin_d_radix_batcher_sort_all, test_reversed) {
+  boost::mpi::communicator world;
+  int size = 7;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {6, 3, 2, 0, -4, -6, -10};
+  expected = {-10, -6, -4, 0, 2, 3, 6};
+  std::vector<int> out(size, 0);
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_all->inputs_count.emplace_back(out.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
+  }
+  auto test_task_all = std::make_shared<opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll>(task_data_all);
+  ASSERT_EQ(test_task_all->Validation(), true);
+  test_task_all->PreProcessing();
+  test_task_all->Run();
+  test_task_all->PostProcessing();
+  if (world.rank() == 0) {
+    ASSERT_EQ(out, expected);
+  }
+}
+
+TEST(opolin_d_radix_batcher_sort_all, test_varying_digit_counts) {
+  boost::mpi::communicator world;
+  int size = 6;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {123456, 12, 123, 1, 12345, 1234};
+  expected = {1, 12, 123, 1234, 12345, 123456};
+  std::vector<int> out(size, 0);
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_all->inputs_count.emplace_back(out.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
+  }
+  auto test_task_all = std::make_shared<opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll>(task_data_all);
+  ASSERT_EQ(test_task_all->Validation(), true);
+  test_task_all->PreProcessing();
+  test_task_all->Run();
+  test_task_all->PostProcessing();
+  if (world.rank() == 0) {
+    ASSERT_EQ(out, expected);
+  }
+}
+
+TEST(opolin_d_radix_batcher_sort_all, test_negative_size) {
+  boost::mpi::communicator world;
+  int size = -1;
+  std::vector<int> expected;
+  std::vector<int> input;
+  std::vector<int> out;
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_all->inputs_count.emplace_back(out.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
+  }
+  auto test_task_all = std::make_shared<opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll>(task_data_all);
+  if (world.rank() == 0) {
+    ASSERT_EQ(test_task_all->Validation(), false);
+  }
+}
+
+TEST(opolin_d_radix_batcher_sort_all, test_size_prime_7) {
+  boost::mpi::communicator world;
+  int size = 7;
+  std::vector<int> expected;
+  std::vector<int> input;
+  opolin_d_radix_batcher_sort_all::GenDataRadixSort(size, input, expected);
+
+  std::vector<int> out(size, 0);
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_all->inputs_count.emplace_back(out.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
+  }
+  auto test_task_all = std::make_shared<opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll>(task_data_all);
+  ASSERT_EQ(test_task_all->Validation(), true);
+  test_task_all->PreProcessing();
+  test_task_all->Run();
+  test_task_all->PostProcessing();
+  if (world.rank() == 0) {
+    ASSERT_EQ(out, expected);
+  }
+}
+
+TEST(opolin_d_radix_batcher_sort_all, test_double_reversed_order) {
+  boost::mpi::communicator world;
+  int size = 6;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {3, 2, 1, 6, 5, 4};
+  expected = {1, 2, 3, 4, 5, 6};
+
+  std::vector<int> out(size, 0);
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_all->inputs_count.emplace_back(out.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
+  }
+  auto test_task_all = std::make_shared<opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll>(task_data_all);
+  ASSERT_EQ(test_task_all->Validation(), true);
+  test_task_all->PreProcessing();
+  test_task_all->Run();
+  test_task_all->PostProcessing();
+  if (world.rank() == 0) {
+    ASSERT_EQ(out, expected);
+  }
+}

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/func_tests/func_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/func_tests/func_all.cpp
@@ -7,7 +7,7 @@
 #include <random>
 #include <vector>
 
-#include "all/opolin_d_radix_sort_batcher_merge/include/ops_all.hpp"
+#include "all/opolin_d_radix_sort_batcher_merge/include/ops_all.hpp"  
 #include "core/task/include/task.hpp"
 
 namespace opolin_d_radix_batcher_sort_all {
@@ -81,7 +81,6 @@ TEST(opolin_d_radix_batcher_sort_all, test_size_6) {
 
 TEST(opolin_d_radix_batcher_sort_all, test_empty) {
   boost::mpi::communicator world;
-  int size = 0;
   std::vector<int> expected;
   std::vector<int> input;
   std::vector<int> out;
@@ -251,7 +250,6 @@ TEST(opolin_d_radix_batcher_sort_all, test_varying_digit_counts) {
 
 TEST(opolin_d_radix_batcher_sort_all, test_negative_size) {
   boost::mpi::communicator world;
-  int size = -1;
   std::vector<int> expected;
   std::vector<int> input;
   std::vector<int> out;

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/func_tests/func_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/func_tests/func_all.cpp
@@ -7,7 +7,7 @@
 #include <random>
 #include <vector>
 
-#include "all/opolin_d_radix_sort_batcher_merge/include/ops_all.hpp"  
+#include "all/opolin_d_radix_sort_batcher_merge/include/ops_all.hpp"
 #include "core/task/include/task.hpp"
 
 namespace opolin_d_radix_batcher_sort_all {

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/include/ops_all.hpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/include/ops_all.hpp
@@ -2,9 +2,7 @@
 
 #include <boost/mpi/collectives.hpp>
 #include <boost/mpi/communicator.hpp>
-#include <cstddef>
 #include <cstdint>
-#include <functional>
 #include <utility>
 #include <vector>
 

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/include/ops_all.hpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/include/ops_all.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace opolin_d_radix_batcher_sort_all {
+static uint32_t ConvertIntToUint(int num);
+static int ConvertUintToInt(uint32_t unum);
+void RadixSort(std::vector<uint32_t>& uns_vec);
+
+class RadixBatcherSortTaskAll : public ppc::core::Task {
+ public:
+  explicit RadixBatcherSortTaskAll(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> input_;
+  std::vector<int> output_;
+  std::vector<uint32_t> unsigned_data_;
+  int size_;
+  boost::mpi::communicator world_;
+  size_t global_original_size_;
+};
+}  // namespace opolin_d_radix_batcher_sort_all

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/include/ops_all.hpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/include/ops_all.hpp
@@ -14,6 +14,7 @@ namespace opolin_d_radix_batcher_sort_all {
 uint32_t ConvertIntToUint(int num);
 int ConvertUintToInt(uint32_t unum);
 void RadixSort(std::vector<uint32_t>& uns_vec);
+void BatcherOddEvenMerge(std::vector<int>& vec, int low, int high);
 
 class RadixBatcherSortTaskAll : public ppc::core::Task {
  public:
@@ -29,6 +30,5 @@ class RadixBatcherSortTaskAll : public ppc::core::Task {
   std::vector<uint32_t> unsigned_data_;
   int size_;
   boost::mpi::communicator world_;
-  size_t global_original_size_;
 };
 }  // namespace opolin_d_radix_batcher_sort_all

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/include/ops_all.hpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/include/ops_all.hpp
@@ -11,8 +11,8 @@
 #include "core/task/include/task.hpp"
 
 namespace opolin_d_radix_batcher_sort_all {
-static uint32_t ConvertIntToUint(int num);
-static int ConvertUintToInt(uint32_t unum);
+uint32_t ConvertIntToUint(int num);
+int ConvertUintToInt(uint32_t unum);
 void RadixSort(std::vector<uint32_t>& uns_vec);
 
 class RadixBatcherSortTaskAll : public ppc::core::Task {

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/perf_tests/perf_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/perf_tests/perf_all.cpp
@@ -1,0 +1,110 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
+#include <memory>
+#include <vector>
+
+#include "all/opolin_d_radix_sort_batcher_merge/include/ops_all.hpp"
+#include "boost/mpi/communicator.hpp"
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+
+namespace opolin_d_radix_batcher_sort_all {
+namespace {
+void GenDataRadixSort(size_t size, std::vector<int> &vec, std::vector<int> &expected) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> dis(-1000, 1000);
+  vec.clear();
+  expected.clear();
+  vec.reserve(size);
+  for (size_t i = 0; i < size; ++i) {
+    vec.push_back(dis(gen));
+  }
+  expected = vec;
+  std::ranges::sort(expected);
+}
+}  // namespace
+}  // namespace opolin_d_radix_batcher_sort_all
+
+TEST(opolin_d_radix_batcher_sort_all, test_pipeline_run) {
+  boost::mpi::communicator world;
+  // Create data
+  int size = 1100000;
+  std::vector<int> input;
+  std::vector<int> expected;
+  std::vector<int> out(size, 0);
+  // Create task_data
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    opolin_d_radix_batcher_sort_all::GenDataRadixSort(size, input, expected);
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_all->inputs_count.emplace_back(out.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
+  }
+
+  // Create Task
+  auto test_task_all = std::make_shared<opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll>(task_data_all);
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_all);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  if (world.rank() == 0) {
+    ASSERT_EQ(expected, out);
+  }
+}
+
+TEST(opolin_d_radix_batcher_sort_all, test_task_run) {
+  int size = 1100000;
+  std::vector<int> input;
+  std::vector<int> expected;
+  std::vector<int> out(size, 0);
+  // Create task_data
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (world.rank() == 0) {
+    opolin_d_radix_batcher_sort_all::GenDataRadixSort(size, input, expected);
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_all->inputs_count.emplace_back(out.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
+  }
+  auto test_task_all = std::make_shared<opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll>(task_data_all);
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  if (world.rank() == 0) {
+    ASSERT_EQ(expected, out);
+  }
+}

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/perf_tests/perf_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/perf_tests/perf_all.cpp
@@ -41,17 +41,17 @@ TEST(opolin_d_radix_batcher_sort_all, test_pipeline_run) {
   std::vector<int> expected;
   std::vector<int> out(size, 0);
   // Create task_data
-  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
     opolin_d_radix_batcher_sort_all::GenDataRadixSort(size, input, expected);
-    task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
-    task_data_tbb->inputs_count.emplace_back(out.size());
-    task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-    task_data_tbb->outputs_count.emplace_back(out.size());
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_all->inputs_count.emplace_back(out.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
   }
 
   // Create Task
-  auto test_task_all = std::make_shared<opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll>(task_data_tbb);
+  auto test_task_all = std::make_shared<opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll>(task_data_all);
   // Create Perf attributes
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;
@@ -81,15 +81,15 @@ TEST(opolin_d_radix_batcher_sort_all, test_task_run) {
   std::vector<int> expected;
   std::vector<int> out(size, 0);
   // Create task_data
-  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
     opolin_d_radix_batcher_sort_all::GenDataRadixSort(size, input, expected);
-    task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
-    task_data_tbb->inputs_count.emplace_back(out.size());
-    task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-    task_data_tbb->outputs_count.emplace_back(out.size());
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_all->inputs_count.emplace_back(out.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_all->outputs_count.emplace_back(out.size());
   }
-  auto test_task_all = std::make_shared<opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll>(task_data_tbb);
+  auto test_task_all = std::make_shared<opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll>(task_data_all);
   // Create Perf attributes
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/perf_tests/perf_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/perf_tests/perf_all.cpp
@@ -41,17 +41,17 @@ TEST(opolin_d_radix_batcher_sort_all, test_pipeline_run) {
   std::vector<int> expected;
   std::vector<int> out(size, 0);
   // Create task_data
-  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
     opolin_d_radix_batcher_sort_all::GenDataRadixSort(size, input, expected);
-    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
-    task_data_all->inputs_count.emplace_back(out.size());
-    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-    task_data_all->outputs_count.emplace_back(out.size());
+    task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_tbb->inputs_count.emplace_back(out.size());
+    task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_tbb->outputs_count.emplace_back(out.size());
   }
 
   // Create Task
-  auto test_task_all = std::make_shared<opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll>(task_data_all);
+  auto test_task_all = std::make_shared<opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll>(task_data_tbb);
   // Create Perf attributes
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;
@@ -81,15 +81,15 @@ TEST(opolin_d_radix_batcher_sort_all, test_task_run) {
   std::vector<int> expected;
   std::vector<int> out(size, 0);
   // Create task_data
-  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  auto task_data_tbb = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
     opolin_d_radix_batcher_sort_all::GenDataRadixSort(size, input, expected);
-    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
-    task_data_all->inputs_count.emplace_back(out.size());
-    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-    task_data_all->outputs_count.emplace_back(out.size());
+    task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+    task_data_tbb->inputs_count.emplace_back(out.size());
+    task_data_tbb->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+    task_data_tbb->outputs_count.emplace_back(out.size());
   }
-  auto test_task_all = std::make_shared<opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll>(task_data_all);
+  auto test_task_all = std::make_shared<opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll>(task_data_tbb);
   // Create Perf attributes
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
   perf_attr->num_running = 10;

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/perf_tests/perf_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/perf_tests/perf_all.cpp
@@ -101,7 +101,7 @@ TEST(opolin_d_radix_batcher_sort_all, test_task_run) {
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
 
   // Create Perf analyzer
-  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_all);
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
   if (world.rank() == 0) {

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/perf_tests/perf_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/perf_tests/perf_all.cpp
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <ctime>
 #include <memory>
+#include <random>
 #include <vector>
 
 #include "all/opolin_d_radix_sort_batcher_merge/include/ops_all.hpp"
@@ -74,6 +75,7 @@ TEST(opolin_d_radix_batcher_sort_all, test_pipeline_run) {
 }
 
 TEST(opolin_d_radix_batcher_sort_all, test_task_run) {
+  boost::mpi::communicator world;
   int size = 1100000;
   std::vector<int> input;
   std::vector<int> expected;

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
@@ -5,10 +5,9 @@
 #include <algorithm>
 #include <boost/mpi/collectives.hpp>
 #include <boost/mpi/collectives/broadcast.hpp>
-#include <boost/mpi/collectives/gather.hpp>
 #include <boost/mpi/collectives/gatherv.hpp>
 #include <boost/mpi/collectives/scatter.hpp>
-#include <boost/mpi/collectives/scattev.hpp>
+#include <boost/mpi/collectives/scatterv.hpp>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
@@ -58,12 +58,14 @@ bool opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll::RunImpl() {
       offset += counts[i];
     }
   }
+  boost::mpi::broadcast(world_, counts, 0);
+  boost::mpi::broadcast(world_, displs, 0);
   boost::mpi::scatter(world_, counts, local_size, 0);
   local_data.resize(local_size);
   if (rank == 0) {
     boost::mpi::scatterv(world_, input_, counts, displs, local_data.data(), local_size, 0);
   } else {
-    boost::mpi::scatterv(world_, local_data.data(), local_size, 0);
+    boost::mpi::scatterv(world_, static_cast<int*>(nullptr), 0, local_data.data(), local_size, 0);
   }
   std::vector<uint32_t> keys(local_size);
   tbb::parallel_for(tbb::blocked_range<size_t>(0, local_size), [&](auto& r) {

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <utility>
 #include <vector>
 
 #include "oneapi/tbb/blocked_range.h"
@@ -95,7 +96,7 @@ bool opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll::RunImpl() {
     boost::mpi::gatherv(world_, local_data.data(), local_size, 0);
   }
   if (rank == 0) {
-    output_.swap(gathered_data);
+    output_ = std::move(gathered_data);
     int offset = counts[0];
     for (int i = 1; i < world_size; ++i) {
       int next = offset + counts[i];

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
@@ -60,8 +60,8 @@ bool opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll::PreProcessingImpl
 
 bool opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll::ValidationImpl() {
   if (world_.rank() == 0) {
-    global_size_ = static_cast<int>(task_data->inputs_count[0]);
-    if (global_size_ <= 0 || task_data->inputs.empty() || task_data->outputs.empty()) {
+    global_original_size_ = static_cast<int>(task_data->inputs_count[0]);
+    if (global_original_size_ <= 0 || task_data->inputs.empty() || task_data->outputs.empty()) {
       return false;
     }
     if (task_data->inputs[0] == nullptr || task_data->outputs[0] == nullptr) {
@@ -184,7 +184,7 @@ uint32_t opolin_d_radix_batcher_sort_all::ConvertIntToUint(int num) { return sta
 
 int opolin_d_radix_batcher_sort_all::ConvertUintToInt(uint32_t unum) { return static_cast<int>(unum ^ 0x80000000U); }
 
-void opolin_d_radix_batcher_sort_tbb::RadixSort(std::vector<uint32_t>& uns_vec) {
+void opolin_d_radix_batcher_sort_all::RadixSort(std::vector<uint32_t>& uns_vec) {
   size_t sz = uns_vec.size();
   if (sz <= 1) {
     return;

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
@@ -4,16 +4,17 @@
 
 #include <algorithm>
 #include <boost/mpi/collectives.hpp>
-#include <boost/mpi/gatherv.hpp>
-#include <boost/mpi/scatter.hpp>
-#include <boost/mpi/scatterv.hpp>
+#include <boost/mpi/collectives/broadcast.hpp>
+#include <boost/mpi/collectives/gather.hpp>
+#include <boost/mpi/collectives/gatherv.hpp>
+#include <boost/mpi/collectives/scatter.hpp>
+#include <boost/mpi/collectives/scattev.hpp>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <vector>
 
 #include "oneapi/tbb/blocked_range.h"
-#include "oneapi/tbb/enumerable_thread_specific.h"
 #include "oneapi/tbb/parallel_for.h"
 #include "oneapi/tbb/parallel_invoke.h"
 

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
@@ -1,15 +1,15 @@
 #include "all/opolin_d_radix_sort_batcher_merge/include/ops_all.hpp"
 
 #include <tbb/tbb.h>
+
 #include <algorithm>
+#include <boost/mpi.hpp>
+#include <boost/mpi/collectives.hpp>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
-#include <vector>
 #include <limits>
-
-#include <boost/mpi.hpp>
-#include <boost/mpi/collectives.hpp>
+#include <vector>
 
 #include "oneapi/tbb/blocked_range.h"
 #include "oneapi/tbb/enumerable_thread_specific.h"

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
@@ -93,7 +93,7 @@ bool opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll::RunImpl() {
     boost::mpi::gatherv(world_, local_data.data(), local_size, 0);
   }
   if (rank == 0) {
-    output_.swap(gathered);
+    output_.swap(gathered_data);
     int offset = counts[0];
     for (int i = 1; i < world_size; ++i) {
       int next = offset + counts[i];

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
@@ -1,0 +1,220 @@
+#include "all/opolin_d_radix_sort_batcher_merge/include/ops_all.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <functional>
+#include <vector>
+
+#include "core/util/include/util.hpp"
+#include "oneapi/tbb/task_arena.h"
+#include "oneapi/tbb/task_group.h"
+
+bool opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll::PreProcessingImpl() {
+  int rank = world_.rank();
+  int num_procs = world_.size();
+
+  std::vector<int> global_input_data_on_root;
+  if (rank == 0) {
+    if (!task_data || task_data->inputs.empty() || task_data->inputs_count.empty()) {
+      global_original_size_ = 0;
+    } else {
+      global_original_size_ = task_data->inputs_count[0];
+      if (this->global_original_size_ > 0) {
+        auto* in_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
+        global_input_data_on_root.assign(in_ptr, in_ptr + this->global_original_size_);
+      }
+    }
+  }
+  boost::mpi::broadcast(world_, this->global_original_size_, 0);
+
+  if (this->global_original_size_ == 0) {
+    size_ = 0;
+    if (rank == 0 && task_data && !task_data->outputs_count.empty()) {
+      task_data->outputs_count[0] = 0;
+    }
+    return true;
+  }
+  size_t padded_chunk_size_calc = (global_original_size_ + num_procs - 1) / num_procs;
+  size_ = static_cast<int>(padded_chunk_size_calc);
+  size_t padded_global_size_calc = padded_chunk_size_calc * num_procs;
+
+  this->input_.resize(this->size_);
+  if (rank == 0) {
+    std::vector<int> temp_padded_global_input_on_root = global_input_data_on_root;
+    if (global_input_data_on_root.size() < padded_global_size_calc) {
+      temp_padded_global_input_on_root.resize(padded_global_size_calc, std::numeric_limits<int>::max());
+    }
+    boost::mpi::scatter(world_, temp_padded_global_input_on_root, this->input_.data(), this->size_, 0);
+  } else {
+    boost::mpi::scatter(world_, this->input_.data(), this->size_, 0);
+  }
+  return true;
+}
+
+bool opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll::ValidationImpl() {
+  if (world_.rank() == 0) {
+    global_size_ = static_cast<int>(task_data->inputs_count[0]);
+    if (global_size_ <= 0 || task_data->inputs.empty() || task_data->outputs.empty()) {
+      return false;
+    }
+    if (task_data->inputs[0] == nullptr || task_data->outputs[0] == nullptr) {
+      return false;
+    }
+    return task_data->inputs_count[0] == task_data->outputs_count[0];
+  }
+  return true;
+}
+
+bool opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll::RunImpl() {
+  if (size_ == 0 && global_original_size_ == 0) {
+    return true;
+  }
+  if (size_ == 0 && global_original_size_ > 0) {
+    output_.assign(size_, std::numeric_limits<int>::max());
+  }
+  if (output_.size() != static_cast<size_t>(size_)) {
+    output_.resize(size_);
+  }
+  if (size_ > 0) {
+    std::vector<uint32_t> keys(size_);
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, static_cast<size_t>(size_)),
+      [&](const tbb::blocked_range<size_t>& r) {
+      for (size_t i = r.begin(); i < r.end(); ++i) {
+        keys[i] = ConvertIntToUint(input_[i]);
+      }
+    });
+    RadixSort(keys);
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, static_cast<size_t>(size_)),
+      [&](const tbb::blocked_range<size_t>& r) {
+      for (size_t i = r.begin(); i < r.end(); ++i) {
+        output_[i] = ConvertUintToInt(keys[i]);
+      }
+    });
+  }
+  int rank = world_.rank();
+  int num_procs = world_.size();
+  if (num_procs > 1 && size_ > 0) {
+    int stages_mpi_merge = 0;
+    if (num_procs > 1) {
+      stages_mpi_merge = static_cast<int>(std::ceil(std::log2(static_cast<double>(num_procs))));
+    }
+
+    for (int stage_idx = 0; stage_idx < stages_mpi_merge; ++stage_idx) {
+      int offset_val = 1 << (stages_mpi_merge - stage_idx - 1);
+      for (int step_val = offset_val; step_val > 0; step_val >>= 1) {
+        int partner = rank ^ step_val;
+        if (partner >= num_procs) {
+          continue;
+        }
+
+        std::vector<int> received_data(size_);
+        std::vector<int> merged_data;
+        merged_data.reserve(static_cast<size_t>(size_) * 2);
+
+        boost::mpi::request reqs[2];
+        if (rank < partner) {
+        reqs[0] = world_.isend(partner, 0, output_.data(), size_);
+        reqs[1] = world_.irecv(partner, 0, received_data.data(), size_);
+        boost::mpi::wait_all(reqs, reqs + 2);
+
+        std::merge(output_.begin(), output_.end(),
+        received_data.begin(), received_data.end(), std::back_inserter(merged_data));
+        std::copy(merged_data.begin(), merged_data.begin() + size_, output_.begin());
+      } else {
+        reqs[0] = world_.irecv(partner, 0, received_data.data(), size_);
+        reqs[1] = world_.isend(partner, 0, output_.data(), size_);
+        boost::mpi::wait_all(reqs, reqs + 2);
+
+        std::merge(received_data.begin(), received_data.end(), output_.begin(), output_.end(),
+                   std::back_inserter(merged_data));
+        std::copy(merged_data.begin() + size_, merged_data.end(), output_.begin());
+        }
+      }
+      world_.barrier();
+    }
+  }
+  return true;
+}
+
+bool opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll::PostProcessingImpl() {
+  int rank = world_.rank();
+  int num_procs = world_.size();
+  if (global_original_size_ == 0) {
+    if (rank == 0 && task_data && !task_data->outputs_count.empty()) {
+      task_data->outputs_count[0] = 0;
+    }
+    return true;
+  }
+  std::vector<int> final_gathered_data;
+  if (rank == 0) {
+    final_gathered_data.resize(static_cast<size_t>(size_) * num_procs);
+  }
+
+  if (size_ > 0 && output_.empty()) {
+    output_.assign(size_, std::numeric_limits<int>::max());
+  }
+
+  boost::mpi::gather(world_, output_.data(), size_, final_gathered_data.data(), 0);
+
+  if (rank == 0) {
+    if (task_data && task_data->outputs[0] != nullptr) {
+      auto* out_ptr = reinterpret_cast<int*>(task_data->outputs[0]);
+      size_t elements_to_copy = std::min(global_original_size_, final_gathered_data.size());
+      for (size_t i = 0; i < elements_to_copy; ++i) {
+        out_ptr[i] = final_gathered_data[i];
+      }
+      if (!task_data->outputs_count.empty()) {
+        task_data->outputs_count[0] = global_original_size_;
+      }
+    } else if (global_original_size_ > 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+uint32_t opolin_d_radix_batcher_sort_all::ConvertIntToUint(int num) {
+  return static_cast<uint32_t>(num) ^ 0x80000000U;
+}
+
+int opolin_d_radix_batcher_sort_all::ConvertUintToInt(uint32_t unum) {
+  return static_cast<int>(unum ^ 0x80000000U);
+}
+
+void opolin_d_radix_batcher_sort_tbb::RadixSort(std::vector<uint32_t>& uns_vec) {
+  size_t sz = uns_vec.size();
+  if (sz <= 1) {
+    return;
+  }
+  const int rad = 256;
+  std::vector<uint32_t> res(sz);
+  for (int stage = 0; stage < 4; stage++) {
+    tbb::enumerable_thread_specific<std::vector<size_t>> local_counts(
+      [&] { return std::vector<size_t>(rad, 0); }
+    );
+    int shift = stage * 8;
+
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, sz), 
+      [&](const tbb::blocked_range<size_t>& r) {
+      auto& lc = local_counts.local();
+      for (size_t i = r.begin(); i < r.end(); ++i) {
+        const uint8_t byte = (uns_vec[i] >> shift) & (rad - 1);
+        lc[byte]++;
+      }
+    });
+    std::vector<size_t> pref(rad, 0);
+    for (auto& lc_instance : local_counts) {
+      for (int j = 0; j < rad; ++j) {
+        pref[j] += lc_instance[j];
+      }
+    }
+    for (int j = 1; j < rad; ++j) {
+      pref[j] += pref[j - 1];
+    }
+    for (int i = static_cast<int>(sz) - 1; i >= 0; --i) {
+      const uint8_t byte = (uns_vec[i] >> shift) & (rad - 1);
+      res[--pref[byte]] = uns_vec[i];
+    }
+    uns_vec.swap(res);
+  }
+}

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
@@ -14,7 +14,7 @@
 #include <vector>
 
 #include "oneapi/tbb/blocked_range.h"
-#include "oneapi/tbb/enumerable_thread_specific.h" // NOLINT(misc-include-cleaner)
+#include "oneapi/tbb/enumerable_thread_specific.h"  // NOLINT(misc-include-cleaner)
 #include "oneapi/tbb/parallel_for.h"
 #include "oneapi/tbb/parallel_invoke.h"
 

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
@@ -3,12 +3,14 @@
 #include <tbb/tbb.h>
 
 #include <algorithm>
-#include <boost/mpi.hpp>
+#include <boost/mpi/broadcast.hpp>
 #include <boost/mpi/collectives.hpp>
+#include <boost/mpi/gatherv.hpp>
+#include <boost/mpi/scatter.hpp>
+#include <boost/mpi/scatterv.hpp>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
-#include <limits>
 #include <vector>
 
 #include "oneapi/tbb/blocked_range.h"
@@ -153,7 +155,9 @@ void opolin_d_radix_batcher_sort_all::RadixSort(std::vector<uint32_t>& uns_vec) 
 }
 
 void opolin_d_radix_batcher_sort_all::BatcherOddEvenMerge(std::vector<int>& vec, int low, int high) {
-  if (high - low <= 1) return;
+  if (high - low <= 1) {
+    return;
+  }
   int mid = (low + high) / 2;
   tbb::parallel_invoke([&] { BatcherOddEvenMerge(vec, low, mid); }, [&] { BatcherOddEvenMerge(vec, mid, high); });
 

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
@@ -93,9 +93,12 @@ bool opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll::RunImpl() {
     boost::mpi::gatherv(world_, local_data.data(), local_size, 0);
   }
   if (rank == 0) {
-    output_.swap(gathered_data);
-    if (size_ > 0) {
-      BatcherOddEvenMerge(output_, 0, size_);
+    output_.swap(gathered);
+    int offset = counts[0];
+    for (int i = 1; i < world_size; ++i) {
+      int next = offset + counts[i];
+      std::inplace_merge(output_.begin(), output_.begin() + offset, output_.begin() + next);
+      offset = next;
     }
   }
   return true;

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
@@ -61,7 +61,7 @@ bool opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll::RunImpl() {
   boost::mpi::scatter(world_, counts, local_size, 0);
   local_data.resize(local_size);
   if (rank == 0) {
-    boost::mpi::scatterv(world_, input_, counts, displs, local_data.data(), 0);
+    boost::mpi::scatterv(world_, input_, counts, displs, local_data.data(), local_size, 0);
   } else {
     boost::mpi::scatterv(world_, local_data.data(), local_size, 0);
   }

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
@@ -3,7 +3,6 @@
 #include <tbb/tbb.h>
 
 #include <algorithm>
-#include <boost/mpi/broadcast.hpp>
 #include <boost/mpi/collectives.hpp>
 #include <boost/mpi/gatherv.hpp>
 #include <boost/mpi/scatter.hpp>

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
@@ -16,7 +16,6 @@
 #include "oneapi/tbb/parallel_for.h"
 #include "oneapi/tbb/parallel_invoke.h"
 
-
 bool opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll::PreProcessingImpl() {
   int rank = world_.rank();
   int num_procs = world_.size();

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
@@ -102,7 +102,7 @@ bool opolin_d_radix_batcher_sort_all::RadixBatcherSortTaskAll::PostProcessingImp
     for (size_t i = 0; i < output_.size(); ++i) {
       reinterpret_cast<int*>(task_data->outputs[0])[i] = output_[i];
     }
-  } 
+  }
   return true;
 }
 

--- a/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
+++ b/tasks/all/opolin_d_radix_sort_batcher_merge/src/ops_all.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "oneapi/tbb/blocked_range.h"
+#include "oneapi/tbb/enumerable_thread_specific.h" // NOLINT(misc-include-cleaner)
 #include "oneapi/tbb/parallel_for.h"
 #include "oneapi/tbb/parallel_invoke.h"
 


### PR DESCRIPTION
На главном процессе распределяем данные на все процессы. Каждый процесс локально конвертирует значения в беззнаковые ключи, выполняет многопоточный Radix-sort и обратно переводит в int. Отсортированные участки собираются обратно на главном процессе с помощью gatherv.