### PR TITLE
[FIX] Ворошилов Виталий. Вариант 30. Построение выпуклой оболочки для компонент бинарного изображения.

### DIFF
--- a/tasks/all/voroshilov_v_convex_hull_components/include/chc.hpp
+++ b/tasks/all/voroshilov_v_convex_hull_components/include/chc.hpp
@@ -44,7 +44,7 @@ struct Image {
   std::vector<Pixel> pixels;
 
   Image() = default;
-  Image(int hght, int wdth, std::vector<int> pxls);
+  Image(int hght, int wdth, std::vector<int>& pxls);
   Image(const Image& other) = default;
   Image& operator=(const Image& other) = default;
   Pixel& GetPixel(int y, int x);

--- a/tasks/all/voroshilov_v_convex_hull_components/include/chc.hpp
+++ b/tasks/all/voroshilov_v_convex_hull_components/include/chc.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <boost/serialization/access.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <boost/serialization/access.hpp>  // NOLINT(misc-include-cleaner)
 #include <cstddef>
 #include <unordered_map>
 #include <vector>
@@ -58,24 +59,38 @@ struct LineSegment {
 
 class UnionFind {
  public:
-  std::unordered_map<int, int> roots;
-  std::unordered_map<int, int> ranks;
+  std::vector<int> roots;
+  std::vector<int> ranks;
 
   UnionFind() = default;
+  UnionFind(int n);
   int FindRoot(int x);
   void Union(int x, int y);
 };
 
-void CheckBoundaryPixels(UnionFind* union_find, Image& image, int y, int x);
+void CheckBoundaryPixels(UnionFind& union_find, Image& image, int y, int x);
 
 void MergeComponentsAcrossAreas(std::vector<Component>& components, Image& image, int area_height,
                                 std::vector<int>& end_y);
 
-Component DepthComponentSearchInArea(Pixel start_pixel, Image* tmp_image, int index, int start_y, int end_y);
+template <typename T>
+std::vector<T> MergeVectors(std::vector<std::vector<T>>& vectors);
 
-std::vector<Component> FindComponentsInArea(Image& tmp_image, int start_y, int end_y, int index_offset);
+Component DepthComponentSearchInArea(Pixel start_pixel, Image& image, int index, int start_y, int end_y);
+
+std::vector<Component> FindComponentsInArea(Image& image, int start_y, int end_y, int index_offset);
 
 std::vector<Component> FindComponentsOMP(Image& image);
+
+std::unordered_map<int, std::vector<Pixel>> UnionComponents(int start_y, int end_y,
+                                                            std::vector<Component>& local_components,
+                                                            std::vector<Component>& from_up,
+                                                            std::unordered_map<int, std::vector<int>>& boundary_map);
+
+std::vector<Component> SendExtraComponents(boost::mpi::communicator& world, int start_y, int end_y,
+                                           std::vector<Component>& local_components);
+
+std::vector<Component> FindComponentsMPIOMP(int height, int width, std::vector<int>& pixels_in);
 
 int CheckRotation(Pixel& first, Pixel& second, Pixel& third);
 
@@ -83,14 +98,9 @@ Pixel FindFarthestPixel(std::vector<Pixel>& pixels, LineSegment& line_segment);
 
 std::vector<Pixel> QuickHull(Component& component);
 
-void ComputePartition(int vec_size, int world_size, std::vector<int>& parts, std::vector<int>& offsets);
-
-std::vector<std::vector<int>> PackIdxs(std::vector<Component>& components, int image_width, std::vector<int>& parts,
-                                       std::vector<int>& offsets, std::vector<int>& comp_sizes);
-
 std::vector<Hull> QuickHullAllOMP(std::vector<Component>& components);
 
-std::vector<Hull> QuickHullAllMPIOMP(std::vector<Component>& components, int image_width);
+std::vector<Hull> QuickHullAllMPIOMP(std::vector<Component>& components);
 
 void PackHulls(std::vector<Hull>& hulls, int width, int height, int* hulls_indxs, int* pixels_indxs);
 

--- a/tasks/all/voroshilov_v_convex_hull_components/perf_tests/main.cpp
+++ b/tasks/all/voroshilov_v_convex_hull_components/perf_tests/main.cpp
@@ -159,9 +159,9 @@ void CheckResultsWithOpencv(int height, int width, std::vector<int>& pixels, std
 }  // namespace
 
 TEST(voroshilov_v_convex_hull_components_all, chc_pipeline_run) {
-  int height = 10'000;
-  int width = 10'000;
-  std::vector<int> pixels = GenerateRectanglesComponents(width, height, 1000, 100, 500);
+  int height = 3'000;
+  int width = 3'000;
+  std::vector<int> pixels = GenerateRectanglesComponents(width, height, 1000, 25, 100);
 
   int* p_height = &height;
   int* p_width = &width;
@@ -182,7 +182,7 @@ TEST(voroshilov_v_convex_hull_components_all, chc_pipeline_run) {
   auto chc_task_all = std::make_shared<voroshilov_v_convex_hull_components_all::ChcTaskALL>(task_data_all);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 1;
+  perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&] {
     auto current_time_point = std::chrono::high_resolution_clock::now();
@@ -208,9 +208,9 @@ TEST(voroshilov_v_convex_hull_components_all, chc_pipeline_run) {
 }
 
 TEST(voroshilov_v_convex_hull_components_all, chc_task_run) {
-  int height = 10'000;
-  int width = 10'000;
-  std::vector<int> pixels = GenerateRectanglesComponents(width, height, 1000, 100, 500);
+  int height = 3'000;
+  int width = 3'000;
+  std::vector<int> pixels = GenerateRectanglesComponents(width, height, 1000, 25, 100);
 
   int* p_height = &height;
   int* p_width = &width;
@@ -231,7 +231,7 @@ TEST(voroshilov_v_convex_hull_components_all, chc_task_run) {
   auto chc_task_all = std::make_shared<voroshilov_v_convex_hull_components_all::ChcTaskALL>(task_data_all);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 1;
+  perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&] {
     auto current_time_point = std::chrono::high_resolution_clock::now();

--- a/tasks/all/voroshilov_v_convex_hull_components/src/chc.cpp
+++ b/tasks/all/voroshilov_v_convex_hull_components/src/chc.cpp
@@ -23,7 +23,7 @@ Pixel::Pixel(int y_param, int x_param, int value_param) : y(y_param), x(x_param)
 bool Pixel::operator==(const int value_param) const { return value == value_param; }
 bool Pixel::operator==(const Pixel& other) const { return (y == other.y) && (x == other.x); }
 
-Image::Image(int hght, int wdth, std::vector<int> pxls) {
+Image::Image(int hght, int wdth, std::vector<int>& pxls) {
   height = hght;
   width = wdth;
   pixels.resize(height * width);

--- a/tasks/all/voroshilov_v_convex_hull_components/src/chc.cpp
+++ b/tasks/all/voroshilov_v_convex_hull_components/src/chc.cpp
@@ -5,7 +5,8 @@
 #include <algorithm>
 #include <boost/mpi/collectives.hpp>
 #include <boost/mpi/communicator.hpp>
-#include <boost/serialization/vector.hpp>  // NOLINT(misc-include-cleaner)
+#include <boost/serialization/utility.hpp>  // NOLINT(misc-include-cleaner)
+#include <boost/serialization/vector.hpp>   // NOLINT(misc-include-cleaner)
 #include <cmath>
 #include <cstddef>
 #include <iterator>
@@ -39,50 +40,56 @@ Pixel& Image::GetPixel(int y, int x) { return pixels[(y * width) + x]; }
 
 LineSegment::LineSegment(Pixel& a_param, Pixel& b_param) : a(a_param), b(b_param) {}
 
+UnionFind::UnionFind(int n) {
+  roots.resize(n);
+  ranks.resize(n);
+  for (int i = 0; i < n; i++) {
+    roots[i] = i;
+    ranks[i] = 1;
+  }
+}
+
 int UnionFind::FindRoot(int x) {
-  if (roots.find(x) == roots.end()) {
-    roots[x] = x;
-    ranks[x] = 1;
+  while (roots[x] != x) {
+    roots[x] = roots[roots[x]];
+    x = roots[x];
   }
-  if (roots[x] != x) {
-    roots[x] = FindRoot(roots[x]);
-  }
-  return roots[x];
+  return x;
 }
 
 void UnionFind::Union(int x, int y) {
   int root_x = FindRoot(x);
   int root_y = FindRoot(y);
-  if (root_x != root_y) {
-    if (ranks[root_x] > ranks[root_y]) {
-      roots[root_y] = root_x;
-    } else if (ranks[root_x] < ranks[root_y]) {
-      roots[root_x] = root_y;
-    } else {
-      roots[root_y] = root_x;
-      ranks[root_x]++;
-    }
+  if (root_x == root_y) {
+    return;
+  }
+  if (ranks[root_x] < ranks[root_y]) {
+    std::swap(root_x, root_y);
+  }
+  roots[root_y] = root_x;
+  if (ranks[root_x] == ranks[root_y]) {
+    ranks[root_x]++;
   }
 }
 
-void voroshilov_v_convex_hull_components_all::CheckBoundaryPixels(UnionFind* union_find, Image& image, int y, int x) {
+void voroshilov_v_convex_hull_components_all::CheckBoundaryPixels(UnionFind& union_find, Image& image, int y, int x) {
   Pixel p1 = image.GetPixel(y, x);
 
   Pixel p2 = image.GetPixel(y + 1, x);
   if (p1.value > 1 && p2.value > 1) {
-    union_find->Union(p1.value, p2.value);
+    union_find.Union(p1.value, p2.value);
   }
 
   if (x > 0) {
     Pixel p3 = image.GetPixel(y + 1, x - 1);
     if (p1.value > 1 && p3.value > 1) {
-      union_find->Union(p1.value, p3.value);
+      union_find.Union(p1.value, p3.value);
     }
   }
   if (x < image.width - 1) {
     Pixel p4 = image.GetPixel(y + 1, x + 1);
     if (p1.value > 1 && p4.value > 1) {
-      union_find->Union(p1.value, p4.value);
+      union_find.Union(p1.value, p4.value);
     }
   }
 }
@@ -90,7 +97,12 @@ void voroshilov_v_convex_hull_components_all::CheckBoundaryPixels(UnionFind* uni
 void voroshilov_v_convex_hull_components_all::MergeComponentsAcrossAreas(std::vector<Component>& components,
                                                                          Image& image, int area_height,
                                                                          std::vector<int>& end_y) {
-  UnionFind union_find;
+  if (components.empty()) {
+    return;
+  }
+
+  int num_threads = omp_get_max_threads();
+  UnionFind union_find((num_threads * 1000) + 3);
 
   int width = image.width;
   int height = image.height;
@@ -99,35 +111,94 @@ void voroshilov_v_convex_hull_components_all::MergeComponentsAcrossAreas(std::ve
     int y = endy - 1;
     if (y != height - 1) {
       for (int x = 0; x < width; x++) {
-        CheckBoundaryPixels(&union_find, image, y, x);
+        CheckBoundaryPixels(union_find, image, y, x);
       }
     }
   }
 
-  std::unordered_map<int, Component> merged_components;
-  for (Component& component : components) {
-    int new_id = union_find.FindRoot(component[0].value);
-    if (merged_components.find(new_id) == merged_components.end()) {
-      merged_components[new_id] = Component();
-    }
-    merged_components[new_id].insert(merged_components[new_id].end(), component.begin(), component.end());
+  int n = (int)components.size();
+  std::vector<int> all_roots;
+  all_roots.reserve(n);
+  for (int i = 0; i < n; i++) {
+    int label = components[i][0].value;
+    all_roots.push_back(union_find.FindRoot(label));
   }
 
-  components.clear();
-  for (auto& entry : merged_components) {
-    components.push_back(entry.second);
+  std::vector<int> roots_unique = all_roots;
+  std::ranges::sort(roots_unique);
+  auto it = std::ranges::unique(roots_unique).begin();
+  roots_unique.erase(it, roots_unique.end());
+  int r = (int)roots_unique.size();
+
+  int max_root = -1;
+  if (!roots_unique.empty()) {
+    max_root = roots_unique.back();
   }
+  std::vector<int> root_to_indx(max_root + 1, -1);
+  for (int i = 0; i < r; i++) {
+    root_to_indx[roots_unique[i]] = i;
+  }
+
+  std::vector<std::vector<int>> comps_by_root(r);
+  for (int i = 0; i < n; i++) {
+    int b = root_to_indx[all_roots[i]];
+    comps_by_root[b].push_back(i);
+  }
+
+  std::vector<Component> merged(r);
+#pragma omp parallel for schedule(dynamic)
+  for (int i = 0; i < r; i++) {
+    size_t total = 0;
+    for (int indx : comps_by_root[i]) {
+      total += components[indx].size();
+    }
+    merged[i].reserve(total);
+
+    for (int indx : comps_by_root[i]) {
+      Component& src = components[indx];
+      std::ranges::move(src, std::back_inserter(merged[i]));
+    }
+  }
+
+  components = std::move(merged);
 }
 
-Component voroshilov_v_convex_hull_components_all::DepthComponentSearchInArea(Pixel start_pixel, Image* tmp_image,
+template <typename T>
+std::vector<T> voroshilov_v_convex_hull_components_all::MergeVectors(std::vector<std::vector<T>>& vectors) {
+  int size = (int)vectors.size();
+
+  std::vector<int> sizes(size);
+  std::vector<int> offsets(size + 1);
+  for (int i = 0; i < size; i++) {
+    sizes[i] = (int)vectors[i].size();
+  }
+  if (!offsets.empty()) {
+    offsets[0] = 0;
+  }
+  for (int i = 0; i < size; i++) {
+    offsets[i + 1] = offsets[i] + sizes[i];
+  }
+
+  std::vector<T> vec(offsets[size]);
+
+  for (int i = 0; i < size; i++) {
+    std::vector<T>& src = vectors[i];
+    auto dst_it = vec.begin() + offsets[i];
+    std::move(src.begin(), src.end(), dst_it);
+  }
+
+  return vec;
+}
+
+Component voroshilov_v_convex_hull_components_all::DepthComponentSearchInArea(Pixel start_pixel, Image& image,
                                                                               int index, int start_y, int end_y) {
   const int step_y[8] = {1, 1, 1, 0, 0, -1, -1, -1};  // Offsets by Y (up, stand, down)
   const int step_x[8] = {-1, 0, 1, -1, 1, -1, 0, 1};  // Offsets by X (left, stand, right)
   std::stack<Pixel> stack;
   std::vector<Pixel> component_pixels;
   stack.push(start_pixel);
-  tmp_image->GetPixel(start_pixel.y, start_pixel.x).value = index;                // Mark start pixel as visited
-  component_pixels.push_back(tmp_image->GetPixel(start_pixel.y, start_pixel.x));  // Add start pixel to component
+  image.GetPixel(start_pixel.y, start_pixel.x).value = index;                // Mark start pixel as visited
+  component_pixels.push_back(image.GetPixel(start_pixel.y, start_pixel.x));  // Add start pixel to component
 
   while (!stack.empty()) {
     Pixel current_pixel = stack.top();
@@ -135,11 +206,11 @@ Component voroshilov_v_convex_hull_components_all::DepthComponentSearchInArea(Pi
     for (int i = 0; i < 8; i++) {
       int next_y = current_pixel.y + step_y[i];
       int next_x = current_pixel.x + step_x[i];
-      if (next_y >= start_y && next_y < end_y && next_x >= 0 && next_x < tmp_image->width &&
-          tmp_image->GetPixel(next_y, next_x) == 1) {
-        stack.push(tmp_image->GetPixel(next_y, next_x));
-        tmp_image->GetPixel(next_y, next_x).value = index;                // Mark neighbour pixel as visited
-        component_pixels.push_back(tmp_image->GetPixel(next_y, next_x));  // Add neighbour pixel to component
+      if (next_y >= start_y && next_y < end_y && next_x >= 0 && next_x < image.width &&
+          image.GetPixel(next_y, next_x) == 1) {
+        stack.push(image.GetPixel(next_y, next_x));
+        image.GetPixel(next_y, next_x).value = index;                // Mark neighbour pixel as visited
+        component_pixels.push_back(image.GetPixel(next_y, next_x));  // Add neighbour pixel to component
       }
     }
   }
@@ -149,15 +220,15 @@ Component voroshilov_v_convex_hull_components_all::DepthComponentSearchInArea(Pi
   return component;
 }
 
-std::vector<Component> voroshilov_v_convex_hull_components_all::FindComponentsInArea(Image& tmp_image, int start_y,
+std::vector<Component> voroshilov_v_convex_hull_components_all::FindComponentsInArea(Image& image, int start_y,
                                                                                      int end_y, int index_offset) {
   std::vector<Component> components;
   int index = index_offset;  // unique index in this area
 
   for (int y = start_y; y < end_y; y++) {
-    for (int x = 0; x < tmp_image.width; x++) {
-      if (tmp_image.GetPixel(y, x) == 1) {
-        Component component = DepthComponentSearchInArea(tmp_image.GetPixel(y, x), &tmp_image, index, start_y, end_y);
+    for (int x = 0; x < image.width; x++) {
+      if (image.GetPixel(y, x) == 1) {
+        Component component = DepthComponentSearchInArea(image.GetPixel(y, x), image, index, start_y, end_y);
         components.push_back(component);
         index++;
       }
@@ -174,7 +245,7 @@ std::vector<Component> voroshilov_v_convex_hull_components_all::FindComponentsIn
 std::vector<Component> voroshilov_v_convex_hull_components_all::FindComponentsOMP(Image& image) {
   int num_threads = omp_get_max_threads();
 
-  std::vector<std::vector<Component>> thread_components(num_threads);
+  std::vector<std::vector<Component>> threads_components(num_threads);
 
   int height = image.height;
 
@@ -203,7 +274,7 @@ std::vector<Component> voroshilov_v_convex_hull_components_all::FindComponentsOM
     end_y[end_y.size() - 1] = height;
 
     for (int i = 0; i < num_threads; i++) {
-      index_offset[i] = (i * 100000) + 2;
+      index_offset[i] = (i * 1000) + 2;
     }
   }
 
@@ -211,18 +282,169 @@ std::vector<Component> voroshilov_v_convex_hull_components_all::FindComponentsOM
   {
     int thread_id = omp_get_thread_num();
 
-    thread_components[thread_id] =
+    threads_components[thread_id] =
         FindComponentsInArea(image, start_y[thread_id], end_y[thread_id], index_offset[thread_id]);
   }
 
-  std::vector<Component> components;
-  for (std::vector<Component>& vec : thread_components) {
-    components.insert(components.end(), vec.begin(), vec.end());
-  }
+  std::vector<Component> components = MergeVectors<Component>(threads_components);
 
   MergeComponentsAcrossAreas(components, image, area_height, end_y);
 
   return components;
+}
+
+std::unordered_map<int, std::vector<Pixel>> voroshilov_v_convex_hull_components_all::UnionComponents(
+    int start_y, int end_y, std::vector<Component>& local_components, std::vector<Component>& from_up,
+    std::unordered_map<int, std::vector<int>>& boundary_map) {
+  int loc_size = (int)local_components.size();
+  int up_size = (int)from_up.size();
+
+  UnionFind uf(loc_size + up_size);
+
+  for (int i = 0; i < (int)from_up.size(); i++) {
+    for (Pixel& p : from_up[i]) {
+      if (p.y == start_y - 1) {
+        for (int dx = -1; dx <= 1; dx++) {
+          int xx = p.x + dx;
+          auto it = boundary_map.find(xx);
+          if (it != boundary_map.end()) {
+            for (int i_loc : it->second) {
+              uf.Union(i_loc, loc_size + i);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  std::unordered_map<int, std::vector<Pixel>> merged_pixels;
+  merged_pixels.reserve(loc_size + up_size);
+  for (int i = 0; i < loc_size; i++) {
+    int r = uf.FindRoot(i);
+    merged_pixels[r].insert(merged_pixels[r].end(), std::make_move_iterator(local_components[i].begin()),
+                            std::make_move_iterator(local_components[i].end()));
+  }
+  for (int i = 0; i < up_size; i++) {
+    int idx = loc_size + i;
+    int r = uf.FindRoot(idx);
+    merged_pixels[r].insert(merged_pixels[r].end(), std::make_move_iterator(from_up[i].begin()),
+                            std::make_move_iterator(from_up[i].end()));
+  }
+
+  return merged_pixels;
+}
+
+std::vector<Component> voroshilov_v_convex_hull_components_all::SendExtraComponents(
+    boost::mpi::communicator& world, int start_y, int end_y, std::vector<Component>& local_components) {
+  int rank = world.rank();
+  int num_procs = world.size();
+
+  std::vector<Component> from_up;
+  if (rank > 0) {
+    world.recv(rank - 1, 2, from_up);
+  }
+
+  std::unordered_map<int, std::vector<int>> boundary_map;
+  for (int i = 0; i < (int)local_components.size(); i++) {
+    for (Pixel& p : local_components[i]) {
+      if (p.y == start_y) {
+        boundary_map[p.x].push_back(i);
+      }
+    }
+  }
+
+  std::unordered_map<int, std::vector<Pixel>> merged_pixels =
+      UnionComponents(start_y, end_y, local_components, from_up, boundary_map);
+
+  std::vector<Component> to_keep;
+  std::vector<Component> to_send;
+
+  for (auto& [root, idxs] : merged_pixels) {
+    Component comp(std::move(idxs));
+    int max_y = comp.front().y;
+    for (Pixel& p : comp) {
+      max_y = std::max(max_y, p.y);
+    }
+    if (rank == num_procs - 1 || max_y < end_y - 1) {
+      to_keep.push_back(std::move(comp));
+    } else {
+      to_send.push_back(std::move(comp));
+    }
+  }
+
+  if (rank + 1 < num_procs) {
+    world.send(rank + 1, 2, to_send);
+  }
+
+  return to_keep;
+}
+
+std::vector<Component> voroshilov_v_convex_hull_components_all::FindComponentsMPIOMP(int height, int width,
+                                                                                     std::vector<int>& pixels_in) {
+  boost::mpi::communicator world;
+
+  int num_procs = world.size();
+  int rank = world.rank();
+
+  // NOLINTNEXTLINE(misc-include-cleaner)
+  boost::mpi::broadcast(world, height, 0);
+  // NOLINTNEXTLINE(misc-include-cleaner)
+  boost::mpi::broadcast(world, width, 0);
+
+  int area_height = height / num_procs;
+  int remainder = height % num_procs;
+  std::vector<int> start_y(num_procs, 0);
+  std::vector<int> end_y(num_procs);
+  std::vector<int> index_offset(num_procs);
+
+  if (num_procs == 1) {
+    end_y[0] = height;
+    index_offset[0] = 2;
+  } else {
+    for (size_t i = 1; i < start_y.size(); i++) {
+      start_y[i] = start_y[i - 1] + area_height;
+      if (remainder > 0) {
+        start_y[i]++;
+        remainder--;
+      }
+    }
+    for (size_t i = 0; i < end_y.size() - 1; i++) {
+      end_y[i] = start_y[i + 1];
+    }
+    end_y[end_y.size() - 1] = height;
+
+    for (int i = 0; i < num_procs; i++) {
+      index_offset[i] = (i * 1000) + 2;
+    }
+  }
+
+  std::vector<int> sizes(num_procs);
+  std::vector<int> displs(num_procs);
+  for (int i = 0; i < num_procs; i++) {
+    sizes[i] = (end_y[i] - start_y[i]) * width;
+    displs[i] = start_y[i] * width;
+  }
+
+  std::vector<int> local_pixels(sizes[rank]);
+  // NOLINTNEXTLINE(misc-include-cleaner)
+  boost::mpi::scatterv(world, pixels_in, sizes, displs, local_pixels.data(), static_cast<int>(local_pixels.size()), 0);
+
+  int local_height = end_y[rank] - start_y[rank];
+  Image local_image(local_height, width, local_pixels);
+
+  std::vector<Component> local_components = FindComponentsOMP(local_image);
+
+  int y_offset = start_y[rank];
+  for (Component& comp : local_components) {
+    for (Pixel& p : comp) {
+      p.y += y_offset;
+    }
+  }
+
+  std::vector<Component> local_full_components =
+      SendExtraComponents(world, start_y[rank], end_y[rank], local_components);
+
+  return local_full_components;
 }
 
 int voroshilov_v_convex_hull_components_all::CheckRotation(Pixel& first, Pixel& second, Pixel& third) {
@@ -303,51 +525,6 @@ std::vector<Pixel> voroshilov_v_convex_hull_components_all::QuickHull(Component&
   return res_hull;
 }
 
-void voroshilov_v_convex_hull_components_all::ComputePartition(int vec_size, int world_size, std::vector<int>& parts,
-                                                               std::vector<int>& offsets) {
-  int base = vec_size / world_size;
-  int remainder = vec_size % world_size;
-  parts.resize(world_size);
-  offsets.resize(world_size);
-  for (int i = 0; i < world_size; i++) {
-    parts[i] = base;
-    if (remainder > 0) {
-      parts[i]++;
-      remainder--;
-    }
-    if (i == 0) {
-      offsets[i] = 0;
-    } else {
-      offsets[i] = offsets[i - 1] + parts[i - 1];
-    }
-  }
-}
-
-std::vector<std::vector<int>> voroshilov_v_convex_hull_components_all::PackIdxs(std::vector<Component>& components,
-                                                                                int image_width,
-                                                                                std::vector<int>& parts,
-                                                                                std::vector<int>& offsets,
-                                                                                std::vector<int>& comp_sizes) {
-  int world_size = static_cast<int>(parts.size());
-  std::vector<std::vector<int>> split_idxs(world_size);
-  for (int i = 0; i < world_size; i++) {
-    int part = parts[i];
-    int offset = offsets[i];
-    int total_pixels = 0;
-    for (int j = 0; j < part; j++) {
-      total_pixels += comp_sizes[offset + j];
-    }
-    split_idxs[i].reserve(total_pixels);
-    for (int j = 0; j < part; j++) {
-      Component comp = components[offset + j];
-      for (Pixel& p : comp) {
-        split_idxs[i].push_back((p.y * image_width) + p.x);
-      }
-    }
-  }
-  return split_idxs;
-}
-
 std::vector<Hull> voroshilov_v_convex_hull_components_all::QuickHullAllOMP(std::vector<Component>& components) {
   if (components.empty()) {
     return {};
@@ -364,75 +541,20 @@ std::vector<Hull> voroshilov_v_convex_hull_components_all::QuickHullAllOMP(std::
   return hulls;
 }
 
-std::vector<Hull> voroshilov_v_convex_hull_components_all::QuickHullAllMPIOMP(std::vector<Component>& components,
-                                                                              int image_width) {
+std::vector<Hull> voroshilov_v_convex_hull_components_all::QuickHullAllMPIOMP(
+    std::vector<Component>& local_components) {
   boost::mpi::communicator world;
-  // NOLINTNEXTLINE(misc-include-cleaner)
-  boost::mpi::broadcast(world, image_width, 0);
+  int rank = world.rank();
 
-  std::vector<int> comp_sizes;
-  if (world.rank() == 0) {
-    comp_sizes.reserve(components.size());
-    for (Component& comp : components) {
-      comp_sizes.push_back(static_cast<int>(comp.size()));
-    }
-  }
-  // NOLINTNEXTLINE(misc-include-cleaner)
-  boost::mpi::broadcast(world, comp_sizes, 0);
-
-  std::vector<int> parts;
-  std::vector<int> offsets;
-  if (world.rank() == 0) {
-    ComputePartition(static_cast<int>(components.size()), world.size(), parts, offsets);
-  }
-  // NOLINTNEXTLINE(misc-include-cleaner)
-  boost::mpi::broadcast(world, parts, 0);
-  // NOLINTNEXTLINE(misc-include-cleaner)
-  boost::mpi::broadcast(world, offsets, 0);
-
-  std::vector<std::vector<int>> split_idxs;
-  if (world.rank() == 0) {
-    split_idxs = PackIdxs(components, image_width, parts, offsets, comp_sizes);
-  }
-
-  std::vector<int> local_idxs;
-  // NOLINTNEXTLINE(misc-include-cleaner)
-  boost::mpi::scatter(world, split_idxs, local_idxs, 0);
-
-  std::vector<Component> local_components(parts[world.rank()]);
-  int pos = 0;
-  for (int i = 0; i < parts[world.rank()]; i++) {
-    int comp_size = comp_sizes[offsets[world.rank()] + i];
-    Component comp;
-    comp.reserve(comp_size);
-    for (int j = 0; j < comp_size; j++, pos++) {
-      int idx = local_idxs[pos];
-      int y = idx / image_width;
-      int x = idx % image_width;
-      comp.emplace_back(y, x, 1);
-    }
-    local_components[i] = std::move(comp);
-  }
-
-  int local_components_size = static_cast<int>(local_components.size());
-  std::vector<Hull> local_hulls(local_components.size());
-
-#pragma omp parallel for schedule(dynamic)
-  for (int i = 0; i < local_components_size; i++) {
-    local_hulls[i] = QuickHull(local_components[i]);
-  }
+  std::vector<Hull> local_hulls = QuickHullAllOMP(local_components);
 
   std::vector<std::vector<Hull>> gathered_hulls;
   // NOLINTNEXTLINE(misc-include-cleaner)
   boost::mpi::gather(world, local_hulls, gathered_hulls, 0);
-  if (world.rank() == 0) {
-    std::vector<Hull> hulls;
-    for (auto& vector_hulls : gathered_hulls) {
-      hulls.insert(hulls.end(), std::make_move_iterator(vector_hulls.begin()),
-                   std::make_move_iterator(vector_hulls.end()));
-    }
 
-    return hulls;
+  if (rank == 0) {
+    std::vector<Hull> result_hulls = MergeVectors<Hull>(gathered_hulls);
+    return result_hulls;
   }
 
   return {};

--- a/tasks/all/voroshilov_v_convex_hull_components/src/chc_all.cpp
+++ b/tasks/all/voroshilov_v_convex_hull_components/src/chc_all.cpp
@@ -36,18 +36,9 @@ bool voroshilov_v_convex_hull_components_all::ChcTaskALL::PreProcessingImpl() {
 }
 
 bool voroshilov_v_convex_hull_components_all::ChcTaskALL::RunImpl() {
-  std::vector<Component> components;
+  std::vector<Component> local_components = FindComponentsMPIOMP(height_in_, width_in_, pixels_in_);
 
-  if (world_.rank() == 0) {
-    Image image(height_in_, width_in_, pixels_in_);
-    components = FindComponentsOMP(image);
-  }
-
-  if (world_.size() <= 1) {
-    hulls_out_ = QuickHullAllOMP(components);
-  } else {
-    hulls_out_ = QuickHullAllMPIOMP(components, width_in_);
-  }
+  hulls_out_ = QuickHullAllMPIOMP(local_components);
 
   return true;
 }

--- a/tasks/omp/voroshilov_v_convex_hull_components/include/chc.hpp
+++ b/tasks/omp/voroshilov_v_convex_hull_components/include/chc.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstddef>
-#include <unordered_map>
 #include <vector>
 
 namespace voroshilov_v_convex_hull_components_omp {
@@ -46,22 +45,26 @@ using Hull = std::vector<Pixel>;
 
 class UnionFind {
  public:
-  std::unordered_map<int, int> roots;
-  std::unordered_map<int, int> ranks;
+  std::vector<int> roots;
+  std::vector<int> ranks;
 
   UnionFind() = default;
+  UnionFind(int n);
   int FindRoot(int x);
   void Union(int x, int y);
 };
 
-void CheckBoundaryPixels(UnionFind* union_find, Image& image, int y, int x);
+void CheckBoundaryPixels(UnionFind& union_find, Image& image, int y, int x);
 
 void MergeComponentsAcrossAreas(std::vector<Component>& components, Image& image, int area_height,
                                 std::vector<int>& end_y);
 
-Component DepthComponentSearchInArea(Pixel start_pixel, Image* tmp_image, int index, int start_y, int end_y);
+template <typename T>
+std::vector<T> MergeVectors(std::vector<std::vector<T>>& vectors);
 
-std::vector<Component> FindComponentsInArea(Image& tmp_image, int start_y, int end_y, int index_offset);
+Component DepthComponentSearchInArea(Pixel start_pixel, Image& image, int index, int start_y, int end_y);
+
+std::vector<Component> FindComponentsInArea(Image& image, int start_y, int end_y, int index_offset);
 
 std::vector<Component> FindComponentsOMP(Image& image);
 

--- a/tasks/omp/voroshilov_v_convex_hull_components/perf_tests/main.cpp
+++ b/tasks/omp/voroshilov_v_convex_hull_components/perf_tests/main.cpp
@@ -134,9 +134,9 @@ bool IsHullSubset(Hull& hull_first, Hull& hull_second) {
 }  // namespace
 
 TEST(voroshilov_v_convex_hull_components_omp, chc_pipeline_run) {
-  int height = 10'000;
-  int width = 10'000;
-  std::vector<int> pixels = GenerateRectanglesComponents(width, height, 1000, 100, 500);
+  int height = 3'000;
+  int width = 3'000;
+  std::vector<int> pixels = GenerateRectanglesComponents(width, height, 1000, 25, 100);
 
   int* p_height = &height;
   int* p_width = &width;
@@ -155,7 +155,7 @@ TEST(voroshilov_v_convex_hull_components_omp, chc_pipeline_run) {
   auto chc_task_omp = std::make_shared<voroshilov_v_convex_hull_components_omp::ChcTaskOMP>(task_data_omp);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 1;
+  perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&] {
     auto current_time_point = std::chrono::high_resolution_clock::now();
@@ -196,9 +196,9 @@ TEST(voroshilov_v_convex_hull_components_omp, chc_pipeline_run) {
 }
 
 TEST(voroshilov_v_convex_hull_components_omp, chc_task_run) {
-  int height = 10'000;
-  int width = 10'000;
-  std::vector<int> pixels = GenerateRectanglesComponents(width, height, 1000, 100, 500);
+  int height = 3'000;
+  int width = 3'000;
+  std::vector<int> pixels = GenerateRectanglesComponents(width, height, 1000, 25, 100);
 
   int* p_height = &height;
   int* p_width = &width;
@@ -217,7 +217,7 @@ TEST(voroshilov_v_convex_hull_components_omp, chc_task_run) {
   auto chc_task_omp = std::make_shared<voroshilov_v_convex_hull_components_omp::ChcTaskOMP>(task_data_omp);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 1;
+  perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&] {
     auto current_time_point = std::chrono::high_resolution_clock::now();

--- a/tasks/omp/voroshilov_v_convex_hull_components/src/chc.cpp
+++ b/tasks/omp/voroshilov_v_convex_hull_components/src/chc.cpp
@@ -5,8 +5,8 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <iterator>
 #include <stack>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -35,50 +35,56 @@ Pixel& Image::GetPixel(int y, int x) { return pixels[(y * width) + x]; }
 
 LineSegment::LineSegment(Pixel& a_param, Pixel& b_param) : a(a_param), b(b_param) {}
 
+UnionFind::UnionFind(int n) {
+  roots.resize(n);
+  ranks.resize(n);
+  for (int i = 0; i < n; i++) {
+    roots[i] = i;
+    ranks[i] = 1;
+  }
+}
+
 int UnionFind::FindRoot(int x) {
-  if (roots.find(x) == roots.end()) {
-    roots[x] = x;
-    ranks[x] = 1;
+  while (roots[x] != x) {
+    roots[x] = roots[roots[x]];
+    x = roots[x];
   }
-  if (roots[x] != x) {
-    roots[x] = FindRoot(roots[x]);
-  }
-  return roots[x];
+  return x;
 }
 
 void UnionFind::Union(int x, int y) {
   int root_x = FindRoot(x);
   int root_y = FindRoot(y);
-  if (root_x != root_y) {
-    if (ranks[root_x] > ranks[root_y]) {
-      roots[root_y] = root_x;
-    } else if (ranks[root_x] < ranks[root_y]) {
-      roots[root_x] = root_y;
-    } else {
-      roots[root_y] = root_x;
-      ranks[root_x]++;
-    }
+  if (root_x == root_y) {
+    return;
+  }
+  if (ranks[root_x] < ranks[root_y]) {
+    std::swap(root_x, root_y);
+  }
+  roots[root_y] = root_x;
+  if (ranks[root_x] == ranks[root_y]) {
+    ranks[root_x]++;
   }
 }
 
-void voroshilov_v_convex_hull_components_omp::CheckBoundaryPixels(UnionFind* union_find, Image& image, int y, int x) {
+void voroshilov_v_convex_hull_components_omp::CheckBoundaryPixels(UnionFind& union_find, Image& image, int y, int x) {
   Pixel p1 = image.GetPixel(y, x);
 
   Pixel p2 = image.GetPixel(y + 1, x);
   if (p1.value > 1 && p2.value > 1) {
-    union_find->Union(p1.value, p2.value);
+    union_find.Union(p1.value, p2.value);
   }
 
   if (x > 0) {
     Pixel p3 = image.GetPixel(y + 1, x - 1);
     if (p1.value > 1 && p3.value > 1) {
-      union_find->Union(p1.value, p3.value);
+      union_find.Union(p1.value, p3.value);
     }
   }
   if (x < image.width - 1) {
     Pixel p4 = image.GetPixel(y + 1, x + 1);
     if (p1.value > 1 && p4.value > 1) {
-      union_find->Union(p1.value, p4.value);
+      union_find.Union(p1.value, p4.value);
     }
   }
 }
@@ -86,7 +92,12 @@ void voroshilov_v_convex_hull_components_omp::CheckBoundaryPixels(UnionFind* uni
 void voroshilov_v_convex_hull_components_omp::MergeComponentsAcrossAreas(std::vector<Component>& components,
                                                                          Image& image, int area_height,
                                                                          std::vector<int>& end_y) {
-  UnionFind union_find;
+  if (components.empty()) {
+    return;
+  }
+
+  int num_threads = omp_get_max_threads();
+  UnionFind union_find((num_threads * 1000) + 3);
 
   int width = image.width;
   int height = image.height;
@@ -95,35 +106,93 @@ void voroshilov_v_convex_hull_components_omp::MergeComponentsAcrossAreas(std::ve
     int y = endy - 1;
     if (y != height - 1) {
       for (int x = 0; x < width; x++) {
-        CheckBoundaryPixels(&union_find, image, y, x);
+        CheckBoundaryPixels(union_find, image, y, x);
       }
     }
   }
 
-  std::unordered_map<int, Component> merged_components;
-  for (Component& component : components) {
-    int new_id = union_find.FindRoot(component[0].value);
-    if (merged_components.find(new_id) == merged_components.end()) {
-      merged_components[new_id] = Component();
-    }
-    merged_components[new_id].insert(merged_components[new_id].end(), component.begin(), component.end());
+  int n = (int)components.size();
+  std::vector<int> all_roots;
+  all_roots.reserve(n);
+  for (int i = 0; i < n; i++) {
+    int label = components[i][0].value;
+    all_roots.push_back(union_find.FindRoot(label));
   }
 
-  components.clear();
-  for (auto& entry : merged_components) {
-    components.push_back(entry.second);
+  std::vector<int> roots_unique = all_roots;
+  std::ranges::sort(roots_unique);
+  auto it = std::ranges::unique(roots_unique).begin();
+  roots_unique.erase(it, roots_unique.end());
+  int r = (int)roots_unique.size();
+
+  int max_root = -1;
+  if (!roots_unique.empty()) {
+    max_root = roots_unique.back();
   }
+  std::vector<int> root_to_indx(max_root + 1, -1);
+  for (int i = 0; i < r; i++) {
+    root_to_indx[roots_unique[i]] = i;
+  }
+
+  std::vector<std::vector<int>> comps_by_root(r);
+  for (int i = 0; i < n; i++) {
+    int b = root_to_indx[all_roots[i]];
+    comps_by_root[b].push_back(i);
+  }
+
+  std::vector<Component> merged(r);
+#pragma omp parallel for schedule(dynamic)
+  for (int i = 0; i < r; i++) {
+    size_t total = 0;
+    for (int indx : comps_by_root[i]) {
+      total += components[indx].size();
+    }
+    merged[i].reserve(total);
+
+    for (int indx : comps_by_root[i]) {
+      Component& src = components[indx];
+      std::ranges::move(src, std::back_inserter(merged[i]));
+    }
+  }
+
+  components = std::move(merged);
 }
 
-Component voroshilov_v_convex_hull_components_omp::DepthComponentSearchInArea(Pixel start_pixel, Image* tmp_image,
+template <typename T>
+std::vector<T> voroshilov_v_convex_hull_components_omp::MergeVectors(std::vector<std::vector<T>>& vectors) {
+  int size = (int)vectors.size();
+
+  std::vector<int> sizes(size);
+  std::vector<int> offsets(size + 1);
+  for (int i = 0; i < size; i++) {
+    sizes[i] = (int)vectors[i].size();
+  }
+
+  offsets[0] = 0;
+  for (int i = 0; i < size; i++) {
+    offsets[i + 1] = offsets[i] + sizes[i];
+  }
+
+  std::vector<T> vec(offsets[size]);
+
+  for (int i = 0; i < size; i++) {
+    std::vector<T>& src = vectors[i];
+    auto dst_it = vec.begin() + offsets[i];
+    std::move(src.begin(), src.end(), dst_it);
+  }
+
+  return vec;
+}
+
+Component voroshilov_v_convex_hull_components_omp::DepthComponentSearchInArea(Pixel start_pixel, Image& image,
                                                                               int index, int start_y, int end_y) {
   const int step_y[8] = {1, 1, 1, 0, 0, -1, -1, -1};  // Offsets by Y (up, stand, down)
   const int step_x[8] = {-1, 0, 1, -1, 1, -1, 0, 1};  // Offsets by X (left, stand, right)
   std::stack<Pixel> stack;
   std::vector<Pixel> component_pixels;
   stack.push(start_pixel);
-  tmp_image->GetPixel(start_pixel.y, start_pixel.x).value = index;                // Mark start pixel as visited
-  component_pixels.push_back(tmp_image->GetPixel(start_pixel.y, start_pixel.x));  // Add start pixel to component
+  image.GetPixel(start_pixel.y, start_pixel.x).value = index;                // Mark start pixel as visited
+  component_pixels.push_back(image.GetPixel(start_pixel.y, start_pixel.x));  // Add start pixel to component
 
   while (!stack.empty()) {
     Pixel current_pixel = stack.top();
@@ -131,11 +200,11 @@ Component voroshilov_v_convex_hull_components_omp::DepthComponentSearchInArea(Pi
     for (int i = 0; i < 8; i++) {
       int next_y = current_pixel.y + step_y[i];
       int next_x = current_pixel.x + step_x[i];
-      if (next_y >= start_y && next_y < end_y && next_x >= 0 && next_x < tmp_image->width &&
-          tmp_image->GetPixel(next_y, next_x) == 1) {
-        stack.push(tmp_image->GetPixel(next_y, next_x));
-        tmp_image->GetPixel(next_y, next_x).value = index;                // Mark neighbour pixel as visited
-        component_pixels.push_back(tmp_image->GetPixel(next_y, next_x));  // Add neighbour pixel to component
+      if (next_y >= start_y && next_y < end_y && next_x >= 0 && next_x < image.width &&
+          image.GetPixel(next_y, next_x) == 1) {
+        stack.push(image.GetPixel(next_y, next_x));
+        image.GetPixel(next_y, next_x).value = index;                // Mark neighbour pixel as visited
+        component_pixels.push_back(image.GetPixel(next_y, next_x));  // Add neighbour pixel to component
       }
     }
   }
@@ -145,15 +214,15 @@ Component voroshilov_v_convex_hull_components_omp::DepthComponentSearchInArea(Pi
   return component;
 }
 
-std::vector<Component> voroshilov_v_convex_hull_components_omp::FindComponentsInArea(Image& tmp_image, int start_y,
+std::vector<Component> voroshilov_v_convex_hull_components_omp::FindComponentsInArea(Image& image, int start_y,
                                                                                      int end_y, int index_offset) {
   std::vector<Component> components;
   int index = index_offset;  // unique index in this area
 
   for (int y = start_y; y < end_y; y++) {
-    for (int x = 0; x < tmp_image.width; x++) {
-      if (tmp_image.GetPixel(y, x) == 1) {
-        Component component = DepthComponentSearchInArea(tmp_image.GetPixel(y, x), &tmp_image, index, start_y, end_y);
+    for (int x = 0; x < image.width; x++) {
+      if (image.GetPixel(y, x) == 1) {
+        Component component = DepthComponentSearchInArea(image.GetPixel(y, x), image, index, start_y, end_y);
         components.push_back(component);
         index++;
       }
@@ -168,22 +237,20 @@ std::vector<Component> voroshilov_v_convex_hull_components_omp::FindComponentsIn
 }
 
 std::vector<Component> voroshilov_v_convex_hull_components_omp::FindComponentsOMP(Image& image) {
-  Image tmp_image(image);
-
   int num_threads = omp_get_max_threads();
 
-  std::vector<std::vector<Component>> thread_components(num_threads);
+  std::vector<std::vector<Component>> threads_components(num_threads);
 
-  int height = tmp_image.height;
+  int height = image.height;
 
   int area_height = height / num_threads;
   int remainder = height % num_threads;
   std::vector<int> start_y(num_threads);
   std::vector<int> end_y(num_threads);
   std::vector<int> index_offset(num_threads);
+  start_y[0] = 0;
 
   if (num_threads == 1) {
-    start_y[0] = 0;
     end_y[0] = height;
     index_offset[0] = 2;
   } else {
@@ -201,7 +268,7 @@ std::vector<Component> voroshilov_v_convex_hull_components_omp::FindComponentsOM
     end_y[end_y.size() - 1] = height;
 
     for (int i = 0; i < num_threads; i++) {
-      index_offset[i] = (i * 100000) + 2;
+      index_offset[i] = (i * 1000) + 2;
     }
   }
 
@@ -209,16 +276,13 @@ std::vector<Component> voroshilov_v_convex_hull_components_omp::FindComponentsOM
   {
     int thread_id = omp_get_thread_num();
 
-    thread_components[thread_id] =
-        FindComponentsInArea(tmp_image, start_y[thread_id], end_y[thread_id], index_offset[thread_id]);
+    threads_components[thread_id] =
+        FindComponentsInArea(image, start_y[thread_id], end_y[thread_id], index_offset[thread_id]);
   }
 
-  std::vector<Component> components;
-  for (std::vector<Component>& vec : thread_components) {
-    components.insert(components.end(), vec.begin(), vec.end());
-  }
+  std::vector<Component> components = MergeVectors<Component>(threads_components);
 
-  MergeComponentsAcrossAreas(components, tmp_image, area_height, end_y);
+  MergeComponentsAcrossAreas(components, image, area_height, end_y);
 
   return components;
 }

--- a/tasks/seq/voroshilov_v_convex_hull_components/include/chc.hpp
+++ b/tasks/seq/voroshilov_v_convex_hull_components/include/chc.hpp
@@ -53,7 +53,7 @@ struct Hull {
   bool operator==(const Hull& other) const;
 };
 
-Component DepthComponentSearch(Pixel& start_pixel, Image* tmp_image, int index);
+Component DepthComponentSearch(Pixel& start_pixel, Image& image, int index);
 
 std::vector<Component> FindComponents(Image& image);
 

--- a/tasks/seq/voroshilov_v_convex_hull_components/perf_tests/main.cpp
+++ b/tasks/seq/voroshilov_v_convex_hull_components/perf_tests/main.cpp
@@ -135,9 +135,9 @@ bool IsHullSubset(Hull& hull_first, Hull& hull_second) {
 }  // namespace
 
 TEST(voroshilov_v_convex_hull_components_seq, chc_pipeline_run) {
-  int height = 10'000;
-  int width = 10'000;
-  std::vector<int> pixels = GenerateRectanglesComponents(width, height, 1000, 100, 500);
+  int height = 3'000;
+  int width = 3'000;
+  std::vector<int> pixels = GenerateRectanglesComponents(width, height, 1000, 25, 100);
 
   int* p_height = &height;
   int* p_width = &width;
@@ -157,7 +157,7 @@ TEST(voroshilov_v_convex_hull_components_seq, chc_pipeline_run) {
       std::make_shared<voroshilov_v_convex_hull_components_seq::ChcTaskSequential>(task_data_seq);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 1;
+  perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&] {
     auto current_time_point = std::chrono::high_resolution_clock::now();
@@ -197,9 +197,9 @@ TEST(voroshilov_v_convex_hull_components_seq, chc_pipeline_run) {
 }
 
 TEST(voroshilov_v_convex_hull_components_seq, chc_task_run) {
-  int height = 10'000;
-  int width = 10'000;
-  std::vector<int> pixels = GenerateRectanglesComponents(width, height, 1000, 100, 500);
+  int height = 3'000;
+  int width = 3'000;
+  std::vector<int> pixels = GenerateRectanglesComponents(width, height, 1000, 25, 100);
 
   int* p_height = &height;
   int* p_width = &width;
@@ -219,7 +219,7 @@ TEST(voroshilov_v_convex_hull_components_seq, chc_task_run) {
       std::make_shared<voroshilov_v_convex_hull_components_seq::ChcTaskSequential>(task_data_seq);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 1;
+  perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&] {
     auto current_time_point = std::chrono::high_resolution_clock::now();

--- a/tasks/seq/voroshilov_v_convex_hull_components/src/chc.cpp
+++ b/tasks/seq/voroshilov_v_convex_hull_components/src/chc.cpp
@@ -33,15 +33,14 @@ LineSegment::LineSegment(Pixel& a_param, Pixel& b_param) : a(a_param), b(b_param
 
 bool Hull::operator==(const Hull& other) const { return pixels == other.pixels; }
 
-Component voroshilov_v_convex_hull_components_seq::DepthComponentSearch(Pixel& start_pixel, Image* tmp_image,
-                                                                        int index) {
+Component voroshilov_v_convex_hull_components_seq::DepthComponentSearch(Pixel& start_pixel, Image& image, int index) {
   const int step_y[8] = {1, 1, 1, 0, 0, -1, -1, -1};  // Offsets by Y (up, stand, down)
   const int step_x[8] = {-1, 0, 1, -1, 1, -1, 0, 1};  // Offsets by X (left, stand, right)
   std::stack<Pixel> stack;
   Component component;
   stack.push(start_pixel);
-  tmp_image->GetPixel(start_pixel.y, start_pixel.x).value = index;        // Mark start pixel as visited
-  component.AddPixel(tmp_image->GetPixel(start_pixel.y, start_pixel.x));  // Add start pixel to component
+  image.GetPixel(start_pixel.y, start_pixel.x).value = index;        // Mark start pixel as visited
+  component.AddPixel(image.GetPixel(start_pixel.y, start_pixel.x));  // Add start pixel to component
 
   while (!stack.empty()) {
     Pixel current_pixel = stack.top();
@@ -49,11 +48,11 @@ Component voroshilov_v_convex_hull_components_seq::DepthComponentSearch(Pixel& s
     for (int i = 0; i < 8; i++) {
       int next_y = current_pixel.y + step_y[i];
       int next_x = current_pixel.x + step_x[i];
-      if (next_y >= 0 && next_y < tmp_image->height && next_x >= 0 && next_x < tmp_image->width &&
-          tmp_image->GetPixel(next_y, next_x) == 1) {
-        stack.push(tmp_image->GetPixel(next_y, next_x));
-        tmp_image->GetPixel(next_y, next_x).value = index;        // Mark neighbour pixel as visited
-        component.AddPixel(tmp_image->GetPixel(next_y, next_x));  // Add neighbour pixel to component
+      if (next_y >= 0 && next_y < image.height && next_x >= 0 && next_x < image.width &&
+          image.GetPixel(next_y, next_x) == 1) {
+        stack.push(image.GetPixel(next_y, next_x));
+        image.GetPixel(next_y, next_x).value = index;        // Mark neighbour pixel as visited
+        component.AddPixel(image.GetPixel(next_y, next_x));  // Add neighbour pixel to component
       }
     }
   }
@@ -62,18 +61,18 @@ Component voroshilov_v_convex_hull_components_seq::DepthComponentSearch(Pixel& s
 }
 
 std::vector<Component> voroshilov_v_convex_hull_components_seq::FindComponents(Image& image) {
-  Image tmp_image(image);
   std::vector<Component> components;
   int count = 0;
-  for (int y = 0; y < tmp_image.height; y++) {
-    for (int x = 0; x < tmp_image.width; x++) {
-      if (tmp_image.GetPixel(y, x) == 1) {
-        Component component = DepthComponentSearch(tmp_image.GetPixel(y, x), &tmp_image, count + 2);
+  for (int y = 0; y < image.height; y++) {
+    for (int x = 0; x < image.width; x++) {
+      if (image.GetPixel(y, x) == 1) {
+        Component component = DepthComponentSearch(image.GetPixel(y, x), image, count + 2);
         components.push_back(component);
         count++;
       }
     }
   }
+
   if (components.empty()) {
     return {};
   }

--- a/tasks/stl/voroshilov_v_convex_hull_components/include/chc.hpp
+++ b/tasks/stl/voroshilov_v_convex_hull_components/include/chc.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstddef>
-#include <unordered_map>
 #include <vector>
 
 namespace voroshilov_v_convex_hull_components_stl {
@@ -46,22 +45,26 @@ using Hull = std::vector<Pixel>;
 
 class UnionFind {
  public:
-  std::unordered_map<int, int> roots;
-  std::unordered_map<int, int> ranks;
+  std::vector<int> roots;
+  std::vector<int> ranks;
 
   UnionFind() = default;
+  UnionFind(int n);
   int FindRoot(int x);
   void Union(int x, int y);
 };
 
-void CheckBoundaryPixels(UnionFind* union_find, Image& image, int y, int x);
+void CheckBoundaryPixels(UnionFind& union_find, Image& image, int y, int x);
 
 void MergeComponentsAcrossAreas(std::vector<Component>& components, Image& image, int area_height,
                                 std::vector<int>& end_y);
 
-Component DepthComponentSearchInArea(Pixel start_pixel, Image* tmp_image, int index, int start_y, int end_y);
+template <typename T>
+std::vector<T> MergeVectors(std::vector<std::vector<T>>& vectors);
 
-std::vector<Component> FindComponentsInArea(Image& tmp_image, int start_y, int end_y, int index_offset);
+Component DepthComponentSearchInArea(Pixel start_pixel, Image& image, int index, int start_y, int end_y);
+
+std::vector<Component> FindComponentsInArea(Image& image, int start_y, int end_y, int index_offset);
 
 std::vector<Component> FindComponentsSTL(Image& image);
 

--- a/tasks/stl/voroshilov_v_convex_hull_components/perf_tests/main.cpp
+++ b/tasks/stl/voroshilov_v_convex_hull_components/perf_tests/main.cpp
@@ -134,9 +134,9 @@ bool IsHullSubset(Hull& hull_first, Hull& hull_second) {
 }  // namespace
 
 TEST(voroshilov_v_convex_hull_components_stl, chc_pipeline_run) {
-  int height = 10'000;
-  int width = 10'000;
-  std::vector<int> pixels = GenerateRectanglesComponents(width, height, 1000, 100, 500);
+  int height = 3'000;
+  int width = 3'000;
+  std::vector<int> pixels = GenerateRectanglesComponents(width, height, 1000, 25, 100);
 
   int* p_height = &height;
   int* p_width = &width;
@@ -155,7 +155,7 @@ TEST(voroshilov_v_convex_hull_components_stl, chc_pipeline_run) {
   auto chc_task_omp = std::make_shared<voroshilov_v_convex_hull_components_stl::ChcTaskSTL>(task_data_stl);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 1;
+  perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&] {
     auto current_time_point = std::chrono::high_resolution_clock::now();
@@ -196,9 +196,9 @@ TEST(voroshilov_v_convex_hull_components_stl, chc_pipeline_run) {
 }
 
 TEST(voroshilov_v_convex_hull_components_stl, chc_task_run) {
-  int height = 10'000;
-  int width = 10'000;
-  std::vector<int> pixels = GenerateRectanglesComponents(width, height, 1000, 100, 500);
+  int height = 3'000;
+  int width = 3'000;
+  std::vector<int> pixels = GenerateRectanglesComponents(width, height, 1000, 25, 100);
 
   int* p_height = &height;
   int* p_width = &width;
@@ -217,7 +217,7 @@ TEST(voroshilov_v_convex_hull_components_stl, chc_task_run) {
   auto chc_task_omp = std::make_shared<voroshilov_v_convex_hull_components_stl::ChcTaskSTL>(task_data_stl);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 1;
+  perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&] {
     auto current_time_point = std::chrono::high_resolution_clock::now();

--- a/tasks/tbb/voroshilov_v_convex_hull_components/include/chc.hpp
+++ b/tasks/tbb/voroshilov_v_convex_hull_components/include/chc.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstddef>
-#include <unordered_map>
 #include <vector>
 
 namespace voroshilov_v_convex_hull_components_tbb {
@@ -46,22 +45,26 @@ using Hull = std::vector<Pixel>;
 
 class UnionFind {
  public:
-  std::unordered_map<int, int> roots;
-  std::unordered_map<int, int> ranks;
+  std::vector<int> roots;
+  std::vector<int> ranks;
 
   UnionFind() = default;
+  UnionFind(int n);
   int FindRoot(int x);
   void Union(int x, int y);
 };
 
-void CheckBoundaryPixels(UnionFind* union_find, Image& image, int y, int x);
+void CheckBoundaryPixels(UnionFind& union_find, Image& image, int y, int x);
 
 void MergeComponentsAcrossAreas(std::vector<Component>& components, Image& image, int area_height,
                                 std::vector<int>& end_y);
 
-Component DepthComponentSearchInArea(Pixel start_pixel, Image* tmp_image, int index, int start_y, int end_y);
+template <typename T>
+std::vector<T> MergeVectors(std::vector<std::vector<T>>& vectors);
 
-std::vector<Component> FindComponentsInArea(Image& tmp_image, int start_y, int end_y, int index_offset);
+Component DepthComponentSearchInArea(Pixel start_pixel, Image& image, int index, int start_y, int end_y);
+
+std::vector<Component> FindComponentsInArea(Image& image, int start_y, int end_y, int index_offset);
 
 std::vector<Component> FindComponentsTBB(Image& image);
 

--- a/tasks/tbb/voroshilov_v_convex_hull_components/perf_tests/main.cpp
+++ b/tasks/tbb/voroshilov_v_convex_hull_components/perf_tests/main.cpp
@@ -134,9 +134,9 @@ bool IsHullSubset(Hull& hull_first, Hull& hull_second) {
 }  // namespace
 
 TEST(voroshilov_v_convex_hull_components_tbb, chc_pipeline_run) {
-  int height = 10'000;
-  int width = 10'000;
-  std::vector<int> pixels = GenerateRectanglesComponents(width, height, 1000, 100, 500);
+  int height = 3'000;
+  int width = 3'000;
+  std::vector<int> pixels = GenerateRectanglesComponents(width, height, 1000, 25, 100);
 
   int* p_height = &height;
   int* p_width = &width;
@@ -155,7 +155,7 @@ TEST(voroshilov_v_convex_hull_components_tbb, chc_pipeline_run) {
   auto chc_task = std::make_shared<voroshilov_v_convex_hull_components_tbb::ChcTaskTBB>(task_data);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 1;
+  perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&] {
     auto current_time_point = std::chrono::high_resolution_clock::now();
@@ -196,9 +196,9 @@ TEST(voroshilov_v_convex_hull_components_tbb, chc_pipeline_run) {
 }
 
 TEST(voroshilov_v_convex_hull_components_tbb, chc_task_run) {
-  int height = 10'000;
-  int width = 10'000;
-  std::vector<int> pixels = GenerateRectanglesComponents(width, height, 1000, 100, 500);
+  int height = 3'000;
+  int width = 3'000;
+  std::vector<int> pixels = GenerateRectanglesComponents(width, height, 1000, 25, 100);
 
   int* p_height = &height;
   int* p_width = &width;
@@ -217,7 +217,7 @@ TEST(voroshilov_v_convex_hull_components_tbb, chc_task_run) {
   auto chc_task = std::make_shared<voroshilov_v_convex_hull_components_tbb::ChcTaskTBB>(task_data);
 
   auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
-  perf_attr->num_running = 1;
+  perf_attr->num_running = 10;
   const auto t0 = std::chrono::high_resolution_clock::now();
   perf_attr->current_timer = [&] {
     auto current_time_point = std::chrono::high_resolution_clock::now();

--- a/tasks/tbb/voroshilov_v_convex_hull_components/src/chc.cpp
+++ b/tasks/tbb/voroshilov_v_convex_hull_components/src/chc.cpp
@@ -3,8 +3,8 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <iterator>
 #include <stack>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -41,50 +41,56 @@ Pixel& Image::GetPixel(int y, int x) { return pixels[(y * width) + x]; }
 
 LineSegment::LineSegment(Pixel& a_param, Pixel& b_param) : a(a_param), b(b_param) {}
 
+UnionFind::UnionFind(int n) {
+  roots.resize(n);
+  ranks.resize(n);
+  for (int i = 0; i < n; i++) {
+    roots[i] = i;
+    ranks[i] = 1;
+  }
+}
+
 int UnionFind::FindRoot(int x) {
-  if (roots.find(x) == roots.end()) {
-    roots[x] = x;
-    ranks[x] = 1;
+  while (roots[x] != x) {
+    roots[x] = roots[roots[x]];
+    x = roots[x];
   }
-  if (roots[x] != x) {
-    roots[x] = FindRoot(roots[x]);
-  }
-  return roots[x];
+  return x;
 }
 
 void UnionFind::Union(int x, int y) {
   int root_x = FindRoot(x);
   int root_y = FindRoot(y);
-  if (root_x != root_y) {
-    if (ranks[root_x] > ranks[root_y]) {
-      roots[root_y] = root_x;
-    } else if (ranks[root_x] < ranks[root_y]) {
-      roots[root_x] = root_y;
-    } else {
-      roots[root_y] = root_x;
-      ranks[root_x]++;
-    }
+  if (root_x == root_y) {
+    return;
+  }
+  if (ranks[root_x] < ranks[root_y]) {
+    std::swap(root_x, root_y);
+  }
+  roots[root_y] = root_x;
+  if (ranks[root_x] == ranks[root_y]) {
+    ranks[root_x]++;
   }
 }
 
-void voroshilov_v_convex_hull_components_tbb::CheckBoundaryPixels(UnionFind* union_find, Image& image, int y, int x) {
+void voroshilov_v_convex_hull_components_tbb::CheckBoundaryPixels(UnionFind& union_find, Image& image, int y, int x) {
   Pixel p1 = image.GetPixel(y, x);
 
   Pixel p2 = image.GetPixel(y + 1, x);
   if (p1.value > 1 && p2.value > 1) {
-    union_find->Union(p1.value, p2.value);
+    union_find.Union(p1.value, p2.value);
   }
 
   if (x > 0) {
     Pixel p3 = image.GetPixel(y + 1, x - 1);
     if (p1.value > 1 && p3.value > 1) {
-      union_find->Union(p1.value, p3.value);
+      union_find.Union(p1.value, p3.value);
     }
   }
   if (x < image.width - 1) {
     Pixel p4 = image.GetPixel(y + 1, x + 1);
     if (p1.value > 1 && p4.value > 1) {
-      union_find->Union(p1.value, p4.value);
+      union_find.Union(p1.value, p4.value);
     }
   }
 }
@@ -92,7 +98,12 @@ void voroshilov_v_convex_hull_components_tbb::CheckBoundaryPixels(UnionFind* uni
 void voroshilov_v_convex_hull_components_tbb::MergeComponentsAcrossAreas(std::vector<Component>& components,
                                                                          Image& image, int area_height,
                                                                          std::vector<int>& end_y) {
-  UnionFind union_find;
+  if (components.empty()) {
+    return;
+  }
+
+  int num_threads = ppc::util::GetPPCNumThreads();
+  UnionFind union_find((num_threads * 1000) + 3);
 
   int width = image.width;
   int height = image.height;
@@ -101,35 +112,95 @@ void voroshilov_v_convex_hull_components_tbb::MergeComponentsAcrossAreas(std::ve
     int y = endy - 1;
     if (y != height - 1) {
       for (int x = 0; x < width; x++) {
-        CheckBoundaryPixels(&union_find, image, y, x);
+        CheckBoundaryPixels(union_find, image, y, x);
       }
     }
   }
 
-  std::unordered_map<int, Component> merged_components;
-  for (Component& component : components) {
-    int new_id = union_find.FindRoot(component[0].value);
-    if (merged_components.find(new_id) == merged_components.end()) {
-      merged_components[new_id] = Component();
-    }
-    merged_components[new_id].insert(merged_components[new_id].end(), component.begin(), component.end());
+  int n = (int)components.size();
+  std::vector<int> all_roots;
+  all_roots.reserve(n);
+  for (int i = 0; i < n; i++) {
+    int label = components[i][0].value;
+    all_roots.push_back(union_find.FindRoot(label));
   }
 
-  components.clear();
-  for (auto& entry : merged_components) {
-    components.push_back(entry.second);
+  std::vector<int> roots_unique = all_roots;
+  std::ranges::sort(roots_unique);
+  auto it = std::ranges::unique(roots_unique).begin();
+  roots_unique.erase(it, roots_unique.end());
+  int r = (int)roots_unique.size();
+
+  int max_root = -1;
+  if (!roots_unique.empty()) {
+    max_root = roots_unique.back();
   }
+  std::vector<int> root_to_indx(max_root + 1, -1);
+  for (int i = 0; i < r; i++) {
+    root_to_indx[roots_unique[i]] = i;
+  }
+
+  std::vector<std::vector<int>> comps_by_root(r);
+  for (int i = 0; i < n; i++) {
+    int b = root_to_indx[all_roots[i]];
+    comps_by_root[b].push_back(i);
+  }
+
+  std::vector<Component> merged(r);
+  oneapi::tbb::task_arena arena(num_threads);
+
+  arena.execute([&] {
+    oneapi::tbb::parallel_for(0, r, [&](int i) {
+      size_t total = 0;
+      for (int indx : comps_by_root[i]) {
+        total += components[indx].size();
+      }
+      merged[i].reserve(total);
+
+      for (int indx : comps_by_root[i]) {
+        Component& src = components[indx];
+        std::ranges::move(src, std::back_inserter(merged[i]));
+      }
+    });
+  });
+  components = std::move(merged);
 }
 
-Component voroshilov_v_convex_hull_components_tbb::DepthComponentSearchInArea(Pixel start_pixel, Image* tmp_image,
+template <typename T>
+std::vector<T> voroshilov_v_convex_hull_components_tbb::MergeVectors(std::vector<std::vector<T>>& vectors) {
+  int size = (int)vectors.size();
+
+  std::vector<int> sizes(size);
+  std::vector<int> offsets(size + 1);
+  for (int i = 0; i < size; i++) {
+    sizes[i] = (int)vectors[i].size();
+  }
+
+  offsets[0] = 0;
+  for (int i = 0; i < size; i++) {
+    offsets[i + 1] = offsets[i] + sizes[i];
+  }
+
+  std::vector<T> vec(offsets[size]);
+
+  for (int i = 0; i < size; i++) {
+    std::vector<T>& src = vectors[i];
+    auto dst_it = vec.begin() + offsets[i];
+    std::move(src.begin(), src.end(), dst_it);
+  }
+
+  return vec;
+}
+
+Component voroshilov_v_convex_hull_components_tbb::DepthComponentSearchInArea(Pixel start_pixel, Image& image,
                                                                               int index, int start_y, int end_y) {
   const int step_y[8] = {1, 1, 1, 0, 0, -1, -1, -1};  // Offsets by Y (up, stand, down)
   const int step_x[8] = {-1, 0, 1, -1, 1, -1, 0, 1};  // Offsets by X (left, stand, right)
   std::stack<Pixel> stack;
   std::vector<Pixel> component_pixels;
   stack.push(start_pixel);
-  tmp_image->GetPixel(start_pixel.y, start_pixel.x).value = index;                // Mark start pixel as visited
-  component_pixels.push_back(tmp_image->GetPixel(start_pixel.y, start_pixel.x));  // Add start pixel to component
+  image.GetPixel(start_pixel.y, start_pixel.x).value = index;                // Mark start pixel as visited
+  component_pixels.push_back(image.GetPixel(start_pixel.y, start_pixel.x));  // Add start pixel to component
 
   while (!stack.empty()) {
     Pixel current_pixel = stack.top();
@@ -137,11 +208,11 @@ Component voroshilov_v_convex_hull_components_tbb::DepthComponentSearchInArea(Pi
     for (int i = 0; i < 8; i++) {
       int next_y = current_pixel.y + step_y[i];
       int next_x = current_pixel.x + step_x[i];
-      if (next_y >= start_y && next_y < end_y && next_x >= 0 && next_x < tmp_image->width &&
-          tmp_image->GetPixel(next_y, next_x) == 1) {
-        stack.push(tmp_image->GetPixel(next_y, next_x));
-        tmp_image->GetPixel(next_y, next_x).value = index;                // Mark neighbour pixel as visited
-        component_pixels.push_back(tmp_image->GetPixel(next_y, next_x));  // Add neighbour pixel to component
+      if (next_y >= start_y && next_y < end_y && next_x >= 0 && next_x < image.width &&
+          image.GetPixel(next_y, next_x) == 1) {
+        stack.push(image.GetPixel(next_y, next_x));
+        image.GetPixel(next_y, next_x).value = index;                // Mark neighbour pixel as visited
+        component_pixels.push_back(image.GetPixel(next_y, next_x));  // Add neighbour pixel to component
       }
     }
   }
@@ -151,15 +222,15 @@ Component voroshilov_v_convex_hull_components_tbb::DepthComponentSearchInArea(Pi
   return component;
 }
 
-std::vector<Component> voroshilov_v_convex_hull_components_tbb::FindComponentsInArea(Image& tmp_image, int start_y,
+std::vector<Component> voroshilov_v_convex_hull_components_tbb::FindComponentsInArea(Image& image, int start_y,
                                                                                      int end_y, int index_offset) {
   std::vector<Component> components;
   int index = index_offset;  // unique index in this area
 
   for (int y = start_y; y < end_y; y++) {
-    for (int x = 0; x < tmp_image.width; x++) {
-      if (tmp_image.GetPixel(y, x) == 1) {
-        Component component = DepthComponentSearchInArea(tmp_image.GetPixel(y, x), &tmp_image, index, start_y, end_y);
+    for (int x = 0; x < image.width; x++) {
+      if (image.GetPixel(y, x) == 1) {
+        Component component = DepthComponentSearchInArea(image.GetPixel(y, x), image, index, start_y, end_y);
         components.push_back(component);
         index++;
       }
@@ -174,22 +245,20 @@ std::vector<Component> voroshilov_v_convex_hull_components_tbb::FindComponentsIn
 }
 
 std::vector<Component> voroshilov_v_convex_hull_components_tbb::FindComponentsTBB(Image& image) {
-  Image tmp_image(image);
-
   int num_threads = ppc::util::GetPPCNumThreads();
 
-  std::vector<std::vector<Component>> thread_components(num_threads);
+  std::vector<std::vector<Component>> threads_components(num_threads);
 
-  int height = tmp_image.height;
+  int height = image.height;
 
   int area_height = height / num_threads;
   int remainder = height % num_threads;
   std::vector<int> start_y(num_threads);
   std::vector<int> end_y(num_threads);
   std::vector<int> index_offset(num_threads);
+  start_y[0] = 0;
 
   if (num_threads == 1) {
-    start_y[0] = 0;
     end_y[0] = height;
     index_offset[0] = 2;
   } else {
@@ -207,7 +276,7 @@ std::vector<Component> voroshilov_v_convex_hull_components_tbb::FindComponentsTB
     end_y[end_y.size() - 1] = height;
 
     for (int i = 0; i < num_threads; i++) {
-      index_offset[i] = (i * 100000) + 2;
+      index_offset[i] = (i * 1000) + 2;
     }
   }
 
@@ -215,17 +284,14 @@ std::vector<Component> voroshilov_v_convex_hull_components_tbb::FindComponentsTB
 
   arena.execute([&] {
     oneapi::tbb::parallel_for(0, num_threads, [&](int thread_id) {
-      thread_components[thread_id] =
-          FindComponentsInArea(tmp_image, start_y[thread_id], end_y[thread_id], index_offset[thread_id]);
+      threads_components[thread_id] =
+          FindComponentsInArea(image, start_y[thread_id], end_y[thread_id], index_offset[thread_id]);
     });
   });
 
-  std::vector<Component> components;
-  for (std::vector<Component>& vec : thread_components) {
-    components.insert(components.end(), vec.begin(), vec.end());
-  }
+  std::vector<Component> components = MergeVectors<Component>(threads_components);
 
-  MergeComponentsAcrossAreas(components, tmp_image, area_height, end_y);
+  MergeComponentsAcrossAreas(components, image, area_height, end_y);
 
   return components;
 }


### PR DESCRIPTION
Внёс оптимизационные изменения во все версии задачи:
1. В `ALL` версии ранее распараллеливание на процессы с помощью `boost::mpi` применялось только во 2-ом этапе задачи (построение оболочек). Теперь поиск компонент тоже параллельный по процессам:
```c++
bool voroshilov_v_convex_hull_components_all::ChcTaskALL::RunImpl() {
  std::vector<Component> local_components = FindComponentsMPIOMP(height_in_, width_in_, pixels_in_);

  hulls_out_ = QuickHullAllMPIOMP(local_components);

  return true;
}
``` 

2. В остальных версиях немного изменены вспомогательные функции:
```c++
void MergeComponentsAcrossAreas(std::vector<Component>& components, Image& image, int area_height,
                                std::vector<int>& end_y);

template <typename T>
std::vector<T> MergeVectors(std::vector<std::vector<T>>& vectors);
``` 
Оптимизация этих функций позволила повысить производительность без изменений в основном алгоритме (снижены затраты на обеспечение взаимодействия между потоками, на копирование больших векторов).

3. Изменены размеры входных данных:
```c++
int height = 3'000;
int width = 3'000;
std::vector<int> pixels = GenerateRectanglesComponents(width, height, 1000, 25, 100);
``` 