### PR TITLE
[FIX PERF TESTS] Ковалев Константин. Вариант 18. Технология SEQ. Поразрядная сортировка для целых чисел с четно-нечетным слиянием Бэтчера.

### DIFF
--- a/tasks/all/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
+++ b/tasks/all/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
@@ -46,7 +46,7 @@ TEST(kovalev_k_radix_sort_batcher_merge_all, test_pipeline_run) {
   };
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_all);
-  perf_analyzer->TaskRun(perf_attr, perf_results);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
   if (world.rank() == 0) {
     ppc::core::Perf::PrintPerfStatistic(perf_results);
     std::ranges::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });

--- a/tasks/all/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
+++ b/tasks/all/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
@@ -19,15 +19,17 @@ const long long int kMinLl = std::numeric_limits<long long>::lowest(), kMaxLl = 
 
 TEST(kovalev_k_radix_sort_batcher_merge_all, test_pipeline_run) {
   boost::mpi::communicator world;
-  const unsigned int length = 20000000;
-  std::srand(std::time(nullptr));
-  const int alpha = rand();
+  const unsigned int length = 15000000;
   std::vector<long long int> in;
   std::vector<long long int> out;
   std::shared_ptr<ppc::core::TaskData> task_data_all = std::make_shared<ppc::core::TaskData>();
   if (world.rank() == 0) {
-    in = std::vector<long long int>(length, alpha);
+    in = std::vector<long long int>(length);
     out = std::vector<long long int>(length);
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<long long int> dis(kMinLl, kMaxLl);
+    std::ranges::generate(in.begin(), in.end(), [&]() { return dis(gen); });
     task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
     task_data_all->inputs_count.emplace_back(in.size());
     task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
@@ -44,9 +46,10 @@ TEST(kovalev_k_radix_sort_batcher_merge_all, test_pipeline_run) {
   };
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_all);
-  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
   if (world.rank() == 0) {
     ppc::core::Perf::PrintPerfStatistic(perf_results);
+    std::ranges::sort(in.begin(), in.end(), [](long long int a, long long int b) { return a < b; });
     auto *tmp = reinterpret_cast<long long int *>(out.data());
     int count_viol = 0;
     for (unsigned int i = 0; i < length; i++) {
@@ -60,7 +63,7 @@ TEST(kovalev_k_radix_sort_batcher_merge_all, test_pipeline_run) {
 
 TEST(kovalev_k_radix_sort_batcher_merge_all, test_task_run) {
   boost::mpi::communicator world;
-  const unsigned int length = 20000000;
+  const unsigned int length = 15000000;
   std::vector<long long int> in;
   std::vector<long long int> out;
   std::shared_ptr<ppc::core::TaskData> task_data_all = std::make_shared<ppc::core::TaskData>();

--- a/tasks/omp/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
+++ b/tasks/omp/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
@@ -41,7 +41,7 @@ TEST(kovalev_k_radix_sort_batcher_merge_omp, test_pipeline_run) {
   };
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
-  perf_analyzer->TaskRun(perf_attr, perf_results);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
   std::ranges::sort(etalon.begin(), etalon.end(), [](long long int a, long long int b) { return a < b; });
   auto *tmp = reinterpret_cast<long long int *>(out.data());

--- a/tasks/omp/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
+++ b/tasks/omp/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
@@ -17,11 +17,14 @@
 const long long int kMinLl = std::numeric_limits<long long>::lowest(), kMaxLl = std::numeric_limits<long long>::max();
 
 TEST(kovalev_k_radix_sort_batcher_merge_omp, test_pipeline_run) {
-  const unsigned int length = 20000000;
-  std::srand(std::time(nullptr));
-  const int alpha = rand();
-  std::vector<long long int> in(length, alpha);
+  const unsigned int length = 15000000;
+  std::vector<long long int> in(length);
   std::vector<long long int> out(length);
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<long long int> dis(kMinLl, kMaxLl);
+  std::ranges::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::vector<long long int> etalon(in);
   std::shared_ptr<ppc::core::TaskData> task_data_omp = std::make_shared<ppc::core::TaskData>();
   task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
   task_data_omp->inputs_count.emplace_back(in.size());
@@ -38,12 +41,13 @@ TEST(kovalev_k_radix_sort_batcher_merge_omp, test_pipeline_run) {
   };
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
-  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
+  std::ranges::sort(etalon.begin(), etalon.end(), [](long long int a, long long int b) { return a < b; });
   auto *tmp = reinterpret_cast<long long int *>(out.data());
   int count_viol = 0;
   for (unsigned int i = 0; i < length; i++) {
-    if (tmp[i] != in[i]) {
+    if (tmp[i] != etalon[i]) {
       count_viol++;
     }
   }
@@ -51,7 +55,7 @@ TEST(kovalev_k_radix_sort_batcher_merge_omp, test_pipeline_run) {
 }
 
 TEST(kovalev_k_radix_sort_batcher_merge_omp, test_task_run) {
-  const unsigned int length = 20000000;
+  const unsigned int length = 15000000;
   std::vector<long long int> in(length);
   std::vector<long long int> out(length);
   std::random_device rd;

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
@@ -41,7 +41,7 @@ TEST(kovalev_k_radix_sort_batcher_merge_seq, test_pipeline_run) {
   };
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
-  perf_analyzer->TaskRun(perf_attr, perf_results);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
   std::ranges::sort(etalon.begin(), etalon.end(), [](long long int a, long long int b) { return a < b; });
   auto *tmp = reinterpret_cast<long long int *>(out.data());

--- a/tasks/seq/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
+++ b/tasks/seq/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
@@ -17,11 +17,14 @@
 const long long int kMinLl = std::numeric_limits<long long>::lowest(), kMaxLl = std::numeric_limits<long long>::max();
 
 TEST(kovalev_k_radix_sort_batcher_merge_seq, test_pipeline_run) {
-  const unsigned int length = 20000000;
-  std::srand(std::time(nullptr));
-  const int alpha = rand();
-  std::vector<long long int> in(length, alpha);
+  const unsigned int length = 15000000;
+  std::vector<long long int> in(length);
   std::vector<long long int> out(length);
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<long long int> dis(kMinLl, kMaxLl);
+  std::ranges::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::vector<long long int> etalon(in);
   std::shared_ptr<ppc::core::TaskData> task_seq = std::make_shared<ppc::core::TaskData>();
   task_seq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
   task_seq->inputs_count.emplace_back(in.size());
@@ -38,12 +41,13 @@ TEST(kovalev_k_radix_sort_batcher_merge_seq, test_pipeline_run) {
   };
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_sequential);
-  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
+  std::ranges::sort(etalon.begin(), etalon.end(), [](long long int a, long long int b) { return a < b; });
   auto *tmp = reinterpret_cast<long long int *>(out.data());
   int count_viol = 0;
   for (unsigned int i = 0; i < length; i++) {
-    if (tmp[i] != in[i]) {
+    if (tmp[i] != etalon[i]) {
       count_viol++;
     }
   }
@@ -51,7 +55,7 @@ TEST(kovalev_k_radix_sort_batcher_merge_seq, test_pipeline_run) {
 }
 
 TEST(kovalev_k_radix_sort_batcher_merge_seq, test_task_run) {
-  const unsigned int length = 10000000;
+  const unsigned int length = 15000000;
   std::vector<long long int> in(length);
   std::vector<long long int> out(length);
   std::random_device rd;

--- a/tasks/stl/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
+++ b/tasks/stl/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
@@ -17,11 +17,14 @@
 const long long int kMinLl = std::numeric_limits<long long>::lowest(), kMaxLl = std::numeric_limits<long long>::max();
 
 TEST(kovalev_k_radix_sort_batcher_merge_stl, test_pipeline_run) {
-  const unsigned int length = 20000000;
-  std::srand(std::time(nullptr));
-  const int alpha = rand();
-  std::vector<long long int> in(length, alpha);
+  const unsigned int length = 15000000;
+  std::vector<long long int> in(length);
   std::vector<long long int> out(length);
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<long long int> dis(kMinLl, kMaxLl);
+  std::ranges::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::vector<long long int> etalon(in);
   std::shared_ptr<ppc::core::TaskData> task_data_stl = std::make_shared<ppc::core::TaskData>();
   task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
   task_data_stl->inputs_count.emplace_back(in.size());
@@ -38,12 +41,13 @@ TEST(kovalev_k_radix_sort_batcher_merge_stl, test_pipeline_run) {
   };
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_stl);
-  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
+  std::ranges::sort(etalon.begin(), etalon.end(), [](long long int a, long long int b) { return a < b; });
   auto *tmp = reinterpret_cast<long long int *>(out.data());
   int count_viol = 0;
   for (unsigned int i = 0; i < length; i++) {
-    if (tmp[i] != in[i]) {
+    if (tmp[i] != etalon[i]) {
       count_viol++;
     }
   }
@@ -51,7 +55,7 @@ TEST(kovalev_k_radix_sort_batcher_merge_stl, test_pipeline_run) {
 }
 
 TEST(kovalev_k_radix_sort_batcher_merge_stl, test_task_run) {
-  const unsigned int length = 20000000;
+  const unsigned int length = 15000000;
   std::vector<long long int> in(length);
   std::vector<long long int> out(length);
   std::random_device rd;

--- a/tasks/stl/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
+++ b/tasks/stl/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
@@ -41,7 +41,7 @@ TEST(kovalev_k_radix_sort_batcher_merge_stl, test_pipeline_run) {
   };
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_stl);
-  perf_analyzer->TaskRun(perf_attr, perf_results);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
   std::ranges::sort(etalon.begin(), etalon.end(), [](long long int a, long long int b) { return a < b; });
   auto *tmp = reinterpret_cast<long long int *>(out.data());

--- a/tasks/tbb/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
+++ b/tasks/tbb/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
@@ -17,11 +17,14 @@
 const long long int kMinLl = std::numeric_limits<long long>::lowest(), kMaxLl = std::numeric_limits<long long>::max();
 
 TEST(kovalev_k_radix_sort_batcher_merge_tbb, test_pipeline_run) {
-  const unsigned int length = 20000000;
-  std::srand(std::time(nullptr));
-  const int alpha = rand();
-  std::vector<long long int> in(length, alpha);
+  const unsigned int length = 15000000;
+  std::vector<long long int> in(length);
   std::vector<long long int> out(length);
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<long long int> dis(kMinLl, kMaxLl);
+  std::ranges::generate(in.begin(), in.end(), [&]() { return dis(gen); });
+  std::vector<long long int> etalon(in);
   std::shared_ptr<ppc::core::TaskData> task_data_tbb = std::make_shared<ppc::core::TaskData>();
   task_data_tbb->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
   task_data_tbb->inputs_count.emplace_back(in.size());
@@ -38,12 +41,13 @@ TEST(kovalev_k_radix_sort_batcher_merge_tbb, test_pipeline_run) {
   };
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_tbb);
-  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
+  std::ranges::sort(etalon.begin(), etalon.end(), [](long long int a, long long int b) { return a < b; });
   auto *tmp = reinterpret_cast<long long int *>(out.data());
   int count_viol = 0;
   for (unsigned int i = 0; i < length; i++) {
-    if (tmp[i] != in[i]) {
+    if (tmp[i] != etalon[i]) {
       count_viol++;
     }
   }
@@ -51,7 +55,7 @@ TEST(kovalev_k_radix_sort_batcher_merge_tbb, test_pipeline_run) {
 }
 
 TEST(kovalev_k_radix_sort_batcher_merge_tbb, test_task_run) {
-  const unsigned int length = 20000000;
+  const unsigned int length = 15000000;
   std::vector<long long int> in(length);
   std::vector<long long int> out(length);
   std::random_device rd;

--- a/tasks/tbb/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
+++ b/tasks/tbb/kovalev_k_radix_sort_batcher_merge/perf_tests/main_perf.cpp
@@ -41,7 +41,7 @@ TEST(kovalev_k_radix_sort_batcher_merge_tbb, test_pipeline_run) {
   };
   auto perf_results = std::make_shared<ppc::core::PerfResults>();
   auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_tbb);
-  perf_analyzer->TaskRun(perf_attr, perf_results);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
   ppc::core::Perf::PrintPerfStatistic(perf_results);
   std::ranges::sort(etalon.begin(), etalon.end(), [](long long int a, long long int b) { return a < b; });
   auto *tmp = reinterpret_cast<long long int *>(out.data());


### PR DESCRIPTION
Из-за предыдущего исправления (https://github.com/learning-process/ppc-2025-threads/pull/931) размеры perf тестов остались различны в версии seq и прочих, что и исправлено в этом PR