### PR TITLE
Ковальчук Александр. Вариант 15. Технология MPI + TBB. Сортировка Шелла с простым слиянием

### DIFF
--- a/tasks/all/kovalchuk_a_shell_sort/func_tests/func_all.cpp
+++ b/tasks/all/kovalchuk_a_shell_sort/func_tests/func_all.cpp
@@ -1,0 +1,175 @@
+#include <gtest/gtest.h>
+
+#include <climits>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "all/kovalchuk_a_shell_sort/include/ops_all.hpp"
+
+TEST(kovalchuk_a_shell_sort_func, Test_EmptyArray) {
+  std::vector<int> input = {};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort_all::ShellSortAll>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  EXPECT_TRUE(output.empty());
+}
+
+TEST(kovalchuk_a_shell_sort_func, Test_SingleElement) {
+  std::vector<int> input = {7};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort_all::ShellSortAll>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  EXPECT_EQ(input, output);
+}
+
+TEST(kovalchuk_a_shell_sort_func, Test_AlreadySorted) {
+  std::vector<int> input = {1, 2, 3, 4, 5};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort_all::ShellSortAll>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  EXPECT_EQ(input, output);
+}
+
+TEST(kovalchuk_a_shell_sort_func, Test_ReverseSorted) {
+  std::vector<int> input = {10, 7, 5, 3, 1};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort_all::ShellSortAll>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  std::vector<int> expected = {1, 3, 5, 7, 10};
+  EXPECT_EQ(expected, output);
+}
+
+TEST(kovalchuk_a_shell_sort_func, Test_Duplicates) {
+  std::vector<int> input = {5, 2, 5, 1, 2};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort_all::ShellSortAll>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  std::vector<int> expected = {1, 2, 2, 5, 5};
+  EXPECT_EQ(expected, output);
+}
+
+TEST(kovalchuk_a_shell_sort_func, Test_NegativeNumbers) {
+  std::vector<int> input = {-5, 0, -3, 9, -1};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort_all::ShellSortAll>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  std::vector<int> expected = {-5, -3, -1, 0, 9};
+  EXPECT_EQ(expected, output);
+}
+
+TEST(kovalchuk_a_shell_sort_func, Test_ExtremeValues) {
+  std::vector<int> input = {INT32_MIN, 0, INT32_MAX};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort_all::ShellSortAll>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  std::vector<int> expected = {INT32_MIN, 0, INT32_MAX};
+  EXPECT_EQ(expected, output);
+}
+
+TEST(kovalchuk_a_shell_sort_func, Test_MixedOrder) {
+  std::vector<int> input = {4, 1, 7, 2, 9, 3};
+  std::vector<int> output(input.size());
+
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+  task_data->inputs_count.emplace_back(input.size());
+  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+  task_data->outputs_count.emplace_back(output.size());
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort_all::ShellSortAll>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+
+  std::vector<int> expected = {1, 2, 3, 4, 7, 9};
+  EXPECT_EQ(expected, output);
+}

--- a/tasks/all/kovalchuk_a_shell_sort/func_tests/func_all.cpp
+++ b/tasks/all/kovalchuk_a_shell_sort/func_tests/func_all.cpp
@@ -6,58 +6,41 @@
 #include <memory>
 #include <vector>
 
+#include "../include/ops_all.hpp"
+#include "boost/mpi/communicator.hpp"
 #include "core/task/include/task.hpp"
-#include "all/kovalchuk_a_shell_sort/include/ops_all.hpp"
 
 TEST(kovalchuk_a_shell_sort_func, Test_EmptyArray) {
   std::vector<int> input = {};
   std::vector<int> output(input.size());
+  boost::mpi::communicator world;
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
-  task_data->inputs_count.emplace_back(input.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
-  task_data->outputs_count.emplace_back(output.size());
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+    task_data->inputs_count.emplace_back(input.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+    task_data->outputs_count.emplace_back(output.size());
+  }
 
   auto task = std::make_shared<kovalchuk_a_shell_sort_all::ShellSortAll>(task_data);
-
-  ASSERT_TRUE(task->Validation());
-  task->PreProcessing();
-  task->Run();
-  task->PostProcessing();
-
-  EXPECT_TRUE(output.empty());
-}
-
-TEST(kovalchuk_a_shell_sort_func, Test_SingleElement) {
-  std::vector<int> input = {7};
-  std::vector<int> output(input.size());
-
-  auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
-  task_data->inputs_count.emplace_back(input.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
-  task_data->outputs_count.emplace_back(output.size());
-
-  auto task = std::make_shared<kovalchuk_a_shell_sort_all::ShellSortAll>(task_data);
-
-  ASSERT_TRUE(task->Validation());
-  task->PreProcessing();
-  task->Run();
-  task->PostProcessing();
-
-  EXPECT_EQ(input, output);
+  if (world.rank() == 0) {
+    ASSERT_FALSE(task->Validation());
+  }
 }
 
 TEST(kovalchuk_a_shell_sort_func, Test_AlreadySorted) {
   std::vector<int> input = {1, 2, 3, 4, 5};
   std::vector<int> output(input.size());
+  boost::mpi::communicator world;
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
-  task_data->inputs_count.emplace_back(input.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
-  task_data->outputs_count.emplace_back(output.size());
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+    task_data->inputs_count.emplace_back(input.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+    task_data->outputs_count.emplace_back(output.size());
+  }
 
   auto task = std::make_shared<kovalchuk_a_shell_sort_all::ShellSortAll>(task_data);
 
@@ -65,19 +48,23 @@ TEST(kovalchuk_a_shell_sort_func, Test_AlreadySorted) {
   task->PreProcessing();
   task->Run();
   task->PostProcessing();
-
-  EXPECT_EQ(input, output);
+  if (world.rank() == 0) {
+    EXPECT_EQ(input, output);
+  }
 }
 
 TEST(kovalchuk_a_shell_sort_func, Test_ReverseSorted) {
   std::vector<int> input = {10, 7, 5, 3, 1};
   std::vector<int> output(input.size());
+  boost::mpi::communicator world;
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
-  task_data->inputs_count.emplace_back(input.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
-  task_data->outputs_count.emplace_back(output.size());
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+    task_data->inputs_count.emplace_back(input.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+    task_data->outputs_count.emplace_back(output.size());
+  }
 
   auto task = std::make_shared<kovalchuk_a_shell_sort_all::ShellSortAll>(task_data);
 
@@ -86,19 +73,24 @@ TEST(kovalchuk_a_shell_sort_func, Test_ReverseSorted) {
   task->Run();
   task->PostProcessing();
 
-  std::vector<int> expected = {1, 3, 5, 7, 10};
-  EXPECT_EQ(expected, output);
+  if (world.rank() == 0) {
+    std::vector<int> expected = {1, 3, 5, 7, 10};
+    EXPECT_EQ(expected, output);
+  }
 }
 
 TEST(kovalchuk_a_shell_sort_func, Test_Duplicates) {
   std::vector<int> input = {5, 2, 5, 1, 2};
   std::vector<int> output(input.size());
+  boost::mpi::communicator world;
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
-  task_data->inputs_count.emplace_back(input.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
-  task_data->outputs_count.emplace_back(output.size());
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+    task_data->inputs_count.emplace_back(input.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+    task_data->outputs_count.emplace_back(output.size());
+  }
 
   auto task = std::make_shared<kovalchuk_a_shell_sort_all::ShellSortAll>(task_data);
 
@@ -106,20 +98,24 @@ TEST(kovalchuk_a_shell_sort_func, Test_Duplicates) {
   task->PreProcessing();
   task->Run();
   task->PostProcessing();
-
-  std::vector<int> expected = {1, 2, 2, 5, 5};
-  EXPECT_EQ(expected, output);
+  if (world.rank() == 0) {
+    std::vector<int> expected = {1, 2, 2, 5, 5};
+    EXPECT_EQ(expected, output);
+  }
 }
 
 TEST(kovalchuk_a_shell_sort_func, Test_NegativeNumbers) {
   std::vector<int> input = {-5, 0, -3, 9, -1};
   std::vector<int> output(input.size());
+  boost::mpi::communicator world;
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
-  task_data->inputs_count.emplace_back(input.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
-  task_data->outputs_count.emplace_back(output.size());
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+    task_data->inputs_count.emplace_back(input.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+    task_data->outputs_count.emplace_back(output.size());
+  }
 
   auto task = std::make_shared<kovalchuk_a_shell_sort_all::ShellSortAll>(task_data);
 
@@ -127,20 +123,24 @@ TEST(kovalchuk_a_shell_sort_func, Test_NegativeNumbers) {
   task->PreProcessing();
   task->Run();
   task->PostProcessing();
-
-  std::vector<int> expected = {-5, -3, -1, 0, 9};
-  EXPECT_EQ(expected, output);
+  if (world.rank() == 0) {
+    std::vector<int> expected = {-5, -3, -1, 0, 9};
+    EXPECT_EQ(expected, output);
+  }
 }
 
 TEST(kovalchuk_a_shell_sort_func, Test_ExtremeValues) {
   std::vector<int> input = {INT32_MIN, 0, INT32_MAX};
   std::vector<int> output(input.size());
+  boost::mpi::communicator world;
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
-  task_data->inputs_count.emplace_back(input.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
-  task_data->outputs_count.emplace_back(output.size());
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+    task_data->inputs_count.emplace_back(input.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+    task_data->outputs_count.emplace_back(output.size());
+  }
 
   auto task = std::make_shared<kovalchuk_a_shell_sort_all::ShellSortAll>(task_data);
 
@@ -148,20 +148,23 @@ TEST(kovalchuk_a_shell_sort_func, Test_ExtremeValues) {
   task->PreProcessing();
   task->Run();
   task->PostProcessing();
-
-  std::vector<int> expected = {INT32_MIN, 0, INT32_MAX};
-  EXPECT_EQ(expected, output);
+  if (world.rank() == 0) {
+    std::vector<int> expected = {INT32_MIN, 0, INT32_MAX};
+    EXPECT_EQ(expected, output);
+  }
 }
-
 TEST(kovalchuk_a_shell_sort_func, Test_MixedOrder) {
   std::vector<int> input = {4, 1, 7, 2, 9, 3};
   std::vector<int> output(input.size());
+  boost::mpi::communicator world;
 
   auto task_data = std::make_shared<ppc::core::TaskData>();
-  task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
-  task_data->inputs_count.emplace_back(input.size());
-  task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
-  task_data->outputs_count.emplace_back(output.size());
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+    task_data->inputs_count.emplace_back(input.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+    task_data->outputs_count.emplace_back(output.size());
+  }
 
   auto task = std::make_shared<kovalchuk_a_shell_sort_all::ShellSortAll>(task_data);
 
@@ -170,6 +173,31 @@ TEST(kovalchuk_a_shell_sort_func, Test_MixedOrder) {
   task->Run();
   task->PostProcessing();
 
-  std::vector<int> expected = {1, 2, 3, 4, 7, 9};
-  EXPECT_EQ(expected, output);
+  if (world.rank() == 0) {
+    std::vector<int> expected = {1, 2, 3, 4, 7, 9};
+    EXPECT_EQ(expected, output);
+  }
+}
+TEST(kovalchuk_a_shell_sort_func, Test_SingleElement) {
+  std::vector<int> input = {7};
+  std::vector<int> output(input.size());
+  boost::mpi::communicator world;
+  auto task_data = std::make_shared<ppc::core::TaskData>();
+
+  if (world.rank() == 0) {
+    task_data->inputs.emplace_back(reinterpret_cast<uint8_t*>(input.data()));
+    task_data->inputs_count.emplace_back(input.size());
+    task_data->outputs.emplace_back(reinterpret_cast<uint8_t*>(output.data()));
+    task_data->outputs_count.emplace_back(output.size());
+  }
+
+  auto task = std::make_shared<kovalchuk_a_shell_sort_all::ShellSortAll>(task_data);
+
+  ASSERT_TRUE(task->Validation());
+  task->PreProcessing();
+  task->Run();
+  task->PostProcessing();
+  if (world.rank() == 0) {
+    EXPECT_EQ(input, output);
+  }
 }

--- a/tasks/all/kovalchuk_a_shell_sort/include/ops_all.hpp
+++ b/tasks/all/kovalchuk_a_shell_sort/include/ops_all.hpp
@@ -13,9 +13,8 @@ class ShellSortAll : public ppc::core::Task {
   bool PostProcessingImpl() override;
 
  private:
-  std::vector<int> input_;
-  boost::mpi::communicator world_;
-  void ShellSort();
+  std::vector<int> input_, counts_, result_;
+  boost::mpi::communicator world_, group_;
 };
 
 }  // namespace kovalchuk_a_shell_sort_all

--- a/tasks/all/kovalchuk_a_shell_sort/include/ops_all.hpp
+++ b/tasks/all/kovalchuk_a_shell_sort/include/ops_all.hpp
@@ -1,0 +1,21 @@
+#include <boost/mpi.hpp>
+
+#include "core/task/include/task.hpp"
+
+namespace kovalchuk_a_shell_sort_all {
+
+class ShellSortAll : public ppc::core::Task {
+ public:
+  explicit ShellSortAll(ppc::core::TaskDataPtr task_data);
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> input_;
+  boost::mpi::communicator world_;
+  void ShellSort();
+};
+
+}  // namespace kovalchuk_a_shell_sort_all

--- a/tasks/all/kovalchuk_a_shell_sort/include/ops_all.hpp
+++ b/tasks/all/kovalchuk_a_shell_sort/include/ops_all.hpp
@@ -13,6 +13,7 @@ class ShellSortAll : public ppc::core::Task {
   bool PostProcessingImpl() override;
 
  private:
+  void SimpleMerge(int num_procs, const std::vector<int>& gathered, const std::vector<int>& displs, int total_size);
   std::vector<int> input_, counts_, result_;
   boost::mpi::communicator world_, group_;
 };

--- a/tasks/all/kovalchuk_a_shell_sort/include/ops_all.hpp
+++ b/tasks/all/kovalchuk_a_shell_sort/include/ops_all.hpp
@@ -1,5 +1,6 @@
-#include <boost/mpi.hpp>
+#include <vector>
 
+#include "boost/mpi/communicator.hpp"
 #include "core/task/include/task.hpp"
 
 namespace kovalchuk_a_shell_sort_all {

--- a/tasks/all/kovalchuk_a_shell_sort/perf_tests/perf_all.cpp
+++ b/tasks/all/kovalchuk_a_shell_sort/perf_tests/perf_all.cpp
@@ -4,15 +4,17 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
+#include <numeric>
 #include <vector>
 
+#include "../include/ops_all.hpp"
+#include "boost/mpi/communicator.hpp"
 #include "core/perf/include/perf.hpp"
 #include "core/task/include/task.hpp"
-#include "all/kovalchuk_a_shell_sort/include/ops_all.hpp"
 
 TEST(kovalchuk_a_shell_sort_all, test_pipeline_run) {
   constexpr int kCount = 1000000;
-
+  boost::mpi::communicator world;
   std::vector<int> in(kCount);
   std::iota(in.rbegin(), in.rend(), 1);
 
@@ -39,13 +41,14 @@ TEST(kovalchuk_a_shell_sort_all, test_pipeline_run) {
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task);
   perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
-
-  ASSERT_TRUE(std::ranges::is_sorted(out));
+  if (world.rank() == 0) {
+    ASSERT_TRUE(std::ranges::is_sorted(out));
+  }
 }
 
 TEST(kovalchuk_a_shell_sort_all, test_task_run) {
   constexpr int kCount = 1000000;
-
+  boost::mpi::communicator world;
   std::vector<int> in(kCount);
   std::iota(in.rbegin(), in.rend(), 1);
 
@@ -73,5 +76,7 @@ TEST(kovalchuk_a_shell_sort_all, test_task_run) {
   perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
 
-  ASSERT_TRUE(std::ranges::is_sorted(out));
+  if (world.rank() == 0) {
+    ASSERT_TRUE(std::ranges::is_sorted(out));
+  }
 }

--- a/tasks/all/kovalchuk_a_shell_sort/perf_tests/perf_all.cpp
+++ b/tasks/all/kovalchuk_a_shell_sort/perf_tests/perf_all.cpp
@@ -1,0 +1,77 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "all/kovalchuk_a_shell_sort/include/ops_all.hpp"
+
+TEST(kovalchuk_a_shell_sort_all, test_pipeline_run) {
+  constexpr int kCount = 1000000;
+
+  std::vector<int> in(kCount);
+  std::iota(in.rbegin(), in.rend(), 1);
+
+  std::vector<int> out(kCount);
+
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data_all->inputs_count.emplace_back(in.size());
+  task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_all->outputs_count.emplace_back(out.size());
+
+  auto test_task = std::make_shared<kovalchuk_a_shell_sort_all::ShellSortAll>(task_data_all);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  ASSERT_TRUE(std::ranges::is_sorted(out));
+}
+
+TEST(kovalchuk_a_shell_sort_all, test_task_run) {
+  constexpr int kCount = 1000000;
+
+  std::vector<int> in(kCount);
+  std::iota(in.rbegin(), in.rend(), 1);
+
+  std::vector<int> out(kCount);
+
+  auto task_data_all = std::make_shared<ppc::core::TaskData>();
+  task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t*>(in.data()));
+  task_data_all->inputs_count.emplace_back(in.size());
+  task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t*>(out.data()));
+  task_data_all->outputs_count.emplace_back(out.size());
+
+  auto test_task = std::make_shared<kovalchuk_a_shell_sort_all::ShellSortAll>(task_data_all);
+
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+
+  ASSERT_TRUE(std::ranges::is_sorted(out));
+}

--- a/tasks/all/kovalchuk_a_shell_sort/src/ops_all.cpp
+++ b/tasks/all/kovalchuk_a_shell_sort/src/ops_all.cpp
@@ -1,0 +1,84 @@
+#include "../include/ops_all.hpp"
+
+#include <tbb/parallel_for.h>
+
+#include <algorithm>
+#include <boost/mpi.hpp>
+#include <boost/serialization/vector.hpp>
+#include <vector>
+
+namespace kovalchuk_a_shell_sort_all {
+
+ShellSortAll::ShellSortAll(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+
+bool ShellSortAll::PreProcessingImpl() {
+  if (world_.rank() == 0) {
+    auto* input_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
+    input_.assign(input_ptr, input_ptr + task_data->inputs_count[0]);
+  }
+
+  int total_size{};
+  boost::mpi::broadcast(world_, total_size, 0);
+
+  int num_procs = world_.size();
+  std::vector<int> counts(num_procs, total_size / num_procs);
+  std::vector<int> displs(num_procs, 0);
+  for (int i = 0; i < total_size % num_procs; ++i) {
+    counts[i]++;
+  }
+  for (int i = 1; i < num_procs; ++i) {
+    displs[i] = displs[i - 1] + counts[i - 1];
+  }
+
+
+  std::vector<int> buffer;
+  if (world_.rank() == 0) {
+    buffer = input_;
+  }
+
+  input_.resize(counts[world_.rank()]);
+  boost::mpi::scatterv(world_, input_.data(), counts, displs, buffer.data(), counts[world_.rank()], 0);
+
+  return true;
+}
+
+bool ShellSortAll::ValidationImpl() {
+  return !task_data->inputs_count.empty() && task_data->inputs_count[0] == task_data->outputs_count[0];
+}
+
+bool ShellSortAll::RunImpl() {
+  ShellSort();
+  return true;
+}
+
+void ShellSortAll::ShellSort() {
+  int n = static_cast<int>(input_.size());
+  for (int gap = n / 2; gap > 0; gap /= 2) {
+    tbb::parallel_for(0, gap, [&](int k) {
+      for (int i = k + gap; i < n; i += gap) {
+        int temp = input_[i];
+        int j = i;
+        while (j >= gap && input_[j - gap] > temp) {
+          input_[j] = input_[j - gap];
+          j -= gap;
+        }
+        input_[j] = temp;
+      }
+    });
+  }
+}
+
+bool ShellSortAll::PostProcessingImpl() {
+  std::vector<int> gathered;
+  boost::mpi::gather(world_, input_.data(), static_cast<int>(input_.size()), gathered, 0);
+
+  if (world_.rank() == 0) {
+    std::ranges::sort(gathered.begin(), gathered.end());
+    auto* output_ptr = reinterpret_cast<int*>(task_data->outputs[0]);
+    std::ranges::copy(gathered.begin(), gathered.end(), output_ptr);
+  }
+
+  return true;
+}
+
+}  // namespace kovalchuk_a_shell_sort_all


### PR DESCRIPTION
Root процесс рассылает размер данных всем процессам(total_size)
Разбиваем блоки с помощью scatterv
Каждый процесс сортирует свой блок
С помощью TBB параллелизуем обработку подмассивов в блоке
Собираем на root процессе данные через gatherv
Производим слияние через min-heap